### PR TITLE
Fixed link to Quarkus dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ public class WebServerSpec {
 
 A [Quarkus](https://quarkus.io) extension is also provided to ease the development of Quarkus-based operators.
 
-Add [this dependency] (https://search.maven.org/search?q=a:operator-framework-quarkus-extension)
+Add [this dependency](https://search.maven.org/search?q=a:operator-framework-quarkus-extension)
 to your project:
 
 ```xml


### PR DESCRIPTION
This trivial PR just fixes a markdown mistake on adding the link to the Quarkus dependency.