### PR TITLE
Bump actions-setup-minikube to v2.3.0

### DIFF
--- a/.github/workflows/master-snapshot-release.yml
+++ b/.github/workflows/master-snapshot-release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Run unit tests
         run: mvn -B test -P no-integration-tests --file pom.xml
       - name: Set up Minikube
-        uses: manusa/actions-setup-minikube@v2.0.1
+        uses: manusa/actions-setup-minikube@v2.3.0
         with:
           minikube version: 'v1.15.1'
           kubernetes version: ${{ matrix.kubernetes }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Run unit tests
         run: mvn -B test -P no-integration-tests --file pom.xml
       - name: Set up Minikube
-        uses: manusa/actions-setup-minikube@v2.0.1
+        uses: manusa/actions-setup-minikube@v2.3.0
         with:
           minikube version: 'v1.15.1'
           kubernetes version: ${{ matrix.kubernetes }}


### PR DESCRIPTION
Upgrade `manusa/actions-setup-minikube` to use the latest version.

GitHub is rolling out Ubuntu 20.04 as the default environment. GitHub actions workflows using `ubuntu-latest` will [soon ](https://github.com/actions/virtual-environments/issues/1816) start an Ubuntu 20,04 instance instead of 18.04.

Prior versions of `manusa/actions-setup-minikube` have a check which won't allow the workflow job to run. Starting on `2.2.0`, Ubuntu 20.04 is supported too (https://github.com/manusa/actions-setup-minikube/issues/26).