### PR TITLE
fix(watchers): gracefully handle watch disconnection

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/DefaultEventSourceManager.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/DefaultEventSourceManager.java
@@ -82,6 +82,11 @@ public class DefaultEventSourceManager implements EventSourceManager {
     return Collections.unmodifiableMap(eventSources);
   }
 
+  @Override
+  public void close() {
+    customResourceEventSource.close();
+  }
+
   public void cleanup(String customResourceUid) {
     getRegisteredEventSources()
         .keySet()

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventSource.java
@@ -5,4 +5,7 @@ public interface EventSource {
   void setEventHandler(EventHandler eventHandler);
 
   void eventSourceDeRegisteredForResource(String customResourceUid);
+
+  default void close() {}
+  ;
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventSourceManager.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventSourceManager.java
@@ -11,4 +11,7 @@ public interface EventSourceManager {
       String name, String customResourceUid);
 
   Map<String, EventSource> getRegisteredEventSources();
+
+  default void close() {}
+  ;
 }

--- a/operator-framework-quarkus-extension/runtime/src/main/java/io/javaoperatorsdk/quarkus/extension/OperatorProducer.java
+++ b/operator-framework-quarkus-extension/runtime/src/main/java/io/javaoperatorsdk/quarkus/extension/OperatorProducer.java
@@ -6,6 +6,8 @@ import io.javaoperatorsdk.operator.Operator;
 import io.javaoperatorsdk.operator.api.ResourceController;
 import io.javaoperatorsdk.operator.api.config.ConfigurationService;
 import io.quarkus.arc.DefaultBean;
+import io.quarkus.runtime.ShutdownEvent;
+import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
@@ -23,5 +25,9 @@ public class OperatorProducer {
     final var operator = new Operator(client, configuration);
     controllers.stream().forEach(operator::register);
     return operator;
+  }
+
+  void onStop(@Observes ShutdownEvent ev, Operator operator) {
+    operator.close();
   }
 }


### PR DESCRIPTION
This shows a possible (but not necessarily elegant) way of cleaning up watcher when the application is shut down. In order to gracefully shut down, the `close()` method should be called manually. For Quarkus based apps - this is done automatically.