### PR TITLE
Change stream implementation to List.contains()

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/CustomResourceUtils.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/CustomResourceUtils.java
@@ -15,11 +15,7 @@ public abstract class CustomResourceUtils {
    * @throws OperatorException when the Custom Resource has validation error
    */
   public static void assertCustomResource(Class<?> resClass, CustomResourceDefinition crd) {
-    var namespaced =
-        Arrays.stream(resClass.getInterfaces())
-            .filter(classInterface -> classInterface.equals(Namespaced.class))
-            .findAny()
-            .isPresent();
+    var namespaced = Arrays.asList(resClass.getInterfaces()).contains(Namespaced.class);
 
     if (!namespaced && Namespaced.class.getSimpleName().equals(crd.getSpec().getScope())) {
       throw new OperatorException(


### PR DESCRIPTION
This stream filtering implementation is basically the same as using List.contains(), and any performance differences might be negligible since we are just seeing if dependent classes are namespaced (there shouldn't be _that_ many of them).