### PR TITLE
Add analytics to website.

### DIFF
--- a/docs/_includes/analytics.html
+++ b/docs/_includes/analytics.html
@@ -1,0 +1,9 @@
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-TCB1LERV5K"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-TCB1LERV5K');
+</script>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -5,6 +5,7 @@
   <meta content="width=device-width, initial-scale=1" name="viewport"/>
   <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title | escape }}{% endif %}</title>
   {% include links.html %}
+  {% include analytics.html %}
 </head>
 <body class="page">
   {% include header.html %}

--- a/docs/_layouts/homepage.html
+++ b/docs/_layouts/homepage.html
@@ -5,6 +5,7 @@
   <meta content="width=device-width, initial-scale=1" name="viewport"/>
   <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title | escape }}{% endif %}</title>
   {% include links.html %}
+  {% include analytics.html %}
 </head>
 <body class="page">
   {% include header.html %}


### PR DESCRIPTION
This PR adds Google Analytics to the website. I think it would be useful to get an idea of how many people are visiting the site. The analytics currently goes to Container Solutions.

This is just a proposal currently, please let me know if there are any concerns or issues.

I've not used the website generator before, so I may have made a mistake in there.