### PR TITLE
add example of a complex resource manager

### DIFF
--- a/samples/spring-boot-complex-resources/crd/crd.yaml
+++ b/samples/spring-boot-complex-resources/crd/crd.yaml
@@ -1,0 +1,49 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: customservices.sample.javaoperatorsdk
+spec:
+  group: sample.javaoperatorsdk
+  version: v1
+  scope: Namespaced
+  names:
+    plural: customservices
+    singular: customservice
+    kind: CustomService
+    shortNames:
+      - cs
+  preserveUnknownFields: false
+  validation: 
+    openAPIV3Schema:
+      type: object
+      properties:
+        name:
+          type: string
+        spec:
+          type: object
+          properties:
+            testSuite:
+              type: string
+            service:
+              type: object
+              properties:
+                name:
+                  type: string
+                image:
+                  type: string
+            dependencies:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  image:
+                    type: string
+        status:
+          type: object
+          properties:
+            ready:
+              type: boolean
+  subresources:
+    status: {}

--- a/samples/spring-boot-complex-resources/crd/test_object.yaml
+++ b/samples/spring-boot-complex-resources/crd/test_object.yaml
@@ -1,0 +1,14 @@
+apiVersion: "sample.javaoperatorsdk/v1"
+kind: CustomService
+metadata:
+  name: custom-service1
+spec:
+  testSuite: thoba/todo-list-app:latest
+  service:
+    name: reporting
+    image: thoba/todo-list-app:latest
+  dependencies:
+    - name: authentication
+      image: thoba/todo-list-app:latest
+status:
+  ready: no

--- a/samples/spring-boot-complex-resources/pom.xml
+++ b/samples/spring-boot-complex-resources/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.github.containersolutions</groupId>
+        <artifactId>java-operator-sdk-samples</artifactId>
+        <version>1.3.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>operator-framework-samples-spring-boot-plain</artifactId>
+    <name>Operator SDK - Samples - Spring Boot - Plain</name>
+    <description>Sample usage with Spring Boot</description>
+    <packaging>jar</packaging>
+
+    <properties>
+        <java.version>8</java.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+    <dependency>
+  <groupId>com.github.containersolutions</groupId>
+  <artifactId>operator-framework</artifactId>
+  <version>1.3.0</version>
+</dependency>
+    
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-log4j2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>2.3.2.RELEASE</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>2.3.2.RELEASE</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/samples/spring-boot-complex-resources/src/main/java/com/github/containersolutions/operator/sample/Config.java
+++ b/samples/spring-boot-complex-resources/src/main/java/com/github/containersolutions/operator/sample/Config.java
@@ -1,0 +1,50 @@
+package com.github.containersolutions.operator.sample;
+
+import com.github.containersolutions.operator.Operator;
+import com.github.containersolutions.operator.api.ResourceController;
+import com.github.containersolutions.operator.processing.retry.GenericRetry;
+
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.internal.CustomResourceOperationsImpl;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+import java.util.Map;
+
+@Configuration
+public class Config {
+
+    @Bean
+    public KubernetesClient kubernetesClient() {
+        return new DefaultKubernetesClient();
+    }
+
+    @Bean
+    public CustomServiceController customServiceController(KubernetesClient client) {
+        return new CustomServiceController(client);
+    }
+
+    //  Register all controller beans
+    @SuppressWarnings("unchecked")
+	@Bean
+    public Operator operator(KubernetesClient client, List<ResourceController> controllers) {
+        Operator operator = new Operator(client);
+        controllers.forEach(c -> {operator.registerControllerForAllNamespaces(c,
+                GenericRetry.defaultLimitedExponentialRetry());
+        if (c instanceof CustomServiceController) {
+        	((CustomServiceController)c).setCustomResourceClient(operator.getCustomResourceClients());
+        }
+        });
+        return operator;
+    }
+    
+//    @Bean
+//    public Map<Class<? extends CustomResource>, CustomResourceOperationsImpl> getCustomResourceClient(Operator operator) {
+//    	return operator.getCustomResourceClients();
+//    }
+
+}

--- a/samples/spring-boot-complex-resources/src/main/java/com/github/containersolutions/operator/sample/CustomService.java
+++ b/samples/spring-boot-complex-resources/src/main/java/com/github/containersolutions/operator/sample/CustomService.java
@@ -1,0 +1,27 @@
+package com.github.containersolutions.operator.sample;
+
+import io.fabric8.kubernetes.api.model.ServiceStatus;
+import io.fabric8.kubernetes.client.CustomResource;
+
+public class CustomService extends CustomResource {
+
+    private ServiceSpec spec;
+    
+    private ServiceStatus status;
+
+    public ServiceSpec getSpec() {
+        return spec;
+    }
+
+    public void setSpec(ServiceSpec spec) {
+        this.spec = spec;
+    }
+
+	public ServiceStatus getStatus() {
+		return status;
+	}
+
+	public void setStatus(ServiceStatus status) {
+		this.status = status;
+	}
+}

