### PR TITLE
Simplify testing support for spring boot

### DIFF
--- a/operator-framework-spring-boot-starter-test/pom.xml
+++ b/operator-framework-spring-boot-starter-test/pom.xml
@@ -52,5 +52,19 @@
       <artifactId>kubernetes-server-mock</artifactId>
       <version>4.12.0</version>
     </dependency>
+    <dependency>
+      <groupId>io.javaoperatorsdk</groupId>
+      <artifactId>operator-framework-spring-boot-starter</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-test-autoconfigure</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/operator-framework-spring-boot-starter-test/src/main/java/io/javaoperatorsdk/operator/springboot/starter/test/EnableMockOperator.java
+++ b/operator-framework-spring-boot-starter-test/src/main/java/io/javaoperatorsdk/operator/springboot/starter/test/EnableMockOperator.java
@@ -19,5 +19,4 @@ public @interface EnableMockOperator {
    */
   @PropertyMapping("crd-paths")
   String[] crdPaths() default {};
-
 }

--- a/operator-framework-spring-boot-starter-test/src/main/java/io/javaoperatorsdk/operator/springboot/starter/test/EnableMockOperator.java
+++ b/operator-framework-spring-boot-starter-test/src/main/java/io/javaoperatorsdk/operator/springboot/starter/test/EnableMockOperator.java
@@ -2,8 +2,20 @@ package io.javaoperatorsdk.operator.springboot.starter.test;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import org.springframework.boot.test.autoconfigure.properties.PropertyMapping;
 import org.springframework.context.annotation.Import;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Import(TestConfiguration.class)
-public @interface EnableMockOperator {}
+@PropertyMapping("io.javaoperatorsdk.test")
+public @interface EnableMockOperator {
+
+    /**
+     * Define a list of files that contain CustomResourceDefinitions for the tested operator.
+     * If the file to be loaded is shall be loaded from the classpath prefix it with 'classpath', otherwise provide a path relative to the work directory.
+     * @return List of files
+     */
+    @PropertyMapping("crd-paths")
+    String[] crdPaths() default {};
+
+}

