### PR TITLE
Enhance event handling

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/DefaultEventHandler.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/DefaultEventHandler.java
@@ -37,6 +37,7 @@ public class DefaultEventHandler implements EventHandler {
   private final EventDispatcher eventDispatcher;
   private final Retry retry;
   private final Map<String, RetryExecution> retryState = new HashMap<>();
+  private final String controllerName;
   private DefaultEventSourceManager eventSourceManager;
 
   private final ReentrantLock lock = new ReentrantLock();
@@ -50,6 +51,7 @@ public class DefaultEventHandler implements EventHandler {
     this.customResourceCache = customResourceCache;
     this.eventDispatcher = eventDispatcher;
     this.retry = retry;
+    this.controllerName = relatedControllerName;
     eventBuffer = new EventBuffer();
     executor =
         new ScheduledThreadPoolExecutor(
@@ -68,6 +70,16 @@ public class DefaultEventHandler implements EventHandler {
         relatedControllerName,
         retry,
         ConfigurationService.DEFAULT_RECONCILIATION_THREADS_NUMBER);
+  }
+
+  @Override
+  public void close() {
+    if (eventSourceManager != null) {
+      log.debug("Closing EventSourceManager {} -> {}", controllerName, eventSourceManager);
+      eventSourceManager.close();
+    }
+
+    executor.shutdownNow();
   }
 
   public void setEventSourceManager(DefaultEventSourceManager eventSourceManager) {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/DefaultEventSourceManager.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/DefaultEventSourceManager.java
@@ -18,9 +18,8 @@ public class DefaultEventSourceManager implements EventSourceManager {
   private static final Logger log = LoggerFactory.getLogger(DefaultEventSourceManager.class);
 
   private final ReentrantLock lock = new ReentrantLock();
-  private Map<String, EventSource> eventSources = new ConcurrentHashMap<>();
-  private CustomResourceEventSource customResourceEventSource;
-  private DefaultEventHandler defaultEventHandler;
+  private final Map<String, EventSource> eventSources = new ConcurrentHashMap<>();
+  private final DefaultEventHandler defaultEventHandler;
   private TimerEventSource retryTimerEventSource;
 
   public DefaultEventSourceManager(DefaultEventHandler defaultEventHandler, boolean supportRetry) {
@@ -33,8 +32,7 @@ public class DefaultEventSourceManager implements EventSourceManager {
 
   public void registerCustomResourceEventSource(
       CustomResourceEventSource customResourceEventSource) {
-    this.customResourceEventSource = customResourceEventSource;
-    this.customResourceEventSource.addedToEventManager();
+    customResourceEventSource.addedToEventManager();
   }
 
   @Override

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/DefaultEventSourceManager.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/DefaultEventSourceManager.java
@@ -36,7 +36,7 @@ public class DefaultEventSourceManager implements EventSourceManager {
   }
 
   @Override
-  public void registerEventSource(String name, EventSource eventSource) {
+  public final void registerEventSource(String name, EventSource eventSource) {
     Objects.requireNonNull(eventSource, "EventSource must not be null");
 
     try {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/DefaultEventSourceManager.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/DefaultEventSourceManager.java
@@ -41,8 +41,7 @@ public class DefaultEventSourceManager implements EventSourceManager {
 
     try {
       lock.lock();
-      EventSource currentEventSource = eventSources.get(name);
-      if (currentEventSource != null) {
+      if (eventSources.containsKey(name)) {
         throw new IllegalStateException(
             "Event source with name already registered. Event source name: " + name);
       }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventHandler.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventHandler.java
@@ -1,6 +1,11 @@
 package io.javaoperatorsdk.operator.processing.event;
 
-public interface EventHandler {
+import java.io.Closeable;
+
+public interface EventHandler extends Closeable {
 
   void handleEvent(Event event);
+
+  @Override
+  default void close() {}
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventSource.java
@@ -1,6 +1,19 @@
 package io.javaoperatorsdk.operator.processing.event;
 
-public interface EventSource {
+public interface EventSource extends AutoCloseable {
+
+  /**
+   * This method is invoked when this {@link EventSource} instance is properly registered to a
+   * {@link EventSourceManager}.
+   */
+  default void start() {}
+
+  /**
+   * This method is invoked when this {@link EventSource} instance is de-registered from a {@link
+   * EventSourceManager}.
+   */
+  @Override
+  default void close() {}
 
   void setEventHandler(EventHandler eventHandler);
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventSource.java
@@ -1,6 +1,8 @@
 package io.javaoperatorsdk.operator.processing.event;
 
-public interface EventSource extends AutoCloseable {
+import java.io.Closeable;
+
+public interface EventSource extends Closeable {
 
   /**
    * This method is invoked when this {@link EventSource} instance is properly registered to a

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventSourceManager.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventSourceManager.java
@@ -5,7 +5,25 @@ import java.util.Optional;
 
 public interface EventSourceManager {
 
-  <T extends EventSource> void registerEventSource(String name, T eventSource);
+  /**
+   * Add the {@link EventSource} identified by the given <code>name</code> to the event manager.
+   *
+   * @param name the name of the {@link EventSource} to add
+   * @param eventSource the {@link EventSource} to register
+   * @thorw IllegalStateException if an {@link EventSource} with the same name is already
+   *     registered.
+   */
+  void registerEventSource(String name, EventSource eventSource);
+
+  /**
+   * Remove the {@link EventSource} identified by the given <code>name</code> from the event
+   * manager.
+   *
+   * @param name the name of the {@link EventSource} to remove
+   * @return an optional {@link EventSource} which would be empty if no {@link EventSource} have
+   *     been registered with the given name.
+   */
+  Optional<EventSource> deRegisterEventSource(String name);
 
   Optional<EventSource> deRegisterCustomResourceFromEventSource(
       String name, String customResourceUid);

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventSourceManager.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventSourceManager.java
@@ -1,9 +1,10 @@
 package io.javaoperatorsdk.operator.processing.event;
 
+import java.io.Closeable;
 import java.util.Map;
 import java.util.Optional;
 
-public interface EventSourceManager {
+public interface EventSourceManager extends Closeable {
 
   /**
    * Add the {@link EventSource} identified by the given <code>name</code> to the event manager.
@@ -29,4 +30,7 @@ public interface EventSourceManager {
       String name, String customResourceUid);
 
   Map<String, EventSource> getRegisteredEventSources();
+
+  @Override
+  default void close() {}
 }

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/internal/CustomResourceEventSourceTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/internal/CustomResourceEventSourceTest.java
@@ -25,7 +25,7 @@ class CustomResourceEventSourceTest {
 
   private CustomResourceEventSource customResourceEventSource =
       CustomResourceEventSource.customResourceEventSourceForAllNamespaces(
-          customResourceCache, mixedOperation, true, FINALIZER);
+          customResourceCache, mixedOperation, true, FINALIZER, TestCustomResource.class);
 
   @BeforeEach
   public void setup() {
@@ -73,7 +73,7 @@ class CustomResourceEventSourceTest {
   public void handlesAllEventIfNotGenerationAware() {
     customResourceEventSource =
         CustomResourceEventSource.customResourceEventSourceForAllNamespaces(
-            customResourceCache, mixedOperation, false, FINALIZER);
+            customResourceCache, mixedOperation, false, FINALIZER, TestCustomResource.class);
     setup();
 
     TestCustomResource customResource1 = TestUtils.testCustomResource();


### PR DESCRIPTION
This PR includes:
- add lifecycle hooks to EventSource (#368)
- review DefaultEventSourceManager instance variable modifiers
- make DefaultEventSourceManager::registerEventSource final as it is invoked by the constructor
- DefaultEventSourceManager use containsKey instead of null check to determine if an event source is already registerd
- add lifecycle hooks to the operator so i.e. watchers can be properly closed

Fixes #368