--- a/samples/spring-boot-complex-resources/src/main/java/com/github/containersolutions/operator/sample/CustomServiceController.java
+++ b/samples/spring-boot-complex-resources/src/main/java/com/github/containersolutions/operator/sample/CustomServiceController.java
@@ -1,0 +1,230 @@
+package com.github.containersolutions.operator.sample;
+
+import com.github.containersolutions.operator.api.Context;
+
+import io.fabric8.kubernetes.client.dsl.Resource;
+
+import com.github.containersolutions.operator.api.Controller;
+import com.github.containersolutions.operator.api.ResourceController;
+import com.github.containersolutions.operator.api.UpdateControl;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.ContainerPort;
+import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.ListOptions;
+import io.fabric8.kubernetes.api.model.ListOptionsBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
+import io.fabric8.kubernetes.api.model.ServicePort;
+import io.fabric8.kubernetes.api.model.ServiceSpec;
+import io.fabric8.kubernetes.api.model.ServiceStatus;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentStatus;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.internal.CustomResourceOperationsImpl;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A very simple sample controller that creates a service with a label.
+ */
+@Controller(customResourceClass = CustomService.class, crdName = "customservices.sample.javaoperatorsdk")
+public class CustomServiceController implements ResourceController<CustomService> {
+
+	public static final String KIND = "CustomService";
+	private final static Logger log = LoggerFactory.getLogger(CustomServiceController.class);
+
+	private final KubernetesClient kubernetesClient;
+
+	private Map<Class<? extends CustomResource>, CustomResourceOperationsImpl> customResourceClient;
+
+	public CustomServiceController(KubernetesClient kubernetesClient) {
+		this.kubernetesClient = kubernetesClient;
+	}
+
+	@Override
+	public boolean deleteResource(CustomService resource, Context<CustomService> context) {
+		log.info("Execution deleteResource for: {}", resource.getMetadata().getName());
+		kubernetesClient.services().inNamespace(resource.getMetadata().getNamespace())
+				.withName(resource.getMetadata().getName()).delete();
+		return true;
+	}
+
+	/***
+	 * recap: create ALL dependent deployments. Register for ALL. Collect ready
+	 * states or some state after receiving events create MAIN deployment. Register
+	 * for it. on success, dereg. create TEST deployment. Register for it. on
+	 * result, update own ready status.
+	 */
+
+	private static boolean isDeploymentReady(Deployment d) {
+		return d != null && d.getStatus() != null && d.getStatus().getReadyReplicas() != null
+				&& d.getStatus().getAvailableReplicas() != null
+				&& d.getStatus().getReadyReplicas() == d.getStatus().getAvailableReplicas()
+				&& d.getStatus().getReadyReplicas() > 0;
+	}
+
+	@Override
+	public UpdateControl<CustomService> createOrUpdateResource(CustomService resource, Context<CustomService> context) {
+		log.info("Execution createOrUpdateResource for: {}", resource.getMetadata().getName());
+
+		String ns = resource.getMetadata().getNamespace();
+		String resourceName = resource.getMetadata().getName();
+
+		ArrayList<String> deploymentNames = new ArrayList<String>();
+		for (ServiceDependency dep : resource.getSpec().getDependencies()) {
+			deploymentNames.add(resourceName + "-" + dep.getName());
+		}
+
+		Watcher<Deployment> testWatcher = new Watcher<Deployment>() {
+
+			@Override
+			public void eventReceived(Action action, Deployment watchedResource) {
+				// has the main deployment finished?
+				if (isDeploymentReady(watchedResource)) {
+					MixedOperation<?, ?, ?, Resource<CustomResource, ?>> x = (MixedOperation<?, ?, ?, Resource<CustomResource, ?>>) customResourceClient
+							.get(CustomService.class);
+					CustomService r = (CustomService) x.inNamespace(resource.getMetadata().getNamespace())
+							.withName(resource.getMetadata().getName()).get();
+					r.setStatus(new ServiceStatus());
+					r.getStatus().setAdditionalProperty("ready", true);
+					x.inNamespace(ns).withName(resource.getMetadata().getName()).updateStatus(r);
+				}
+			}
+
+			@Override
+			public void onClose(KubernetesClientException cause) {
+			}
+
+		};
+		String testDeploymentName = resourceName + "-" + resource.getSpec().getService().getName() + "testing";
+
+		Watcher<Deployment> mainWatcher = new Watcher<Deployment>() {
+
+			@Override
+			public void eventReceived(Action action, Deployment watchedResource) {
+				// has the main deployment finished?
+				if (isDeploymentReady(watchedResource)) {
+					// "run" test suite
+					createDeployment(ns, testDeploymentName, resource.getSpec().getTestSuite(), resource, testWatcher);
+					// unregister watcher?
+				}
+			}
+
+			@Override
+			public void onClose(KubernetesClientException cause) {
+			}
+
+		};
+		String mainDeploymentName = resourceName + "-" + resource.getSpec().getService().getName();
+
+		Watcher<Deployment> dependentWatcher = new Watcher<Deployment>() {
+
+			@Override
+			public void eventReceived(Action action, Deployment watchedResource) {
+					// has this deployment become ready?
+					if (isDeploymentReady(watchedResource)) {
+						boolean readyForMain = true;
+						for (String dep : deploymentNames) {
+							if (!isDeploymentReady(
+									kubernetesClient.apps().deployments().inNamespace(ns).withName(dep).get())) {
+								// check all deployments are ready
+								readyForMain = false;
+							}
+						}
+						if (readyForMain) {
+							// create main deployment
+							createDeployment(ns, mainDeploymentName, resource.getSpec().getService().getImage(),
+									resource, mainWatcher);
+						}
+					}
+			}
+
+			@Override
+			public void onClose(KubernetesClientException cause) {
+			}
+		};
+
+		// create dependent deployments
+		boolean dependenciesAllDone = true;
+		for (ServiceDependency dep : resource.getSpec().getDependencies()) {
+			String name = resourceName + "-" + dep.getName();
+			String image = dep.getImage();
+			if (kubernetesClient.apps().deployments().inNamespace(ns).withName(name).get() == null) {
+				createDeployment(ns, name, image, resource, dependentWatcher);
+				dependenciesAllDone = false;
+			}
+		}
+		if (dependenciesAllDone) {
+			// create main deployment
+			if (kubernetesClient.apps().deployments().inNamespace(ns).withName(mainDeploymentName).get() == null) {
+				createDeployment(ns, mainDeploymentName, resource.getSpec().getService().getImage(), resource,
+						mainWatcher);
+			} else {
+				if (kubernetesClient.apps().deployments().inNamespace(ns).withName(testDeploymentName).get() == null) {
+					// "run" test suite
+					createDeployment(ns, testDeploymentName, resource.getSpec().getTestSuite(), resource, testWatcher);
+				} else {
+					if (resource.getStatus() == null
+							|| resource.getStatus().getAdditionalProperties().get("ready") == null
+							|| resource.getStatus().getAdditionalProperties().get("ready") != new Boolean(true)) {
+						MixedOperation<?, ?, ?, Resource<CustomResource, ?>> x = (MixedOperation<?, ?, ?, Resource<CustomResource, ?>>) customResourceClient
+								.get(CustomService.class);
+						CustomService r = (CustomService) x.inNamespace(resource.getMetadata().getNamespace())
+								.withName(resource.getMetadata().getName()).get();
+						r.setStatus(new ServiceStatus());
+						r.getStatus().setAdditionalProperty("ready", true);
+						x.inNamespace(ns).withName(resource.getMetadata().getName()).updateStatus(r);
+					}
+				}
+			}
+		}
+
+		return UpdateControl.noUpdate();
+	}
+
+	private void createDeployment(String ns, String name, String image, CustomResource ownerResource,
+			Watcher<Deployment> watcher) {
+		ArrayList<ContainerPort> ports = new ArrayList<ContainerPort>();
+		ports.add(new ContainerPortBuilder().withContainerPort(3000).build());
+		ArrayList<Container> containers = new ArrayList<Container>();
+		containers.add(new ContainerBuilder().withName(name).withImage(image).withPorts(ports).build());
+		Map<String, String> labels = new HashMap<>();
+		labels.put("app", name);
+		kubernetesClient.apps().deployments().inNamespace(ns).createOrReplaceWithNew().withNewMetadata().withName(name)
+				.withOwnerReferences((new OwnerReferenceBuilder()).withApiVersion(ownerResource.getApiVersion())
+						.withKind(ownerResource.getKind()).withController(true)
+						.withName(ownerResource.getMetadata().getName()).withUid(ownerResource.getMetadata().getUid())
+						.build())
+				.endMetadata().withNewSpec().withReplicas(3).withNewSelector().withMatchLabels(labels).endSelector()
+				.withNewTemplate().withNewMetadata().withLabels(labels).endMetadata().withNewSpec()
+				.withContainers(containers).endSpec().endTemplate().endSpec().done();
+		kubernetesClient.v1().events().createNew().withNewMetadata().withName(java.util.UUID.randomUUID().toString())
+				.withNamespace(ns).endMetadata().withNewAction("Deployment Creation")
+				.withNewMessage("created deployment " + name).withNewInvolvedObject().withNamespace(ns)
+				.withKind(ownerResource.getKind()).withName(ownerResource.getMetadata().getName())
+				.withNewUid(ownerResource.getMetadata().getUid())
+				.withNewResourceVersion(ownerResource.getMetadata().getResourceVersion()).endInvolvedObject().done();
+		kubernetesClient.apps().deployments().inNamespace(ns).withName(name).watch(watcher);
+	}
+
+	public void setCustomResourceClient(
+			Map<Class<? extends CustomResource>, CustomResourceOperationsImpl> customResourceClients) {
+		this.customResourceClient = customResourceClients;
+
+	}
+}

