### PR TITLE
Quarkus provided dependency

### DIFF
--- a/operator-framework/pom.xml
+++ b/operator-framework/pom.xml
@@ -78,33 +78,22 @@
             <version>4.0.3</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>com.google.testing.compile</groupId>
             <artifactId>compile-testing</artifactId>
             <version>0.19</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>com.google.auto.service</groupId>
             <artifactId>auto-service</artifactId>
             <version>1.0-rc2</version>
-            <scope>provided</scope>
         </dependency>
-
         <dependency>
             <groupId>com.squareup</groupId>
             <artifactId>javapoet</artifactId>
             <version>1.13.0</version>
-            <scope>provided</scope>
         </dependency>
 
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-core</artifactId>
-            <version>1.9.2.Final</version>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/operator-framework/pom.xml
+++ b/operator-framework/pom.xml
@@ -90,14 +90,21 @@
             <groupId>com.google.auto.service</groupId>
             <artifactId>auto-service</artifactId>
             <version>1.0-rc2</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>com.squareup</groupId>
             <artifactId>javapoet</artifactId>
             <version>1.13.0</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+            <version>1.9.2.Final</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/operator-framework/src/main/java/io/javaoperatorsdk/operator/api/Controller.java
+++ b/operator-framework/src/main/java/io/javaoperatorsdk/operator/api/Controller.java
@@ -1,6 +1,8 @@
 package io.javaoperatorsdk.operator.api;
 
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -8,6 +10,7 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE})
+@RegisterForReflection
 public @interface Controller {
     String NULL = "";
 

--- a/operator-framework/src/main/java/io/javaoperatorsdk/operator/processing/ControllerAnnotationProcessor.java
+++ b/operator-framework/src/main/java/io/javaoperatorsdk/operator/processing/ControllerAnnotationProcessor.java
@@ -5,6 +5,8 @@ import com.squareup.javapoet.*;
 import io.fabric8.kubernetes.api.builder.Function;
 import io.fabric8.kubernetes.client.CustomResourceDoneable;
 import io.javaoperatorsdk.operator.api.ResourceController;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import javax.annotation.processing.*;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.*;
@@ -27,7 +29,7 @@ import static io.javaoperatorsdk.operator.ControllerUtils.CONTROLLERS_RESOURCE_P
 
 @SupportedAnnotationTypes(
         "io.javaoperatorsdk.operator.api.Controller")
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
+@SupportedSourceVersion(SourceVersion.RELEASE_11)
 @AutoService(Processor.class)
 public class ControllerAnnotationProcessor extends AbstractProcessor {
     private FileObject resource;
@@ -102,6 +104,7 @@ public class ControllerAnnotationProcessor extends AbstractProcessor {
 
                 final TypeSpec typeSpec = TypeSpec.classBuilder(doneableClassName)
                         .superclass(ParameterizedTypeName.get(ClassName.get(CustomResourceDoneable.class), customResourceType))
+                        .addAnnotation(RegisterForReflection.class)
                         .addModifiers(Modifier.PUBLIC)
                         .addMethod(constructor)
                         .build();

--- a/operator-framework/src/main/java/io/quarkus/runtime/annotations/RegisterForReflection.java
+++ b/operator-framework/src/main/java/io/quarkus/runtime/annotations/RegisterForReflection.java
@@ -1,0 +1,46 @@
+package io.quarkus.runtime.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation that can be used to force a class to be registered for reflection in native image mode
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface RegisterForReflection {
+
+    /**
+     * If the methods should be registered
+     */
+    boolean methods() default true;
+
+    /**
+     * If the fields should be registered
+     */
+    boolean fields() default true;
+
+    /**
+     * If nested classes/interfaces should be ignored/registered
+     *
+     * This is useful when it's necessary to register inner (especially private) classes for Reflection.
+     */
+    boolean ignoreNested() default true;
+
+    /**
+     * Alternative classes that should actually be registered for reflection instead of the current class.
+     *
+     * This allows for classes in 3rd party libraries to be registered without modification or writing an
+     * extension. If this is set then the class it is placed on is not registered for reflection, so this should
+     * generally just be placed on an empty class that is not otherwise used.
+     */
+    Class<?>[] targets() default {};
+
+    /**
+     * This allows for classes to be registered for reflection via class names. This is useful when it's necessary to
+     * register private classes for Reflection.
+     */
+    String[] classNames() default {};
+}

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/processing/ControllerAnnotationProcessorTest.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/processing/ControllerAnnotationProcessorTest.java
@@ -31,6 +31,5 @@ class ControllerAnnotationProcessorTest {
 
         final JavaFileObject expectedResource = JavaFileObjects.forResource("ControllerImplementedIntermediateAbstractClassExpected.java");
         JavaFileObjectSubject.assertThat(compilation.generatedSourceFiles().get(0)).hasSourceEquivalentTo(expectedResource);
-
     }
 }

--- a/operator-framework/src/test/resources/ControllerImplemented2InterfacesExpected.java
+++ b/operator-framework/src/test/resources/ControllerImplemented2InterfacesExpected.java
@@ -2,7 +2,9 @@ package io;
 
 import io.fabric8.kubernetes.api.builder.Function;
 import io.fabric8.kubernetes.client.CustomResourceDoneable;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
+@RegisterForReflection
 public class MyCustomResourceDoneable extends CustomResourceDoneable<ControllerImplemented2Interfaces.MyCustomResource> {
     public MyCustomResourceDoneable(ControllerImplemented2Interfaces.MyCustomResource resource, Function function) {
         super(resource, function);

--- a/operator-framework/src/test/resources/ControllerImplementedIntermediateAbstractClassExpected.java
+++ b/operator-framework/src/test/resources/ControllerImplementedIntermediateAbstractClassExpected.java
@@ -2,7 +2,9 @@ package io;
 
 import io.fabric8.kubernetes.api.builder.Function;
 import io.fabric8.kubernetes.client.CustomResourceDoneable;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
+@RegisterForReflection
 public class MyCustomResourceDoneable extends CustomResourceDoneable<AbstractController.MyCustomResource> {
     public MyCustomResourceDoneable(AbstractController.MyCustomResource resource, Function function) {
         super(resource, function);


### PR DESCRIPTION
I made a Quarkus core dependency **provided**, and is working as expected. i.e The dependency won't exist in the classpath unless the client does that. 
I think this changeset suffice to support Quarkus native builds! 
Would be great to hear what you think about this solution and if there are any concerns.
@csviri @kirek007 @adam-sandor @metacosm 

**Update** The scope **provided** didn't wok :(, I borrowed the Annotation (with full package name) to this project. 
I think this should work, how is your feeling about it :D?