### PR TITLE
Fix resource/class loading in environments with hierarchical Classpath

### DIFF
--- a/operator-framework/src/main/java/io/javaoperatorsdk/operator/ControllerToCustomResourceMappingsProvider.java
+++ b/operator-framework/src/main/java/io/javaoperatorsdk/operator/ControllerToCustomResourceMappingsProvider.java
@@ -20,7 +20,8 @@ class ControllerToCustomResourceMappingsProvider {
     static Map<Class<? extends ResourceController>, Class<? extends CustomResource>> provide(final String resourcePath) {
         Map<Class<? extends ResourceController>, Class<? extends CustomResource>> controllerToCustomResourceMappings = new HashMap();
         try {
-            final Enumeration<URL> customResourcesMetadataList = ControllerUtils.class.getClassLoader().getResources(resourcePath);
+            final var classLoader = Thread.currentThread().getContextClassLoader();
+            final Enumeration<URL> customResourcesMetadataList = classLoader.getResources(resourcePath);
             for (Iterator<URL> it = customResourcesMetadataList.asIterator(); it.hasNext(); ) {
                 URL url = it.next();
 

--- a/operator-framework/src/main/java/io/javaoperatorsdk/operator/ControllerUtils.java
+++ b/operator-framework/src/main/java/io/javaoperatorsdk/operator/ControllerUtils.java
@@ -4,6 +4,7 @@ import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.CustomResourceDoneable;
 import io.javaoperatorsdk.operator.api.Controller;
 import io.javaoperatorsdk.operator.api.ResourceController;
+import org.apache.commons.lang3.ClassUtils;
 
 import java.util.Map;
 
@@ -55,7 +56,7 @@ public class ControllerUtils {
     getCustomResourceDoneableClass(ResourceController<T> controller) {
         try {
             final Class<T> customResourceClass = getCustomResourceClass(controller);
-            return (Class<? extends CustomResourceDoneable<T>>) Class.forName(customResourceClass.getCanonicalName() + "Doneable");
+            return (Class<? extends CustomResourceDoneable<T>>) ClassUtils.getClass(customResourceClass.getCanonicalName() + "Doneable");
         } catch (ClassNotFoundException e) {
             e.printStackTrace();
             return null;


### PR DESCRIPTION
In circumstances that the classpath is not flat the current class/resource loading fails. 
I encountered this problem by running an operator with `quarkus:dev`. 