### PR TITLE
fix: improve missing CRD detection

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Operator.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Operator.java
@@ -114,24 +114,15 @@ public class Operator implements AutoCloseable {
 
       Class<R> resClass = configuration.getCustomResourceClass();
       final String controllerName = configuration.getName();
+      final var crdName = configuration.getCRDName();
+      final var specVersion = "v1";
 
       // check that the custom resource is known by the cluster if configured that way
       final CustomResourceDefinition crd; // todo: check proper CRD spec version based on config
       if (configurationService.checkCRDAndValidateLocalModel()) {
-        final var crdName = configuration.getCRDName();
-        final var specVersion = "v1";
         crd = k8sClient.apiextensions().v1().customResourceDefinitions().withName(crdName).get();
         if (crd == null) {
-          throw new MissingCRDException(
-              crdName,
-              specVersion,
-              "'"
-                  + crdName
-                  + "' "
-                  + specVersion
-                  + " CRD was not found on the cluster, controller '"
-                  + controllerName
-                  + "' cannot be registered");
+          throwMissingCRDException(crdName, specVersion, controllerName);
         }
 
         // Apply validations that are not handled by fabric8
@@ -139,10 +130,14 @@ public class Operator implements AutoCloseable {
       }
 
       final var client = k8sClient.customResources(resClass);
-      DefaultEventSourceManager eventSourceManager =
-          new DefaultEventSourceManager(controller, configuration, client);
-      controller.init(eventSourceManager);
-      closeables.add(eventSourceManager);
+      try {
+        DefaultEventSourceManager eventSourceManager =
+            new DefaultEventSourceManager(controller, configuration, client);
+        controller.init(eventSourceManager);
+        closeables.add(eventSourceManager);
+      } catch (MissingCRDException e) {
+        throwMissingCRDException(crdName, specVersion, controllerName);
+      }
 
       if (failOnMissingCurrentNS(configuration)) {
         throw new OperatorException(
@@ -161,6 +156,19 @@ public class Operator implements AutoCloseable {
           resClass,
           watchedNS);
     }
+  }
+
+  private void throwMissingCRDException(String crdName, String specVersion, String controllerName) {
+    throw new MissingCRDException(
+        crdName,
+        specVersion,
+        "'"
+            + crdName
+            + "' "
+            + specVersion
+            + " CRD was not found on the cluster, controller '"
+            + controllerName
+            + "' cannot be registered");
   }
 
   /**

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/DefaultEventSourceManager.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/DefaultEventSourceManager.java
@@ -2,8 +2,10 @@ package io.javaoperatorsdk.operator.processing.event;
 
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.javaoperatorsdk.operator.MissingCRDException;
 import io.javaoperatorsdk.operator.OperatorException;
 import io.javaoperatorsdk.operator.api.ResourceController;
 import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
@@ -89,6 +91,12 @@ public class DefaultEventSourceManager implements EventSourceManager {
       if (e instanceof IllegalStateException) {
         // leave untouched
         throw e;
+      }
+      if (e instanceof KubernetesClientException) {
+        KubernetesClientException ke = (KubernetesClientException) e;
+        if (404 == ke.getCode()) {
+          throw new MissingCRDException(null, null);
+        }
       }
       throw new OperatorException("Couldn't register event source named '" + name + "'", e);
     } finally {


### PR DESCRIPTION
If starting the event source throws a 404 error, this means that there
is no API endpoint to handle the resource on the server. This is
indicative of the associated CRD not being deployed yet. We therefore
need to handle this case to throw a MissingCRDException. Since we don't
have the needed CRD information at the point of the exception, we let
the exception trickle up and provide the information (crd name and
version) where we know about it.

Fixes #460