### PR TITLE
chore(ci): update Java distribution to use temurin instead of adopt

### DIFF
--- a/.github/workflows/master-snapshot-release.yml
+++ b/.github/workflows/master-snapshot-release.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         java: [11, 16]
-        distribution: [adopt, adopt-openj9]
+        distribution: [temurin, adopt-openj9]
         kubernetes: ['v1.17.13','v1.18.20','v1.19.14','v1.20.10','v1.21.4']
     steps:
       - uses: actions/checkout@v2
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Java and Maven
         uses: actions/setup-java@v2.3.0
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
       - name: Release Maven package
         uses: samuelmeuli/action-maven-publish@v1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         java: [11, 16]
-        distribution: [ adopt, adopt-openj9 ]
+        distribution: [ temurin, adopt-openj9 ]
         kubernetes: ['v1.17.13','v1.18.20','v1.19.14','v1.20.10','v1.21.4']
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/setup-java@v2.3.0
         with:
           java-version: 11
-          distribution: adopt
+          distribution: temurin
       - name: change version to release version
         # Assume that RELEASE_VERSION will have form like: "v1.0.1". So we cut the "v"
         run: ./mvnw ${MAVEN_ARGS} versions:set -DnewVersion="${RELEASE_VERSION:1}" versions:commit
@@ -37,7 +37,7 @@ jobs:
         uses: actions/setup-java@v2.3.0
         with:
           java-version: 11
-          distribution: adopt
+          distribution: temurin
       - name: change version to release version
         run: |
           ./mvnw ${MAVEN_ARGS} versions:set -DnewVersion="${RELEASE_VERSION:1}" versions:commit


### PR DESCRIPTION
Temurin is the new home of what was previously known as AdoptJDK and is
where things will be updated moving forward.