--- a/samples/spring-boot-complex-resources/src/main/java/com/github/containersolutions/operator/sample/ServiceDependency.java
+++ b/samples/spring-boot-complex-resources/src/main/java/com/github/containersolutions/operator/sample/ServiceDependency.java
@@ -1,0 +1,24 @@
+package com.github.containersolutions.operator.sample;
+
+public class ServiceDependency {
+	private String name;
+	private String image;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getImage() {
+		return image;
+	}
+
+	public void setImage(String image) {
+		this.image = image;
+	}
+	
+
+}

--- a/samples/spring-boot-complex-resources/src/main/java/com/github/containersolutions/operator/sample/ServiceService.java
+++ b/samples/spring-boot-complex-resources/src/main/java/com/github/containersolutions/operator/sample/ServiceService.java
@@ -1,0 +1,24 @@
+package com.github.containersolutions.operator.sample;
+
+public class ServiceService {
+
+	private String name;
+	private String image;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getImage() {
+		return image;
+	}
+
+	public void setImage(String image) {
+		this.image = image;
+	}
+	
+}

--- a/samples/spring-boot-complex-resources/src/main/java/com/github/containersolutions/operator/sample/ServiceSpec.java
+++ b/samples/spring-boot-complex-resources/src/main/java/com/github/containersolutions/operator/sample/ServiceSpec.java
@@ -1,0 +1,33 @@
+package com.github.containersolutions.operator.sample;
+
+import java.util.List;
+
+import io.fabric8.kubernetes.api.model.ServiceStatus;
+
+public class ServiceSpec {
+
+
+	private String testSuite;
+	private ServiceService service;
+	private List<ServiceDependency> dependencies;
+	
+	
+	public String getTestSuite() {
+		return testSuite;
+	}
+	public void setTestSuite(String testSuite) {
+		this.testSuite = testSuite;
+	}
+	public ServiceService getService() {
+		return service;
+	}
+	public void setService(ServiceService service) {
+		this.service = service;
+	}
+	public List<ServiceDependency> getDependencies() {
+		return dependencies;
+	}
+	public void setDependencies(List<ServiceDependency> dependencies) {
+		this.dependencies = dependencies;
+	}
+}

