### PR TITLE
fix(watchers): gracefully handle watch disconnection

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/DefaultEventSourceManager.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/DefaultEventSourceManager.java
@@ -82,6 +82,11 @@ public class DefaultEventSourceManager implements EventSourceManager {
     return Collections.unmodifiableMap(eventSources);
   }
 
+  @Override
+  public void close() {
+    customResourceEventSource.close();
+  }
+
   public void cleanup(String customResourceUid) {
     getRegisteredEventSources()
         .keySet()

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventSource.java
@@ -5,4 +5,6 @@ public interface EventSource {
   void setEventHandler(EventHandler eventHandler);
 
   void eventSourceDeRegisteredForResource(String customResourceUid);
+
+  default void close() {};
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventSourceManager.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventSourceManager.java
@@ -11,4 +11,6 @@ public interface EventSourceManager {
       String name, String customResourceUid);
 
   Map<String, EventSource> getRegisteredEventSources();
+
+  default void close() {};
 }

--- a/operator-framework-quarkus-extension/runtime/src/main/java/io/javaoperatorsdk/quarkus/extension/OperatorProducer.java
+++ b/operator-framework-quarkus-extension/runtime/src/main/java/io/javaoperatorsdk/quarkus/extension/OperatorProducer.java
@@ -6,6 +6,8 @@ import io.javaoperatorsdk.operator.Operator;
 import io.javaoperatorsdk.operator.api.ResourceController;
 import io.javaoperatorsdk.operator.api.config.ConfigurationService;
 import io.quarkus.arc.DefaultBean;
+import io.quarkus.runtime.ShutdownEvent;
+import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
@@ -24,4 +26,9 @@ public class OperatorProducer {
     controllers.stream().forEach(operator::register);
     return operator;
   }
+
+  void onStop(@Observes ShutdownEvent ev, Operator operator) {
+    operator.close();
+  }
+
 }


### PR DESCRIPTION
This is based on top of the https://github.com/java-operator-sdk/java-operator-sdk/tree/client-v5 branch. It's created to show a possible solution for the watcher cleanup.

Basically, the idea is to add a `close()` method for manual cleanup of watchers on the `Operator` class. I did not find an automatic way to solve it in general, ideas welcome.

For Quarkus though, this method is automatically called at the application shutdown, so for Quarkus - **it is** automatic.

Draft!