### PR TITLE
Remove finalizer in case of exception

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/EventDispatcher.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/EventDispatcher.java
@@ -151,7 +151,12 @@ public class EventDispatcher {
     log.debug(
         "Adding finalizer for resource: {} version: {}", getUID(resource), getVersion(resource));
     addFinalizerIfNotPresent(resource);
-    replace(resource);
+    try {
+      replace(resource);
+    } catch (RuntimeException e) {
+      removeFinalizer(resource);
+      throw e;
+    }
   }
 
   private CustomResource updateCustomResource(CustomResource resource) {


### PR DESCRIPTION
This PR should fix #310 removing the finalizer in case of exception when trying to apply it on the resource but operation on the k8s server API fails.