--- a/samples/spring-boot-complex-resources/src/main/java/com/github/containersolutions/operator/sample/SpringBootStarterSampleApplication.java
+++ b/samples/spring-boot-complex-resources/src/main/java/com/github/containersolutions/operator/sample/SpringBootStarterSampleApplication.java
@@ -1,0 +1,13 @@
+package com.github.containersolutions.operator.sample;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SpringBootStarterSampleApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(SpringBootStarterSampleApplication.class, args);
+    }
+
+}

--- a/samples/spring-boot-complex-resources/src/main/resources/application.yaml
+++ b/samples/spring-boot-complex-resources/src/main/resources/application.yaml
@@ -1,0 +1,2 @@
+operator.controller.retry:
+  maxAttempts: 3

--- a/samples/spring-boot-complex-resources/src/main/resources/log4j2.xml
+++ b/samples/spring-boot-complex-resources/src/main/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
This is the result of the "Virtual Cloud Native Hackathon 2020" organised by Container Solutions. It aims to give a good workout to the Java SDK by having a custom resource which:
1.  manages several dependencies, declared as images (for simplicity)
2. manages a main container, as well as a "testing" container
3. essentially creates deployments for each, and attempts to do so in an orderly fashion, e.g. until all dependencies as up & running, the main deployment isn't created.

Currently, there are several pain points showcased:
1. race conditions due to using bare watchers
2. it's not easy to update the status of a custom resource from within, as the custom resource client isn't easily injected.
