### PR TITLE
Fixed deleting on the wrong name

### DIFF
--- a/samples/common/src/main/java/io/javaoperatorsdk/operator/sample/CustomServiceController.java
+++ b/samples/common/src/main/java/io/javaoperatorsdk/operator/sample/CustomServiceController.java
@@ -32,7 +32,7 @@ public class CustomServiceController implements ResourceController<CustomService
     public boolean deleteResource(CustomService resource, Context<CustomService> context) {
         log.info("Execution deleteResource for: {}", resource.getMetadata().getName());
         kubernetesClient.services().inNamespace(resource.getMetadata().getNamespace())
-                .withName(resource.getMetadata().getName()).delete();
+                .withName(resource.getSpec().getName()).delete();
         return true;
     }
 


### PR DESCRIPTION
When deleting, we have to use the same name as used in creating the service