### PR TITLE
fix: if a watch closes and fails to reconnect, exit the operator

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/internal/CustomResourceEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/internal/CustomResourceEventSource.java
@@ -154,7 +154,12 @@ public class CustomResourceEventSource extends AbstractEventSource
     }
     if (e.isHttpGone()) {
       log.warn("Received error for watch, will try to reconnect.", e);
-      registerWatch();
+      try {
+        registerWatch();
+      } catch (Throwable ex) {
+        log.error("Unexpected error happened with watch reconnect. Will exit.", e);
+        System.exit(1);
+      }
     } else {
       // Note that this should not happen normally, since fabric8 client handles reconnect.
       // In case it tries to reconnect this method is not called.


### PR DESCRIPTION
This is one of my proposed fixes for https://github.com/java-operator-sdk/java-operator-sdk/issues/395