### PR TITLE
A fix for NPE when operator-framework-core is loaded dynamically.

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/Utils.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/Utils.java
@@ -21,8 +21,7 @@ public class Utils {
    * @return a {@link Version} object encapsulating the version information
    */
   public static Version loadFromProperties() {
-    final var is =
-        Thread.currentThread().getContextClassLoader().getResourceAsStream("version.properties");
+    final var is = Utils.class.getClassLoader().getResourceAsStream("version.properties");
 
     final var properties = new Properties();
     if (is != null) {

--- a/operator-framework/src/main/java/io/javaoperatorsdk/operator/config/runtime/ClassMappingProvider.java
+++ b/operator-framework/src/main/java/io/javaoperatorsdk/operator/config/runtime/ClassMappingProvider.java
@@ -21,7 +21,7 @@ class ClassMappingProvider {
   static <T, V> Map<T, V> provide(final String resourcePath, T key, V value) {
     Map<T, V> result = new HashMap();
     try {
-      final var classLoader = Thread.currentThread().getContextClassLoader();
+      final var classLoader = ClassMappingProvider.class.getClassLoader();
       final Enumeration<URL> customResourcesMetadataList = classLoader.getResources(resourcePath);
       for (Iterator<URL> it = customResourcesMetadataList.asIterator(); it.hasNext(); ) {
         URL url = it.next();
@@ -39,7 +39,8 @@ class ClassMappingProvider {
                 }
 
                 result.put(
-                    (T) ClassUtils.getClass(classNames[0]), (V) ClassUtils.getClass(classNames[1]));
+                    (T) ClassUtils.getClass(classLoader, classNames[0]),
+                    (V) ClassUtils.getClass(classLoader, classNames[1]));
               } catch (ClassNotFoundException e) {
                 throw new RuntimeException(e);
               }


### PR DESCRIPTION
I'm implementing k8s operator controller within a Keycloak plugin which is being loaded dynamically, and I'm getting NPE whenever I call "DefaultConfigurationService.instance()".
I assume because of this dynamic loading (and whatever thread model Keycloak is employing) the contextClassLoader is not able to find "version.properties" file, that eventually leads to NPE.

According to StackOverflow, using getContextClassLoader() is not reliable and is discouraged from using:
https://stackoverflow.com/questions/1771679/difference-between-threads-context-class-loader-and-normal-classloader

And a proper way to get a class loader in the static method, is to use an explicit reference to the class itself:
https://stackoverflow.com/questions/8275499/how-to-call-getclass-from-a-static-method-in-java