### PR TITLE
Hide CustomResourceFacade, make EventDispatcher & ExecutionScope parameterized

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Operator.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Operator.java
@@ -137,9 +137,7 @@ public class Operator {
       }
 
       final var client = k8sClient.customResources(resClass);
-      EventDispatcher dispatcher =
-          new EventDispatcher(
-              controller, finalizer, new EventDispatcher.CustomResourceFacade(client));
+      EventDispatcher dispatcher = new EventDispatcher(controller, finalizer, client);
 
       CustomResourceCache customResourceCache = new CustomResourceCache(objectMapper);
       DefaultEventHandler defaultEventHandler =

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Operator.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Operator.java
@@ -137,7 +137,7 @@ public class Operator {
       }
 
       final var client = k8sClient.customResources(resClass);
-      EventDispatcher dispatcher = new EventDispatcher(controller, finalizer, client);
+      EventDispatcher<R> dispatcher = new EventDispatcher<>(controller, finalizer, client);
 
       CustomResourceCache customResourceCache = new CustomResourceCache(objectMapper);
       DefaultEventHandler defaultEventHandler =

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/EventDispatcher.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/EventDispatcher.java
@@ -30,11 +30,15 @@ public class EventDispatcher {
   private final CustomResourceFacade customResourceFacade;
   private EventSourceManager eventSourceManager;
 
-  public EventDispatcher(
+  EventDispatcher(
       ResourceController controller, String finalizer, CustomResourceFacade customResourceFacade) {
     this.controller = controller;
     this.customResourceFacade = customResourceFacade;
     this.resourceFinalizer = finalizer;
+  }
+
+  public EventDispatcher(ResourceController controller, String finalizer, MixedOperation client) {
+    this(controller, finalizer, new CustomResourceFacade(client));
   }
 
   public void setEventSourceManager(EventSourceManager eventSourceManager) {
@@ -174,7 +178,7 @@ public class EventDispatcher {
   }
 
   // created to support unit testing
-  public static class CustomResourceFacade<R extends CustomResource> {
+  static class CustomResourceFacade<R extends CustomResource> {
 
     private final MixedOperation<R, KubernetesResourceList<R>, Resource<R>> resourceOperation;
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/ExecutionScope.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/ExecutionScope.java
@@ -5,14 +5,14 @@ import io.javaoperatorsdk.operator.api.RetryInfo;
 import io.javaoperatorsdk.operator.processing.event.Event;
 import java.util.List;
 
-public class ExecutionScope {
+public class ExecutionScope<R extends CustomResource> {
 
-  private List<Event> events;
+  private final List<Event> events;
   // the latest custom resource from cache
-  private CustomResource customResource;
-  private RetryInfo retryInfo;
+  private final R customResource;
+  private final RetryInfo retryInfo;
 
-  public ExecutionScope(List<Event> list, CustomResource customResource, RetryInfo retryInfo) {
+  public ExecutionScope(List<Event> list, R customResource, RetryInfo retryInfo) {
     this.events = list;
     this.customResource = customResource;
     this.retryInfo = retryInfo;
@@ -22,7 +22,7 @@ public class ExecutionScope {
     return events;
   }
 
-  public CustomResource getCustomResource() {
+  public R getCustomResource() {
     return customResource;
   }
 

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/EventDispatcherTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/EventDispatcherTest.java
@@ -1,4 +1,4 @@
-package io.javaoperatorsdk.operator;
+package io.javaoperatorsdk.operator.processing;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.Watcher;
+import io.javaoperatorsdk.operator.TestUtils;
 import io.javaoperatorsdk.operator.api.Context;
 import io.javaoperatorsdk.operator.api.DeleteControl;
 import io.javaoperatorsdk.operator.api.ResourceController;

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/EventDispatcherTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/EventDispatcherTest.java
@@ -19,8 +19,6 @@ import io.javaoperatorsdk.operator.api.DeleteControl;
 import io.javaoperatorsdk.operator.api.ResourceController;
 import io.javaoperatorsdk.operator.api.RetryInfo;
 import io.javaoperatorsdk.operator.api.UpdateControl;
-import io.javaoperatorsdk.operator.processing.EventDispatcher;
-import io.javaoperatorsdk.operator.processing.ExecutionScope;
 import io.javaoperatorsdk.operator.processing.event.Event;
 import io.javaoperatorsdk.operator.processing.event.internal.CustomResourceEvent;
 import java.util.ArrayList;


### PR DESCRIPTION
It turns out that completely removing `CustomResourceFacade` is more work than is worth. This PR thus limits its exposure by making it only accessible from the defining package so that it can still be used to control tests but doesn't unnecessarily "pollute" the rest of the code.

Also took the opportunity to make `EventDispatcher` and `ExecutionScope` parameterized so that it's clearer that they work with a single type of resource.

Fixes #389.