--- a/operator-framework-spring-boot-starter-test/src/main/java/io/javaoperatorsdk/operator/springboot/starter/test/EnableMockOperator.java
+++ b/operator-framework-spring-boot-starter-test/src/main/java/io/javaoperatorsdk/operator/springboot/starter/test/EnableMockOperator.java
@@ -13,7 +13,7 @@ public @interface EnableMockOperator {
   /**
    * Define a list of files that contain CustomResourceDefinitions for the tested operator. If the
    * file to be loaded is shall be loaded from the classpath prefix it with 'classpath', otherwise
-   * provide a path relative to the work directory.
+   * provide a path relative to the current working directory.
    *
    * @return List of files
    */

--- a/operator-framework-spring-boot-starter-test/src/main/java/io/javaoperatorsdk/operator/springboot/starter/test/EnableMockOperator.java
+++ b/operator-framework-spring-boot-starter-test/src/main/java/io/javaoperatorsdk/operator/springboot/starter/test/EnableMockOperator.java
@@ -10,12 +10,14 @@ import org.springframework.context.annotation.Import;
 @PropertyMapping("io.javaoperatorsdk.test")
 public @interface EnableMockOperator {
 
-    /**
-     * Define a list of files that contain CustomResourceDefinitions for the tested operator.
-     * If the file to be loaded is shall be loaded from the classpath prefix it with 'classpath', otherwise provide a path relative to the work directory.
-     * @return List of files
-     */
-    @PropertyMapping("crd-paths")
-    String[] crdPaths() default {};
+  /**
+   * Define a list of files that contain CustomResourceDefinitions for the tested operator. If the
+   * file to be loaded is shall be loaded from the classpath prefix it with 'classpath', otherwise
+   * provide a path relative to the work directory.
+   *
+   * @return List of files
+   */
+  @PropertyMapping("crd-paths")
+  String[] crdPaths() default {};
 
 }

--- a/operator-framework-spring-boot-starter-test/src/main/java/io/javaoperatorsdk/operator/springboot/starter/test/TestConfiguration.java
+++ b/operator-framework-spring-boot-starter-test/src/main/java/io/javaoperatorsdk/operator/springboot/starter/test/TestConfiguration.java
@@ -11,6 +11,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.stream.Stream;
 import okhttp3.mockwebserver.MockWebServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,8 +46,7 @@ public class TestConfiguration {
       KubernetesMockServer server, TestConfigurationProperties properties) {
     final var client = server.createClient();
 
-    properties
-        .getCrdPaths()
+    Stream.concat(properties.getCrdPaths().stream(), properties.getGlobalCrdPaths().stream())
         .forEach(
             crdPath -> {
               CustomResourceDefinition crd;

--- a/operator-framework-spring-boot-starter-test/src/main/java/io/javaoperatorsdk/operator/springboot/starter/test/TestConfiguration.java
+++ b/operator-framework-spring-boot-starter-test/src/main/java/io/javaoperatorsdk/operator/springboot/starter/test/TestConfiguration.java
@@ -41,10 +41,11 @@ public class TestConfiguration {
   }
 
   @Bean
-  public KubernetesClient kubernetesClient(KubernetesMockServer server, TestConfigurationProperties properties) {
+  public KubernetesClient kubernetesClient(KubernetesMockServer server,
+      TestConfigurationProperties properties) {
     final var client = server.createClient();
 
-      properties.getCrdPaths().forEach(
+    properties.getCrdPaths().forEach(
         crdPath -> {
           CustomResourceDefinition crd;
           try {

--- a/operator-framework-spring-boot-starter-test/src/main/java/io/javaoperatorsdk/operator/springboot/starter/test/TestConfiguration.java
+++ b/operator-framework-spring-boot-starter-test/src/main/java/io/javaoperatorsdk/operator/springboot/starter/test/TestConfiguration.java
@@ -41,25 +41,26 @@ public class TestConfiguration {
   }
 
   @Bean
-  public KubernetesClient kubernetesClient(KubernetesMockServer server,
-      TestConfigurationProperties properties) {
+  public KubernetesClient kubernetesClient(
+      KubernetesMockServer server, TestConfigurationProperties properties) {
     final var client = server.createClient();
 
-    properties.getCrdPaths().forEach(
-        crdPath -> {
-          CustomResourceDefinition crd;
-          try {
-            crd = Serialization.unmarshal(new FileInputStream(ResourceUtils.getFile(crdPath)));
-          } catch (FileNotFoundException e) {
-            log.warn("CRD with path {} not found!", crdPath);
-            e.printStackTrace();
-            return;
-          }
+    properties
+        .getCrdPaths()
+        .forEach(
+            crdPath -> {
+              CustomResourceDefinition crd;
+              try {
+                crd = Serialization.unmarshal(new FileInputStream(ResourceUtils.getFile(crdPath)));
+              } catch (FileNotFoundException e) {
+                log.warn("CRD with path {} not found!", crdPath);
+                e.printStackTrace();
+                return;
+              }
 
-          client.apiextensions().v1().customResourceDefinitions().create(crd);
-        });
+              client.apiextensions().v1().customResourceDefinitions().create(crd);
+            });
 
     return client;
   }
-
 }

--- a/operator-framework-spring-boot-starter-test/src/main/java/io/javaoperatorsdk/operator/springboot/starter/test/TestConfiguration.java
+++ b/operator-framework-spring-boot-starter-test/src/main/java/io/javaoperatorsdk/operator/springboot/starter/test/TestConfiguration.java
@@ -6,26 +6,26 @@ import io.fabric8.kubernetes.client.server.mock.KubernetesCrudDispatcher;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.mockwebserver.Context;
+import io.javaoperatorsdk.operator.springboot.starter.OperatorAutoConfiguration;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import okhttp3.mockwebserver.MockWebServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.ResourceUtils;
 
 @Configuration
+@ImportAutoConfiguration(OperatorAutoConfiguration.class)
+@EnableConfigurationProperties(TestConfigurationProperties.class)
 public class TestConfiguration {
 
   private static final Logger log = LoggerFactory.getLogger(TestConfiguration.class);
-
-  @Value("${io.javaoperatorsdk.test.crdPaths}")
-  private List<String> crdPaths;
 
   @Bean
   public KubernetesMockServer k8sMockServer() {
@@ -41,12 +41,12 @@ public class TestConfiguration {
   }
 
   @Bean
-  public KubernetesClient kubernetesClient(KubernetesMockServer server) {
+  public KubernetesClient kubernetesClient(KubernetesMockServer server, TestConfigurationProperties properties) {
     final var client = server.createClient();
 
-    crdPaths.forEach(
+      properties.getCrdPaths().forEach(
         crdPath -> {
-          CustomResourceDefinition crd = null;
+          CustomResourceDefinition crd;
           try {
             crd = Serialization.unmarshal(new FileInputStream(ResourceUtils.getFile(crdPath)));
           } catch (FileNotFoundException e) {
@@ -60,4 +60,5 @@ public class TestConfiguration {
 
     return client;
   }
+
 }

--- a/operator-framework-spring-boot-starter-test/src/main/java/io/javaoperatorsdk/operator/springboot/starter/test/TestConfigurationProperties.java
+++ b/operator-framework-spring-boot-starter-test/src/main/java/io/javaoperatorsdk/operator/springboot/starter/test/TestConfigurationProperties.java
@@ -1,0 +1,19 @@
+package io.javaoperatorsdk.operator.springboot.starter.test;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("io.javaoperatorsdk.test")
+public class TestConfigurationProperties {
+
+    private List<String> crdPaths = new ArrayList<>();
+
+    public List<String> getCrdPaths() {
+        return crdPaths;
+    }
+
+    public void setCrdPaths(List<String> crdPaths) {
+        this.crdPaths = crdPaths;
+    }
+}

--- a/operator-framework-spring-boot-starter-test/src/main/java/io/javaoperatorsdk/operator/springboot/starter/test/TestConfigurationProperties.java
+++ b/operator-framework-spring-boot-starter-test/src/main/java/io/javaoperatorsdk/operator/springboot/starter/test/TestConfigurationProperties.java
@@ -7,13 +7,13 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties("io.javaoperatorsdk.test")
 public class TestConfigurationProperties {
 
-    private List<String> crdPaths = new ArrayList<>();
+  private List<String> crdPaths = new ArrayList<>();
 
-    public List<String> getCrdPaths() {
-        return crdPaths;
-    }
+  public List<String> getCrdPaths() {
+    return crdPaths;
+  }
 
-    public void setCrdPaths(List<String> crdPaths) {
-        this.crdPaths = crdPaths;
-    }
+  public void setCrdPaths(List<String> crdPaths) {
+    this.crdPaths = crdPaths;
+  }
 }

--- a/operator-framework-spring-boot-starter-test/src/main/java/io/javaoperatorsdk/operator/springboot/starter/test/TestConfigurationProperties.java
+++ b/operator-framework-spring-boot-starter-test/src/main/java/io/javaoperatorsdk/operator/springboot/starter/test/TestConfigurationProperties.java
@@ -7,6 +7,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties("io.javaoperatorsdk.test")
 public class TestConfigurationProperties {
 
+  private List<String> globalCrdPaths = new ArrayList<>();
+
   private List<String> crdPaths = new ArrayList<>();
 
   public List<String> getCrdPaths() {
@@ -15,5 +17,13 @@ public class TestConfigurationProperties {
 
   public void setCrdPaths(List<String> crdPaths) {
     this.crdPaths = crdPaths;
+  }
+
+  public List<String> getGlobalCrdPaths() {
+    return globalCrdPaths;
+  }
+
+  public void setGlobalCrdPaths(List<String> globalCrdPaths) {
+    this.globalCrdPaths = globalCrdPaths;
   }
 }

--- a/operator-framework-spring-boot-starter-test/src/test/java/io/javaoperatorsdk/operator/springboot/starter/test/EnableMockOperatorTests.java
+++ b/operator-framework-spring-boot-starter-test/src/test/java/io/javaoperatorsdk/operator/springboot/starter/test/EnableMockOperatorTests.java
@@ -27,6 +27,12 @@ class EnableMockOperatorTests {
                 .withName("customservices.sample.javaoperatorsdk")
                 .get())
         .isNotNull();
+    assertThat(
+            client
+                .customResourceDefinitions()
+                .withName("customservices.global.sample.javaoperatorsdk")
+                .get())
+        .isNotNull();
   }
 
   @SpringBootApplication

--- a/operator-framework-spring-boot-starter-test/src/test/java/io/javaoperatorsdk/operator/springboot/starter/test/EnableMockOperatorTests.java
+++ b/operator-framework-spring-boot-starter-test/src/test/java/io/javaoperatorsdk/operator/springboot/starter/test/EnableMockOperatorTests.java
@@ -14,24 +14,21 @@ import org.springframework.context.ApplicationContext;
 @EnableMockOperator(crdPaths = "classpath:crd.yml")
 class EnableMockOperatorTests {
 
-  @Autowired
-  KubernetesClient client;
+  @Autowired KubernetesClient client;
 
-  @Autowired
-  ApplicationContext applicationContext;
+  @Autowired ApplicationContext applicationContext;
 
   @Test
   void testCrdLoaded() {
-    assertThat(applicationContext.getBean(Operator.class))
+    assertThat(applicationContext.getBean(Operator.class)).isNotNull();
+    assertThat(
+            client
+                .customResourceDefinitions()
+                .withName("customservices.sample.javaoperatorsdk")
+                .get())
         .isNotNull();
-    assertThat(client.customResourceDefinitions()
-        .withName("customservices.sample.javaoperatorsdk")
-        .get()).isNotNull();
   }
 
   @SpringBootApplication
-  static class SpringBootTestApplication {
-
-  }
-
+  static class SpringBootTestApplication {}
 }

--- a/operator-framework-spring-boot-starter-test/src/test/java/io/javaoperatorsdk/operator/springboot/starter/test/EnableMockOperatorTests.java
+++ b/operator-framework-spring-boot-starter-test/src/test/java/io/javaoperatorsdk/operator/springboot/starter/test/EnableMockOperatorTests.java
@@ -1,0 +1,37 @@
+package io.javaoperatorsdk.operator.springboot.starter.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.javaoperatorsdk.operator.Operator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+import org.springframework.context.ApplicationContext;
+
+@JsonTest
+@EnableMockOperator(crdPaths = "classpath:crd.yml")
+class EnableMockOperatorTests {
+
+    @Autowired
+    KubernetesClient client;
+
+    @Autowired
+    ApplicationContext applicationContext;
+
+    @Test
+    void testCrdLoaded() {
+        assertThat(applicationContext.getBean(Operator.class))
+                .isNotNull();
+        assertThat(client.customResourceDefinitions()
+                .withName("customservices.sample.javaoperatorsdk")
+                .get()).isNotNull();
+    }
+
+    @SpringBootApplication
+    static class SpringBootTestApplication {
+
+    }
+
+}

--- a/operator-framework-spring-boot-starter-test/src/test/java/io/javaoperatorsdk/operator/springboot/starter/test/EnableMockOperatorTests.java
+++ b/operator-framework-spring-boot-starter-test/src/test/java/io/javaoperatorsdk/operator/springboot/starter/test/EnableMockOperatorTests.java
@@ -14,24 +14,24 @@ import org.springframework.context.ApplicationContext;
 @EnableMockOperator(crdPaths = "classpath:crd.yml")
 class EnableMockOperatorTests {
 
-    @Autowired
-    KubernetesClient client;
+  @Autowired
+  KubernetesClient client;
 
-    @Autowired
-    ApplicationContext applicationContext;
+  @Autowired
+  ApplicationContext applicationContext;
 
-    @Test
-    void testCrdLoaded() {
-        assertThat(applicationContext.getBean(Operator.class))
-                .isNotNull();
-        assertThat(client.customResourceDefinitions()
-                .withName("customservices.sample.javaoperatorsdk")
-                .get()).isNotNull();
-    }
+  @Test
+  void testCrdLoaded() {
+    assertThat(applicationContext.getBean(Operator.class))
+        .isNotNull();
+    assertThat(client.customResourceDefinitions()
+        .withName("customservices.sample.javaoperatorsdk")
+        .get()).isNotNull();
+  }
 
-    @SpringBootApplication
-    static class SpringBootTestApplication {
+  @SpringBootApplication
+  static class SpringBootTestApplication {
 
-    }
+  }
 
 }

--- a/operator-framework-spring-boot-starter-test/src/test/resources/application.properties
+++ b/operator-framework-spring-boot-starter-test/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+io.javaoperatorsdk.test.global-crd-paths=classpath:global-crd.yml

--- a/operator-framework-spring-boot-starter-test/src/test/resources/crd.yml
+++ b/operator-framework-spring-boot-starter-test/src/test/resources/crd.yml
@@ -1,0 +1,17 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: customservices.sample.javaoperatorsdk
+spec:
+  group: sample.javaoperatorsdk
+  scope: Namespaced
+  names:
+    plural: customservices
+    singular: customservice
+    kind: CustomService
+    shortNames:
+      - cs
+  versions:
+    - name: v1
+      served: true
+      storage: true

--- a/operator-framework-spring-boot-starter-test/src/test/resources/global-crd.yml
+++ b/operator-framework-spring-boot-starter-test/src/test/resources/global-crd.yml
@@ -1,0 +1,17 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: customservices.global.sample.javaoperatorsdk
+spec:
+  group: sample.javaoperatorsdk
+  scope: Namespaced
+  names:
+    plural: customservices
+    singular: customservice
+    kind: CustomService
+    shortNames:
+      - cs
+  versions:
+    - name: v1
+      served: true
+      storage: true


### PR DESCRIPTION
Updated the testing support for spring boot integration so the mocked kubernetes can be configured solely via the annotation.

#261 