### PR TITLE
Delayed registration

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/Controller.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/Controller.java
@@ -33,4 +33,7 @@ public @interface Controller {
    * @return the list of namespaces this controller monitors
    */
   String[] namespaces() default {};
+
+  /** Delay registration until specified CDI event is fired. */
+  Class<?> delayRegistrationUntilEvent() default void.class;
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/AbstractControllerConfiguration.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/AbstractControllerConfiguration.java
@@ -15,6 +15,7 @@ public abstract class AbstractControllerConfiguration<R extends CustomResource>
   private final Set<String> namespaces;
   private final boolean watchAllNamespaces;
   private final RetryConfiguration retryConfiguration;
+  private final boolean delayedRegistration;
 
   public AbstractControllerConfiguration(
       String associatedControllerClassName,
@@ -23,7 +24,8 @@ public abstract class AbstractControllerConfiguration<R extends CustomResource>
       String finalizer,
       boolean generationAware,
       Set<String> namespaces,
-      RetryConfiguration retryConfiguration) {
+      RetryConfiguration retryConfiguration,
+      boolean delayedRegistration) {
     this.associatedControllerClassName = associatedControllerClassName;
     this.name = name;
     this.crdName = crdName;
@@ -36,6 +38,7 @@ public abstract class AbstractControllerConfiguration<R extends CustomResource>
         retryConfiguration == null
             ? ControllerConfiguration.super.getRetryConfiguration()
             : retryConfiguration;
+    this.delayedRegistration = delayedRegistration;
   }
 
   @Override
@@ -76,5 +79,10 @@ public abstract class AbstractControllerConfiguration<R extends CustomResource>
   @Override
   public RetryConfiguration getRetryConfiguration() {
     return retryConfiguration;
+  }
+
+  @Override
+  public boolean isRegistrationDelayed() {
+    return delayedRegistration;
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ControllerConfiguration.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ControllerConfiguration.java
@@ -28,4 +28,8 @@ public interface ControllerConfiguration<R extends CustomResource> {
   default RetryConfiguration getRetryConfiguration() {
     return RetryConfiguration.DEFAULT;
   }
+
+  default boolean isRegistrationDelayed() {
+    return false;
+  }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ControllerConfigurationOverrider.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ControllerConfigurationOverrider.java
@@ -65,7 +65,8 @@ public class ControllerConfigurationOverrider<R extends CustomResource> {
         finalizer,
         generationAware,
         namespaces,
-        retry) {
+        retry,
+        original.isRegistrationDelayed()) {
       @Override
       public Class<R> getCustomResourceClass() {
         return original.getCustomResourceClass();

--- a/operator-framework-quarkus-extension/deployment/src/main/java/io/javaoperatorsdk/quarkus/extension/deployment/HybridControllerConfiguration.java
+++ b/operator-framework-quarkus-extension/deployment/src/main/java/io/javaoperatorsdk/quarkus/extension/deployment/HybridControllerConfiguration.java
@@ -1,0 +1,99 @@
+package io.javaoperatorsdk.quarkus.extension.deployment;
+
+import io.javaoperatorsdk.operator.ControllerUtils;
+import io.javaoperatorsdk.operator.api.ResourceController;
+import io.javaoperatorsdk.operator.api.config.RetryConfiguration;
+import io.javaoperatorsdk.quarkus.extension.ExternalConfiguration;
+import io.javaoperatorsdk.quarkus.extension.ExternalControllerConfiguration;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Type;
+import org.jboss.jandex.Type.Kind;
+
+/**
+ * Encapsulates controller configuration values that might come from either annotation or external
+ * properties file.
+ */
+class HybridControllerConfiguration {
+
+  private final ValueExtractor extractor;
+  private final String name;
+  private final ExternalControllerConfiguration extConfig;
+
+  /**
+   * Creates a new HybridControllerConfiguration
+   *
+   * @param resourceControllerClassName the fully-qualified name of the associated {@link
+   *     ResourceController} class
+   * @param externalConfiguration the external configuration
+   * @param controllerAnnotation the {@link io.javaoperatorsdk.operator.api.Controller} annotation
+   *     associated with the controller
+   */
+  public HybridControllerConfiguration(
+      String resourceControllerClassName,
+      ExternalConfiguration externalConfiguration,
+      AnnotationInstance controllerAnnotation) {
+    // retrieve the controller's name
+    final var defaultControllerName =
+        ControllerUtils.getDefaultResourceControllerName(resourceControllerClassName);
+    this.name =
+        ValueExtractor.annotationValueOrDefault(
+            controllerAnnotation, "name", AnnotationValue::asString, () -> defaultControllerName);
+
+    this.extConfig = externalConfiguration.controllers.get(name);
+    this.extractor = new ValueExtractor(controllerAnnotation, extConfig);
+  }
+
+  String name() {
+    return name;
+  }
+
+  String finalizer(final String crdName) {
+    return extractor.extract(
+        c -> c.finalizer,
+        "finalizerName",
+        AnnotationValue::asString,
+        () -> ControllerUtils.getDefaultFinalizerName(crdName));
+  }
+
+  boolean generationAware() {
+    return extractor.extract(
+        c -> c.generationAware,
+        "generationAwareEventProcessing",
+        AnnotationValue::asBoolean,
+        () -> true);
+  }
+
+  String[] namespaces() {
+    return extractor.extract(
+        c -> c.namespaces.map(l -> l.toArray(new String[0])),
+        "namespaces",
+        AnnotationValue::asStringArray,
+        () -> new String[] {});
+  }
+
+  RetryConfiguration retryConfiguration() {
+    return extConfig == null ? null : RetryConfigurationResolver.resolve(extConfig.retry);
+  }
+
+  Type eventType() {
+    return extractor.extract(
+        c ->
+            c.delayRegistrationUntilEvent
+                .filter(s -> void.class.getName().equals(s))
+                .map(DotName::createSimple)
+                .map(dn -> Type.create(dn, Kind.CLASS)),
+        "delayRegistrationUntilEvent",
+        AnnotationValue::asClass,
+        () -> null);
+  }
+
+  boolean delayedRegistration() {
+    return extractor.extract(
+        c -> c.delayRegistrationUntilEvent.map(s -> void.class.getName().equals(s)),
+        "delayRegistrationUntilEvent",
+        v -> v.asClass().kind() != Kind.VOID,
+        () -> false);
+  }
+}

--- a/operator-framework-quarkus-extension/deployment/src/main/java/io/javaoperatorsdk/quarkus/extension/deployment/QuarkusExtensionProcessor.java
+++ b/operator-framework-quarkus-extension/deployment/src/main/java/io/javaoperatorsdk/quarkus/extension/deployment/QuarkusExtensionProcessor.java
@@ -233,7 +233,7 @@ class QuarkusExtensionProcessor {
     final var defaultControllerName =
         ControllerUtils.getDefaultResourceControllerName(resourceControllerClassName);
     final var name =
-        annotationValueOrDefault(
+        ValueExtractor.annotationValueOrDefault(
             controllerAnnotation, "name", AnnotationValue::asString, () -> defaultControllerName);
 
     boolean delayedRegistration = false;
@@ -298,70 +298,6 @@ class QuarkusExtensionProcessor {
 
   private RetryConfiguration retryConfiguration(ExternalControllerConfiguration extConfig) {
     return extConfig == null ? null : RetryConfigurationResolver.resolve(extConfig.retry);
-  }
-
-  private static class ValueExtractor {
-
-    private final AnnotationInstance controllerAnnotation;
-    private final ExternalControllerConfiguration extContConfig;
-
-    ValueExtractor(
-        AnnotationInstance controllerAnnotation, ExternalControllerConfiguration extContConfig) {
-      this.controllerAnnotation = controllerAnnotation;
-      this.extContConfig = extContConfig;
-    }
-
-    /**
-     * Extracts the appropriate configuration value for the controller checking first any annotation
-     * configuration, then potentially overriding it by a properties-provided value or returning a
-     * default value if neither is provided.
-     *
-     * @param extractor a Function extracting the optional value we're interested in from the
-     *     external configuration
-     * @param annotationField the name of the {@link Controller} annotation we're want to retrieve
-     *     if present
-     * @param converter a Function converting the annotation value to the type we're expecting
-     * @param defaultValue a Supplier that computes/retrieve a default value when needed
-     * @param <T> the expected type of the configuration value we're trying to extract
-     * @return the extracted configuration value
-     */
-    <T> T extract(
-        Function<ExternalControllerConfiguration, Optional<T>> extractor,
-        String annotationField,
-        Function<AnnotationValue, T> converter,
-        Supplier<T> defaultValue) {
-      // first check if we have an external configuration
-      if (extContConfig != null) {
-        // extract value from config if present
-        return extractor
-            .apply(extContConfig)
-            // or get from the annotation or default
-            .orElse(annotationValueOrDefault(annotationField, converter, defaultValue));
-      } else {
-        // get from annotation or default
-        return annotationValueOrDefault(annotationField, converter, defaultValue);
-      }
-    }
-
-    private <T> T annotationValueOrDefault(
-        String name, Function<AnnotationValue, T> converter, Supplier<T> defaultValue) {
-      return QuarkusExtensionProcessor.annotationValueOrDefault(
-          controllerAnnotation, name, converter, defaultValue);
-    }
-  }
-
-  private static <T> T annotationValueOrDefault(
-      AnnotationInstance annotation,
-      String name,
-      Function<AnnotationValue, T> converter,
-      Supplier<T> defaultValue) {
-    return annotation != null
-        ?
-        // get converted annotation value of get default
-        Optional.ofNullable(annotation.value(name)).map(converter).orElseGet(defaultValue)
-        :
-        // get default
-        defaultValue.get();
   }
 
   private Class<?> loadClass(String className) {

--- a/operator-framework-quarkus-extension/deployment/src/main/java/io/javaoperatorsdk/quarkus/extension/deployment/ValueExtractor.java
+++ b/operator-framework-quarkus-extension/deployment/src/main/java/io/javaoperatorsdk/quarkus/extension/deployment/ValueExtractor.java
@@ -24,13 +24,13 @@ class ValueExtractor {
    * configuration, then potentially overriding it by a properties-provided value or returning a
    * default value if neither is provided.
    *
-   * @param extractor       a Function extracting the optional value we're interested in from the
-   *                        external configuration
+   * @param extractor a Function extracting the optional value we're interested in from the external
+   *     configuration
    * @param annotationField the name of the {@link Controller} annotation we're want to retrieve if
-   *                        present
-   * @param converter       a Function converting the annotation value to the type we're expecting
-   * @param defaultValue    a Supplier that computes/retrieve a default value when needed
-   * @param <T>             the expected type of the configuration value we're trying to extract
+   *     present
+   * @param converter a Function converting the annotation value to the type we're expecting
+   * @param defaultValue a Supplier that computes/retrieve a default value when needed
+   * @param <T> the expected type of the configuration value we're trying to extract
    * @return the extracted configuration value
    */
   <T> T extract(
@@ -66,7 +66,7 @@ class ValueExtractor {
         // get converted annotation value of get default
         Optional.ofNullable(annotation.value(name)).map(converter).orElseGet(defaultValue)
         :
-            // get default
-            defaultValue.get();
+        // get default
+        defaultValue.get();
   }
 }

--- a/operator-framework-quarkus-extension/deployment/src/main/java/io/javaoperatorsdk/quarkus/extension/deployment/ValueExtractor.java
+++ b/operator-framework-quarkus-extension/deployment/src/main/java/io/javaoperatorsdk/quarkus/extension/deployment/ValueExtractor.java
@@ -1,0 +1,72 @@
+package io.javaoperatorsdk.quarkus.extension.deployment;
+
+import io.javaoperatorsdk.operator.api.Controller;
+import io.javaoperatorsdk.quarkus.extension.ExternalControllerConfiguration;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationValue;
+
+class ValueExtractor {
+
+  private final AnnotationInstance controllerAnnotation;
+  private final ExternalControllerConfiguration extContConfig;
+
+  ValueExtractor(
+      AnnotationInstance controllerAnnotation, ExternalControllerConfiguration extContConfig) {
+    this.controllerAnnotation = controllerAnnotation;
+    this.extContConfig = extContConfig;
+  }
+
+  /**
+   * Extracts the appropriate configuration value for the controller checking first any annotation
+   * configuration, then potentially overriding it by a properties-provided value or returning a
+   * default value if neither is provided.
+   *
+   * @param extractor       a Function extracting the optional value we're interested in from the
+   *                        external configuration
+   * @param annotationField the name of the {@link Controller} annotation we're want to retrieve if
+   *                        present
+   * @param converter       a Function converting the annotation value to the type we're expecting
+   * @param defaultValue    a Supplier that computes/retrieve a default value when needed
+   * @param <T>             the expected type of the configuration value we're trying to extract
+   * @return the extracted configuration value
+   */
+  <T> T extract(
+      Function<ExternalControllerConfiguration, Optional<T>> extractor,
+      String annotationField,
+      Function<AnnotationValue, T> converter,
+      Supplier<T> defaultValue) {
+    // first check if we have an external configuration
+    if (extContConfig != null) {
+      // extract value from config if present
+      return extractor
+          .apply(extContConfig)
+          // or get from the annotation or default
+          .orElse(annotationValueOrDefault(annotationField, converter, defaultValue));
+    } else {
+      // get from annotation or default
+      return annotationValueOrDefault(annotationField, converter, defaultValue);
+    }
+  }
+
+  private <T> T annotationValueOrDefault(
+      String name, Function<AnnotationValue, T> converter, Supplier<T> defaultValue) {
+    return annotationValueOrDefault(controllerAnnotation, name, converter, defaultValue);
+  }
+
+  static <T> T annotationValueOrDefault(
+      AnnotationInstance annotation,
+      String name,
+      Function<AnnotationValue, T> converter,
+      Supplier<T> defaultValue) {
+    return annotation != null
+        ?
+        // get converted annotation value of get default
+        Optional.ofNullable(annotation.value(name)).map(converter).orElseGet(defaultValue)
+        :
+            // get default
+            defaultValue.get();
+  }
+}

--- a/operator-framework-quarkus-extension/runtime/src/main/java/io/javaoperatorsdk/quarkus/extension/ExternalControllerConfiguration.java
+++ b/operator-framework-quarkus-extension/runtime/src/main/java/io/javaoperatorsdk/quarkus/extension/ExternalControllerConfiguration.java
@@ -29,4 +29,10 @@ public class ExternalControllerConfiguration {
 
   /** The optional controller retry configuration */
   public Optional<ExternalRetryConfiguration> retry;
+
+  /**
+   * The optional fully qualified name of a CDI event class that the controller will wait for before
+   * registering with the Operator.
+   */
+  public Optional<String> delayRegistrationUntilEvent;
 }

--- a/operator-framework-quarkus-extension/runtime/src/main/java/io/javaoperatorsdk/quarkus/extension/QuarkusControllerConfiguration.java
+++ b/operator-framework-quarkus-extension/runtime/src/main/java/io/javaoperatorsdk/quarkus/extension/QuarkusControllerConfiguration.java
@@ -22,7 +22,8 @@ public class QuarkusControllerConfiguration<R extends CustomResource>
       boolean generationAware,
       Set<String> namespaces,
       String crClass,
-      RetryConfiguration retryConfiguration) {
+      RetryConfiguration retryConfiguration,
+      boolean registrationDelayed) {
     super(
         associatedControllerClassName,
         name,
@@ -30,7 +31,8 @@ public class QuarkusControllerConfiguration<R extends CustomResource>
         finalizer,
         generationAware,
         namespaces,
-        retryConfiguration);
+        retryConfiguration,
+        registrationDelayed);
     this.crClass = crClass;
   }
 

--- a/operator-framework-quarkus-extension/tests/pom.xml
+++ b/operator-framework-quarkus-extension/tests/pom.xml
@@ -39,6 +39,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-test-kubernetes-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
       <scope>test</scope>

--- a/operator-framework-quarkus-extension/tests/src/main/java/io/javaoperatorsdk/quarkus/it/ConfiguredController.java
+++ b/operator-framework-quarkus-extension/tests/src/main/java/io/javaoperatorsdk/quarkus/it/ConfiguredController.java
@@ -3,13 +3,14 @@ package io.javaoperatorsdk.quarkus.it;
 import io.javaoperatorsdk.operator.api.Context;
 import io.javaoperatorsdk.operator.api.Controller;
 import io.javaoperatorsdk.operator.api.DeleteControl;
-import io.javaoperatorsdk.operator.api.ResourceController;
 import io.javaoperatorsdk.operator.api.UpdateControl;
+import io.javaoperatorsdk.operator.processing.event.EventSourceManager;
 
 @Controller(name = ConfiguredController.NAME, namespaces = "foo")
-public class ConfiguredController implements ResourceController<TestResource> {
+public class ConfiguredController implements RegistrableController<TestResource> {
 
   public static final String NAME = "annotation";
+  private boolean initialised;
 
   @Override
   public DeleteControl deleteResource(TestResource resource, Context<TestResource> context) {
@@ -20,5 +21,15 @@ public class ConfiguredController implements ResourceController<TestResource> {
   public UpdateControl<TestResource> createOrUpdateResource(
       TestResource resource, Context<TestResource> context) {
     return null;
+  }
+
+  @Override
+  public void init(EventSourceManager eventSourceManager) {
+    initialised = true;
+  }
+
+  @Override
+  public boolean isInitialised() {
+    return initialised;
   }
 }

--- a/operator-framework-quarkus-extension/tests/src/main/java/io/javaoperatorsdk/quarkus/it/RegistrableController.java
+++ b/operator-framework-quarkus-extension/tests/src/main/java/io/javaoperatorsdk/quarkus/it/RegistrableController.java
@@ -1,0 +1,8 @@
+package io.javaoperatorsdk.quarkus.it;
+
+import io.fabric8.kubernetes.client.CustomResource;
+import io.javaoperatorsdk.operator.api.ResourceController;
+
+public interface RegistrableController<R extends CustomResource> extends ResourceController<R> {
+  public boolean isInitialised();
+}

--- a/operator-framework-quarkus-extension/tests/src/main/java/io/javaoperatorsdk/quarkus/it/TestController.java
+++ b/operator-framework-quarkus-extension/tests/src/main/java/io/javaoperatorsdk/quarkus/it/TestController.java
@@ -3,12 +3,18 @@ package io.javaoperatorsdk.quarkus.it;
 import io.javaoperatorsdk.operator.api.Context;
 import io.javaoperatorsdk.operator.api.Controller;
 import io.javaoperatorsdk.operator.api.DeleteControl;
-import io.javaoperatorsdk.operator.api.ResourceController;
 import io.javaoperatorsdk.operator.api.UpdateControl;
+import io.javaoperatorsdk.operator.processing.event.EventSourceManager;
 
-@Controller(name = TestController.NAME)
-public class TestController implements ResourceController<TestResource> {
+@Controller(
+    name = TestController.NAME,
+    delayRegistrationUntilEvent = TestController.RegisterEvent.class)
+public class TestController implements RegistrableController<TestResource> {
+  // CDI Event to trigger registration
+  public static class RegisterEvent {}
+
   public static final String NAME = "test";
+  private boolean initialised;
 
   @Override
   public DeleteControl deleteResource(TestResource resource, Context<TestResource> context) {
@@ -19,5 +25,15 @@ public class TestController implements ResourceController<TestResource> {
   public UpdateControl<TestResource> createOrUpdateResource(
       TestResource resource, Context<TestResource> context) {
     return null;
+  }
+
+  @Override
+  public void init(EventSourceManager eventSourceManager) {
+    initialised = true;
+  }
+
+  @Override
+  public boolean isInitialised() {
+    return initialised;
   }
 }

--- a/operator-framework/src/main/java/io/javaoperatorsdk/operator/config/runtime/AnnotationConfiguration.java
+++ b/operator-framework/src/main/java/io/javaoperatorsdk/operator/config/runtime/AnnotationConfiguration.java
@@ -57,4 +57,9 @@ public class AnnotationConfiguration<R extends CustomResource>
   public String getAssociatedControllerClassName() {
     return controller.getClass().getCanonicalName();
   }
+
+  @Override
+  public boolean isRegistrationDelayed() {
+    return annotation.map(annot -> annot.delayRegistrationUntilEvent() != void.class).orElse(false);
+  }
 }


### PR DESCRIPTION
Hey @ppatierno is this something that would work for you?

The idea is that you mark which resource controller you want delayed:

```java
@Controller(
    name = TestController.NAME,
    delayRegistrationUntilEvent = TestController.RegisterEvent.class)
public class TestController implements RegistrableController<TestResource> {
  // CDI Event to trigger registration
  public static class RegisterEvent {}
…
}
```

And then it will not be registered on the `Operator` until someone fires this CDI event:

```
  @Inject Event<TestController.RegisterEvent> event;

  @POST
  @Path("register")
  public void registerController() {
    event.fire(new TestController.RegisterEvent());
  }
```

Let me know if that works for you?