### PR TITLE
Make CustomResource implementations validation configurable for Spring Boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,8 @@ common mistakes. Advanced users or production deployments might want to skip thi
 by setting 
 the `CHECK_CRD_ENV_KEY` environment variable to `false`. Quarkus users can also add 
 `quarkus.operator-sdk.check-crd-and-validate-local-model=false` to their `application.properties` for the 
-same purpose.
+same purpose. Spring Boot users can set the property `javaoperatorsdk.check-crd-and-validate-local-model` 
+to `false`.
 
 #### Automatic generation of CRDs
 

--- a/operator-framework-spring-boot-starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/OperatorAutoConfiguration.java
+++ b/operator-framework-spring-boot-starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/OperatorAutoConfiguration.java
@@ -51,6 +51,11 @@ public class OperatorAutoConfiguration extends AbstractConfigurationService {
     return config.build();
   }
 
+  @Override
+  public boolean checkCRDAndValidateLocalModel() {
+    return configuration.getCheckCrdAndValidateLocalModel();
+  }
+
   @Bean
   @ConditionalOnMissingBean(Operator.class)
   public Operator operator(

--- a/operator-framework-spring-boot-starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/OperatorConfigurationProperties.java
+++ b/operator-framework-spring-boot-starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/OperatorConfigurationProperties.java
@@ -9,6 +9,7 @@ public class OperatorConfigurationProperties {
 
   private KubernetesClientProperties client = new KubernetesClientProperties();
   private Map<String, ControllerProperties> controllers = Collections.emptyMap();
+  private boolean checkCrdAndValidateLocalModel = true;
 
   public KubernetesClientProperties getClient() {
     return client;
@@ -24,5 +25,13 @@ public class OperatorConfigurationProperties {
 
   public void setControllers(Map<String, ControllerProperties> controllers) {
     this.controllers = controllers;
+  }
+
+  public boolean getCheckCrdAndValidateLocalModel() {
+    return checkCrdAndValidateLocalModel;
+  }
+
+  public void setCheckCrdAndValidateLocalModel(boolean checkCrdAndValidateLocalModel) {
+    this.checkCrdAndValidateLocalModel = checkCrdAndValidateLocalModel;
   }
 }


### PR DESCRIPTION
Add the property `javaoperatorsdk.check-crd-and-validate-local-model` to control whether CustomResource implementations are validated.

Addressing https://github.com/java-operator-sdk/java-operator-sdk/issues/380