### PR TITLE
feat: Controllers can now watch only the namespace they're deployed in

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Operator.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Operator.java
@@ -58,7 +58,7 @@ public class Operator {
    * Registers the specified controller with this operator.
    *
    * @param controller the controller to register
-   * @param <R> the {@code CustomResource} type associated with the controller
+   * @param <R>        the {@code CustomResource} type associated with the controller
    * @throws OperatorException if a problem occurred during the registration process
    */
   public <R extends CustomResource> void register(ResourceController<R> controller)
@@ -68,14 +68,13 @@ public class Operator {
 
   /**
    * Registers the specified controller with this operator, overriding its default configuration by
-   * the specified one (usually created via {@link
-   * io.javaoperatorsdk.operator.api.config.ControllerConfigurationOverrider#override(ControllerConfiguration)},
+   * the specified one (usually created via {@link io.javaoperatorsdk.operator.api.config.ControllerConfigurationOverrider#override(ControllerConfiguration)},
    * passing it the controller's original configuration.
    *
-   * @param controller the controller to register
+   * @param controller    the controller to register
    * @param configuration the configuration with which we want to register the controller, if {@code
-   *     null}, the controller's original configuration is used
-   * @param <R> the {@code CustomResource} type associated with the controller
+   *                      null}, the controller's original configuration is used
+   * @param <R>           the {@code CustomResource} type associated with the controller
    * @throws OperatorException if a problem occurred during the registration process
    */
   public <R extends CustomResource> void register(
@@ -95,7 +94,15 @@ public class Operator {
       }
 
       final var retry = GenericRetry.fromConfiguration(configuration.getRetryConfiguration());
-      final var targetNamespaces = configuration.getNamespaces().toArray(new String[] {});
+
+      // check if we only want to watch the current namespace
+      var targetNamespaces = configuration.getNamespaces().toArray(new String[]{});
+      if (configuration.watchCurrentNamespace()) {
+        targetNamespaces = new String[]{
+            configurationService.getClientConfiguration().getNamespace()
+        };
+      }
+
       Class<R> resClass = configuration.getCustomResourceClass();
       String finalizer = configuration.getFinalizer();
 
@@ -164,7 +171,7 @@ public class Operator {
     CustomResourceEventSource customResourceEventSource =
         watchAllNamespaces
             ? CustomResourceEventSource.customResourceEventSourceForAllNamespaces(
-                customResourceCache, client, generationAware, finalizer)
+            customResourceCache, client, generationAware, finalizer)
             : CustomResourceEventSource.customResourceEventSourceForTargetNamespaces(
                 customResourceCache, client, targetNamespaces, generationAware, finalizer);
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Operator.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Operator.java
@@ -58,7 +58,7 @@ public class Operator {
    * Registers the specified controller with this operator.
    *
    * @param controller the controller to register
-   * @param <R>        the {@code CustomResource} type associated with the controller
+   * @param <R> the {@code CustomResource} type associated with the controller
    * @throws OperatorException if a problem occurred during the registration process
    */
   public <R extends CustomResource> void register(ResourceController<R> controller)
@@ -68,13 +68,14 @@ public class Operator {
 
   /**
    * Registers the specified controller with this operator, overriding its default configuration by
-   * the specified one (usually created via {@link io.javaoperatorsdk.operator.api.config.ControllerConfigurationOverrider#override(ControllerConfiguration)},
+   * the specified one (usually created via {@link
+   * io.javaoperatorsdk.operator.api.config.ControllerConfigurationOverrider#override(ControllerConfiguration)},
    * passing it the controller's original configuration.
    *
-   * @param controller    the controller to register
+   * @param controller the controller to register
    * @param configuration the configuration with which we want to register the controller, if {@code
-   *                      null}, the controller's original configuration is used
-   * @param <R>           the {@code CustomResource} type associated with the controller
+   *     null}, the controller's original configuration is used
+   * @param <R> the {@code CustomResource} type associated with the controller
    * @throws OperatorException if a problem occurred during the registration process
    */
   public <R extends CustomResource> void register(
@@ -96,11 +97,10 @@ public class Operator {
       final var retry = GenericRetry.fromConfiguration(configuration.getRetryConfiguration());
 
       // check if we only want to watch the current namespace
-      var targetNamespaces = configuration.getNamespaces().toArray(new String[]{});
+      var targetNamespaces = configuration.getNamespaces().toArray(new String[] {});
       if (configuration.watchCurrentNamespace()) {
-        targetNamespaces = new String[]{
-            configurationService.getClientConfiguration().getNamespace()
-        };
+        targetNamespaces =
+            new String[] {configurationService.getClientConfiguration().getNamespace()};
       }
 
       Class<R> resClass = configuration.getCustomResourceClass();
@@ -171,7 +171,7 @@ public class Operator {
     CustomResourceEventSource customResourceEventSource =
         watchAllNamespaces
             ? CustomResourceEventSource.customResourceEventSourceForAllNamespaces(
-            customResourceCache, client, generationAware, finalizer)
+                customResourceCache, client, generationAware, finalizer)
             : CustomResourceEventSource.customResourceEventSourceForTargetNamespaces(
                 customResourceCache, client, targetNamespaces, generationAware, finalizer);
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/Controller.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/Controller.java
@@ -10,6 +10,7 @@ import java.lang.annotation.Target;
 public @interface Controller {
 
   String NULL = "";
+  String WATCH_CURRENT_NAMESPACE = "JOSDK_WATCH_CURRENT";
 
   String name() default NULL;
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ControllerConfiguration.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ControllerConfiguration.java
@@ -1,11 +1,11 @@
 package io.javaoperatorsdk.operator.api.config;
 
 import io.fabric8.kubernetes.client.CustomResource;
+import io.javaoperatorsdk.operator.api.Controller;
 import java.util.Collections;
 import java.util.Set;
 
 public interface ControllerConfiguration<R extends CustomResource> {
-  String WATCH_CURRENT_NAMESPACE = "JOSDK_WATCH_CURRENT";
 
   String getName();
 
@@ -29,7 +29,7 @@ public interface ControllerConfiguration<R extends CustomResource> {
 
   default boolean watchCurrentNamespace() {
     final var namespaces = getNamespaces();
-    return namespaces.size() == 1 && namespaces.contains(WATCH_CURRENT_NAMESPACE);
+    return namespaces.size() == 1 && namespaces.contains(Controller.WATCH_CURRENT_NAMESPACE);
   }
 
   default RetryConfiguration getRetryConfiguration() {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ControllerConfiguration.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ControllerConfiguration.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 public interface ControllerConfiguration<R extends CustomResource> {
   String WATCH_CURRENT_NAMESPACE = "JOSDK_WATCH_CURRENT";
+
   String getName();
 
   String getCRDName();

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ControllerConfiguration.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ControllerConfiguration.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.Set;
 
 public interface ControllerConfiguration<R extends CustomResource> {
+  String WATCH_CURRENT_NAMESPACE = "JOSDK_WATCH_CURRENT";
   String getName();
 
   String getCRDName();
@@ -23,6 +24,11 @@ public interface ControllerConfiguration<R extends CustomResource> {
 
   default boolean watchAllNamespaces() {
     return getNamespaces().isEmpty();
+  }
+
+  default boolean watchCurrentNamespace() {
+    final var namespaces = getNamespaces();
+    return namespaces.size() == 1 && namespaces.contains(WATCH_CURRENT_NAMESPACE);
   }
 
   default RetryConfiguration getRetryConfiguration() {


### PR DESCRIPTION
This is achieved by using `JOSDK_WATCH_CURRENT` as the only value of the
namespaces configuration for the controller.

Fixes #372