### PR TITLE
Introduce `ConfiguredController` concept, decouple Metrics code from business logic

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Metrics.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Metrics.java
@@ -1,18 +1,34 @@
 package io.javaoperatorsdk.operator;
 
+import java.util.concurrent.TimeUnit;
+import java.util.function.ToDoubleFunction;
+import java.util.function.ToLongFunction;
+
 import io.fabric8.kubernetes.client.CustomResource;
 import io.javaoperatorsdk.operator.api.Context;
 import io.javaoperatorsdk.operator.api.DeleteControl;
 import io.javaoperatorsdk.operator.api.ResourceController;
 import io.javaoperatorsdk.operator.api.UpdateControl;
 import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
-import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.FunctionTimer;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Measurement;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.distribution.pause.PauseDetector;
-import io.micrometer.core.instrument.noop.*;
-import java.util.concurrent.TimeUnit;
-import java.util.function.ToDoubleFunction;
-import java.util.function.ToLongFunction;
+import io.micrometer.core.instrument.noop.NoopCounter;
+import io.micrometer.core.instrument.noop.NoopDistributionSummary;
+import io.micrometer.core.instrument.noop.NoopFunctionCounter;
+import io.micrometer.core.instrument.noop.NoopFunctionTimer;
+import io.micrometer.core.instrument.noop.NoopGauge;
+import io.micrometer.core.instrument.noop.NoopMeter;
+import io.micrometer.core.instrument.noop.NoopTimer;
 
 public class Metrics {
   public static final Metrics NOOP = new Metrics(new NoopMeterRegistry(Clock.SYSTEM));
@@ -97,7 +113,7 @@ public class Metrics {
     }
   }
 
-  public void timeControllerRetry() {
+  public void incrementControllerRetriesNumber() {
 
     registry
         .counter(
@@ -107,7 +123,7 @@ public class Metrics {
 
   }
 
-  public void timeControllerEvents() {
+  public void incrementProcessedEventsNumber() {
 
     registry
         .counter(

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Operator.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Operator.java
@@ -37,12 +37,12 @@ public class Operator implements AutoCloseable {
     DefaultEventHandler.setEventMonitor(new EventMonitor() {
       @Override
       public void processedEvent(String uid, Event event) {
-        configurationService.getMetrics().timeControllerEvents();
+        configurationService.getMetrics().incrementProcessedEventsNumber();
       }
 
       @Override
       public void failedEvent(String uid, Event event) {
-        configurationService.getMetrics().timeControllerRetry();
+        configurationService.getMetrics().incrementControllerRetriesNumber();
       }
     });
   }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Operator.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Operator.java
@@ -1,6 +1,7 @@
 package io.javaoperatorsdk.operator;
 
 import java.io.IOException;
+import java.net.ConnectException;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.locks.ReentrantLock;
@@ -87,8 +88,14 @@ public class Operator implements AutoCloseable {
           log.info("Server version: {}.{}", k8sVersion.getMajor(), k8sVersion.getMinor());
         }
       } catch (Exception e) {
-        log.error("Error retrieving the server version. Exiting!", e);
-        throw new OperatorException("Error retrieving the server version", e);
+        final String error;
+        if (e.getCause() instanceof ConnectException) {
+          error = "Cannot connect to cluster";
+        } else {
+          error = "Error retrieving the server version";
+        }
+        log.error(error, e);
+        throw new OperatorException(error, e);
       }
 
       controllers.parallelStream().forEach(ConfiguredController::start);

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/AbstractControllerConfiguration.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/AbstractControllerConfiguration.java
@@ -1,10 +1,11 @@
 package io.javaoperatorsdk.operator.api.config;
 
-import io.fabric8.kubernetes.client.CustomResource;
 import java.util.Collections;
 import java.util.Set;
 
-public abstract class AbstractControllerConfiguration<R extends CustomResource>
+import io.fabric8.kubernetes.client.CustomResource;
+
+public abstract class AbstractControllerConfiguration<R extends CustomResource<?, ?>>
     implements ControllerConfiguration<R> {
 
   private final String associatedControllerClassName;

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ControllerConfigurationOverrider.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ControllerConfigurationOverrider.java
@@ -74,17 +74,9 @@ public class ControllerConfigurationOverrider<R extends CustomResource<?, ?>> {
         generationAware,
         namespaces,
         retry,
-        labelSelector) {
-      @Override
-      public Class<R> getCustomResourceClass() {
-        return original.getCustomResourceClass();
-      }
-
-      @Override
-      public ConfigurationService getConfigurationService() {
-        return original.getConfigurationService();
-      }
-    };
+        labelSelector,
+        original.getCustomResourceClass(),
+        original.getConfigurationService());
   }
 
   public static <R extends CustomResource<?, ?>> ControllerConfigurationOverrider<R> override(

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ControllerConfigurationOverrider.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ControllerConfigurationOverrider.java
@@ -1,15 +1,16 @@
 package io.javaoperatorsdk.operator.api.config;
 
-import io.fabric8.kubernetes.client.CustomResource;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-public class ControllerConfigurationOverrider<R extends CustomResource> {
+import io.fabric8.kubernetes.client.CustomResource;
+
+public class ControllerConfigurationOverrider<R extends CustomResource<?, ?>> {
 
   private String finalizer;
   private boolean generationAware;
-  private Set<String> namespaces;
+  private final Set<String> namespaces;
   private RetryConfiguration retry;
   private String labelSelector;
   private final ControllerConfiguration<R> original;
@@ -65,7 +66,7 @@ public class ControllerConfigurationOverrider<R extends CustomResource> {
   }
 
   public ControllerConfiguration<R> build() {
-    return new AbstractControllerConfiguration<R>(
+    return new AbstractControllerConfiguration<>(
         original.getAssociatedControllerClassName(),
         original.getName(),
         original.getCRDName(),
@@ -86,7 +87,7 @@ public class ControllerConfigurationOverrider<R extends CustomResource> {
     };
   }
 
-  public static <R extends CustomResource> ControllerConfigurationOverrider<R> override(
+  public static <R extends CustomResource<?, ?>> ControllerConfigurationOverrider<R> override(
       ControllerConfiguration<R> original) {
     return new ControllerConfigurationOverrider<>(original);
   }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/Utils.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/Utils.java
@@ -1,11 +1,11 @@
 package io.javaoperatorsdk.operator.api.config;
 
 import java.io.IOException;
-import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.util.Date;
 import java.util.Properties;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,7 +41,8 @@ public class Utils {
           // RFC 822 date is the default format used by git-commit-id-plugin
           new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ")
               .parse(properties.getProperty("git.build.time"));
-    } catch (ParseException e) {
+    } catch (Exception e) {
+      log.debug("Couldn't parse git.build.time property", e);
       builtTime = Date.from(Instant.EPOCH);
     }
     return new Version(

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/ConfiguredController.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/ConfiguredController.java
@@ -113,7 +113,7 @@ public class ConfiguredController<R extends CustomResource<?, ?>> implements Res
     try {
       DefaultEventSourceManager eventSourceManager =
           new DefaultEventSourceManager(
-              controller, configuration, k8sClient.customResources(resClass));
+              controller, configuration, k8sClient.resources(resClass));
       controller.init(eventSourceManager);
     } catch (MissingCRDException e) {
       throwMissingCRDException(crdName, specVersion, controllerName);

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/ConfiguredController.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/ConfiguredController.java
@@ -1,0 +1,164 @@
+package io.javaoperatorsdk.operator.processing;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Objects;
+
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.javaoperatorsdk.operator.CustomResourceUtils;
+import io.javaoperatorsdk.operator.MissingCRDException;
+import io.javaoperatorsdk.operator.OperatorException;
+import io.javaoperatorsdk.operator.api.Context;
+import io.javaoperatorsdk.operator.api.DeleteControl;
+import io.javaoperatorsdk.operator.api.ResourceController;
+import io.javaoperatorsdk.operator.api.UpdateControl;
+import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
+import io.javaoperatorsdk.operator.processing.event.DefaultEventSourceManager;
+import io.javaoperatorsdk.operator.processing.event.EventSourceManager;
+
+public class ConfiguredController<R extends CustomResource<?, ?>> implements ResourceController<R>,
+    Closeable {
+  private final ResourceController<R> controller;
+  private final ControllerConfiguration<R> configuration;
+  private final KubernetesClient k8sClient;
+  private EventSourceManager manager;
+
+  public ConfiguredController(ResourceController<R> controller,
+      ControllerConfiguration<R> configuration,
+      KubernetesClient k8sClient) {
+    this.controller = controller;
+    this.configuration = configuration;
+    this.k8sClient = k8sClient;
+  }
+
+  @Override
+  public DeleteControl deleteResource(R resource, Context<R> context) {
+    return controller.deleteResource(resource, context);
+  }
+
+  @Override
+  public UpdateControl<R> createOrUpdateResource(R resource, Context<R> context) {
+    return controller.createOrUpdateResource(resource, context);
+  }
+
+  @Override
+  public void init(EventSourceManager eventSourceManager) {
+    this.manager = eventSourceManager;
+    controller.init(eventSourceManager);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ConfiguredController<?> that = (ConfiguredController<?>) o;
+    return configuration.getName().equals(that.configuration.getName());
+  }
+
+  @Override
+  public int hashCode() {
+    return configuration.getName().hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return "'" + configuration.getName() + "' Controller";
+  }
+
+  public ResourceController<R> getController() {
+    return controller;
+  }
+
+  public ControllerConfiguration<R> getConfiguration() {
+    return configuration;
+  }
+
+  public KubernetesClient getClient() {
+    return k8sClient;
+  }
+
+  /**
+   * Registers the specified controller with this operator, overriding its default configuration by
+   * the specified one (usually created via
+   * {@link io.javaoperatorsdk.operator.api.config.ControllerConfigurationOverrider#override(ControllerConfiguration)},
+   * passing it the controller's original configuration.
+   *
+   * @throws OperatorException if a problem occurred during the registration process
+   */
+  public void start() throws OperatorException {
+    final Class<R> resClass = configuration.getCustomResourceClass();
+    final String controllerName = configuration.getName();
+    final var crdName = configuration.getCRDName();
+    final var specVersion = "v1";
+
+    // check that the custom resource is known by the cluster if configured that way
+    final CustomResourceDefinition crd; // todo: check proper CRD spec version based on config
+    if (configuration.getConfigurationService().checkCRDAndValidateLocalModel()) {
+      crd = k8sClient.apiextensions().v1().customResourceDefinitions().withName(crdName).get();
+      if (crd == null) {
+        throwMissingCRDException(crdName, specVersion, controllerName);
+      }
+
+      // Apply validations that are not handled by fabric8
+      CustomResourceUtils.assertCustomResource(resClass, crd);
+    }
+
+    try {
+      DefaultEventSourceManager eventSourceManager =
+          new DefaultEventSourceManager(
+              controller, configuration, k8sClient.customResources(resClass));
+      controller.init(eventSourceManager);
+    } catch (MissingCRDException e) {
+      throwMissingCRDException(crdName, specVersion, controllerName);
+    }
+
+    if (failOnMissingCurrentNS()) {
+      throw new OperatorException(
+          "Controller '"
+              + controllerName
+              + "' is configured to watch the current namespace but it couldn't be inferred from the current configuration.");
+    }
+  }
+
+  private void throwMissingCRDException(String crdName, String specVersion, String controllerName) {
+    throw new MissingCRDException(
+        crdName,
+        specVersion,
+        "'"
+            + crdName
+            + "' "
+            + specVersion
+            + " CRD was not found on the cluster, controller '"
+            + controllerName
+            + "' cannot be registered");
+  }
+
+  /**
+   * Determines whether we should fail because the current namespace is request as target namespace
+   * but is missing
+   *
+   * @return {@code true} if the current namespace is requested but is missing, {@code false}
+   *         otherwise
+   */
+  private boolean failOnMissingCurrentNS() {
+    if (configuration.watchCurrentNamespace()) {
+      final var effectiveNamespaces = configuration.getEffectiveNamespaces();
+      return effectiveNamespaces.size() == 1
+          && effectiveNamespaces.stream().allMatch(Objects::isNull);
+    }
+    return false;
+  }
+
+
+  @Override
+  public void close() throws IOException {
+    manager.close();
+  }
+}

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/ConfiguredController.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/ConfiguredController.java
@@ -1,15 +1,15 @@
 package io.javaoperatorsdk.operator.processing;
 
-import io.fabric8.kubernetes.api.model.KubernetesResourceList;
-import io.fabric8.kubernetes.client.dsl.MixedOperation;
-import io.fabric8.kubernetes.client.dsl.Resource;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Objects;
 
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
 import io.javaoperatorsdk.operator.CustomResourceUtils;
 import io.javaoperatorsdk.operator.MissingCRDException;
 import io.javaoperatorsdk.operator.OperatorException;
@@ -118,9 +118,7 @@ public class ConfiguredController<R extends CustomResource<?, ?>> implements Res
     }
 
     try {
-      DefaultEventSourceManager eventSourceManager =
-          new DefaultEventSourceManager(
-              controller, configuration, k8sClient.resources(resClass));
+      DefaultEventSourceManager<R> eventSourceManager = new DefaultEventSourceManager<>(this);
       controller.init(eventSourceManager);
     } catch (MissingCRDException e) {
       throwMissingCRDException(crdName, specVersion, controllerName);

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/ConfiguredController.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/ConfiguredController.java
@@ -221,6 +221,8 @@ public class ConfiguredController<R extends CustomResource<?, ?>> implements Res
 
   @Override
   public void close() throws IOException {
-    manager.close();
+    if (manager != null) {
+      manager.close();
+    }
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/ConfiguredController.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/ConfiguredController.java
@@ -1,5 +1,8 @@
 package io.javaoperatorsdk.operator.processing;
 
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Objects;
@@ -82,6 +85,10 @@ public class ConfiguredController<R extends CustomResource<?, ?>> implements Res
 
   public KubernetesClient getClient() {
     return k8sClient;
+  }
+
+  public MixedOperation<R, KubernetesResourceList<R>, Resource<R>> getCRClient() {
+    return k8sClient.resources(configuration.getCustomResourceClass());
   }
 
   /**

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/DefaultEventHandler.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/DefaultEventHandler.java
@@ -62,16 +62,12 @@ public class DefaultEventHandler<R extends CustomResource<?, ?>> implements Even
         controller.getConfiguration().getConfigurationService().getTerminationTimeoutSeconds());
   }
 
-  DefaultEventHandler(
-      EventDispatcher<R> eventDispatcher,
-      String relatedControllerName,
-      Retry retry,
-      int concurrentReconciliationThreads) {
+  DefaultEventHandler(EventDispatcher<R> dispatcher, String relatedControllerName, Retry retry) {
     this(
-        eventDispatcher,
+        dispatcher,
         relatedControllerName,
         retry,
-        concurrentReconciliationThreads,
+        ConfigurationService.DEFAULT_RECONCILIATION_THREADS_NUMBER,
         ConfigurationService.DEFAULT_TERMINATION_TIMEOUT_SECONDS);
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/EventDispatcher.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/EventDispatcher.java
@@ -219,7 +219,7 @@ class EventDispatcher<R extends CustomResource<?, ?>> {
       return resourceOperation
           .inNamespace(resource.getMetadata().getNamespace())
           .withName(getName(resource))
-          .replaceStatus(resource);
+          .updateStatus(resource);
     }
 
     public R replaceWithLock(R resource) {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/EventDispatcher.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/EventDispatcher.java
@@ -41,7 +41,7 @@ class EventDispatcher<R extends CustomResource<?, ?>> {
     this(controller, new CustomResourceFacade<>(controller.getCRClient()));
   }
 
-  public PostExecutionControl handleExecution(ExecutionScope<R> executionScope) {
+  public PostExecutionControl<R> handleExecution(ExecutionScope<R> executionScope) {
     try {
       return handleDispatch(executionScope);
     } catch (KubernetesClientException e) {
@@ -57,7 +57,7 @@ class EventDispatcher<R extends CustomResource<?, ?>> {
     }
   }
 
-  private PostExecutionControl handleDispatch(ExecutionScope<R> executionScope) {
+  private PostExecutionControl<R> handleDispatch(ExecutionScope<R> executionScope) {
     R resource = executionScope.getCustomResource();
     log.debug("Handling events: {} for resource {}", executionScope.getEvents(), getName(resource));
 
@@ -106,7 +106,7 @@ class EventDispatcher<R extends CustomResource<?, ?>> {
     return configuration().useFinalizer() && !resource.hasFinalizer(configuration().getFinalizer());
   }
 
-  private PostExecutionControl handleCreateOrUpdate(
+  private PostExecutionControl<R> handleCreateOrUpdate(
       ExecutionScope<R> executionScope, R resource, Context<R> context) {
     if (configuration().useFinalizer() && !resource.hasFinalizer(configuration().getFinalizer())) {
       /*
@@ -153,7 +153,7 @@ class EventDispatcher<R extends CustomResource<?, ?>> {
     }
   }
 
-  private PostExecutionControl handleDelete(R resource, Context<R> context) {
+  private PostExecutionControl<R> handleDelete(R resource, Context<R> context) {
     log.debug(
         "Executing delete for resource: {} with version: {}",
         getName(resource),
@@ -213,7 +213,7 @@ class EventDispatcher<R extends CustomResource<?, ?>> {
   }
 
   // created to support unit testing
-  static class CustomResourceFacade<R extends CustomResource> {
+  static class CustomResourceFacade<R extends CustomResource<?, ?>> {
 
     private final MixedOperation<R, KubernetesResourceList<R>, Resource<R>> resourceOperation;
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/EventDispatcher.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/EventDispatcher.java
@@ -227,7 +227,7 @@ class EventDispatcher<R extends CustomResource<?, ?>> {
       return resourceOperation
           .inNamespace(resource.getMetadata().getNamespace())
           .withName(getName(resource))
-          .updateStatus(resource);
+          .replaceStatus(resource);
     }
 
     public R replaceWithLock(R resource) {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/EventDispatcher.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/EventDispatcher.java
@@ -124,11 +124,7 @@ class EventDispatcher<R extends CustomResource<?, ?>> {
           getVersion(resource),
           executionScope);
 
-      UpdateControl<R> updateControl =
-          configuration()
-              .getConfigurationService()
-              .getMetrics()
-              .timeControllerCreateOrUpdate(controller, configuration(), resource, context);
+      UpdateControl<R> updateControl = controller.createOrUpdateResource(resource, context);
       R updatedCustomResource = null;
       if (updateControl.isUpdateCustomResourceAndStatusSubResource()) {
         updatedCustomResource = updateCustomResource(updateControl.getCustomResource());
@@ -159,11 +155,7 @@ class EventDispatcher<R extends CustomResource<?, ?>> {
         getName(resource),
         getVersion(resource));
 
-    DeleteControl deleteControl =
-        configuration()
-            .getConfigurationService()
-            .getMetrics()
-            .timeControllerDelete(controller, configuration(), resource, context);
+    DeleteControl deleteControl = controller.deleteResource(resource, context);
     final var useFinalizer = configuration().useFinalizer();
     if (useFinalizer) {
       if (deleteControl == DeleteControl.DEFAULT_DELETE

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/ExecutionConsumer.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/ExecutionConsumer.java
@@ -1,20 +1,17 @@
 package io.javaoperatorsdk.operator.processing;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.fabric8.kubernetes.client.CustomResource;
 
-class ExecutionConsumer implements Runnable {
+class ExecutionConsumer<R extends CustomResource<?, ?>> implements Runnable {
 
-  private static final Logger log = LoggerFactory.getLogger(ExecutionConsumer.class);
-
-  private final ExecutionScope executionScope;
-  private final EventDispatcher eventDispatcher;
-  private final DefaultEventHandler defaultEventHandler;
+  private final ExecutionScope<R> executionScope;
+  private final EventDispatcher<R> eventDispatcher;
+  private final DefaultEventHandler<R> defaultEventHandler;
 
   ExecutionConsumer(
-      ExecutionScope executionScope,
-      EventDispatcher eventDispatcher,
-      DefaultEventHandler defaultEventHandler) {
+      ExecutionScope<R> executionScope,
+      EventDispatcher<R> eventDispatcher,
+      DefaultEventHandler<R> defaultEventHandler) {
     this.executionScope = executionScope;
     this.eventDispatcher = eventDispatcher;
     this.defaultEventHandler = defaultEventHandler;
@@ -22,7 +19,7 @@ class ExecutionConsumer implements Runnable {
 
   @Override
   public void run() {
-    PostExecutionControl postExecutionControl = eventDispatcher.handleExecution(executionScope);
+    PostExecutionControl<R> postExecutionControl = eventDispatcher.handleExecution(executionScope);
     defaultEventHandler.eventProcessingFinished(executionScope, postExecutionControl);
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/ExecutionScope.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/ExecutionScope.java
@@ -1,11 +1,12 @@
 package io.javaoperatorsdk.operator.processing;
 
+import java.util.List;
+
 import io.fabric8.kubernetes.client.CustomResource;
 import io.javaoperatorsdk.operator.api.RetryInfo;
 import io.javaoperatorsdk.operator.processing.event.Event;
-import java.util.List;
 
-public class ExecutionScope<R extends CustomResource> {
+public class ExecutionScope<R extends CustomResource<?, ?>> {
 
   private final List<Event> events;
   // the latest custom resource from cache

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/PostExecutionControl.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/PostExecutionControl.java
@@ -1,19 +1,20 @@
 package io.javaoperatorsdk.operator.processing;
 
-import io.fabric8.kubernetes.client.CustomResource;
 import java.util.Optional;
 
-public final class PostExecutionControl {
+import io.fabric8.kubernetes.client.CustomResource;
+
+public final class PostExecutionControl<R extends CustomResource<?, ?>> {
 
   private final boolean onlyFinalizerHandled;
 
-  private final CustomResource updatedCustomResource;
+  private final R updatedCustomResource;
 
   private final RuntimeException runtimeException;
 
   private PostExecutionControl(
       boolean onlyFinalizerHandled,
-      CustomResource updatedCustomResource,
+      R updatedCustomResource,
       RuntimeException runtimeException) {
     this.onlyFinalizerHandled = onlyFinalizerHandled;
     this.updatedCustomResource = updatedCustomResource;
@@ -28,8 +29,9 @@ public final class PostExecutionControl {
     return new PostExecutionControl(false, null, null);
   }
 
-  public static PostExecutionControl customResourceUpdated(CustomResource updatedCustomResource) {
-    return new PostExecutionControl(false, updatedCustomResource, null);
+  public static <R extends CustomResource<?, ?>> PostExecutionControl<R> customResourceUpdated(
+      R updatedCustomResource) {
+    return new PostExecutionControl<>(false, updatedCustomResource, null);
   }
 
   public static PostExecutionControl exceptionDuringExecution(RuntimeException exception) {
@@ -40,7 +42,7 @@ public final class PostExecutionControl {
     return onlyFinalizerHandled;
   }
 
-  public Optional<CustomResource> getUpdatedCustomResource() {
+  public Optional<R> getUpdatedCustomResource() {
     return Optional.ofNullable(updatedCustomResource);
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/DefaultEventSourceManager.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/DefaultEventSourceManager.java
@@ -50,6 +50,10 @@ public class DefaultEventSourceManager<R extends CustomResource<?, ?>>
         new CustomResourceEventSource<>(controller));
   }
 
+  public DefaultEventHandler<R> getEventHandler() {
+    return defaultEventHandler;
+  }
+
   @Override
   public void close() {
     try {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/DefaultEventSourceManager.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/DefaultEventSourceManager.java
@@ -1,5 +1,6 @@
 package io.javaoperatorsdk.operator.processing.event;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -110,7 +111,11 @@ public class DefaultEventSourceManager<R extends CustomResource<?, ?>>
       lock.lock();
       EventSource currentEventSource = eventSources.remove(name);
       if (currentEventSource != null) {
-        currentEventSource.close();
+        try {
+          currentEventSource.close();
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
       }
 
       return Optional.ofNullable(currentEventSource);

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/DefaultEventSourceManager.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/DefaultEventSourceManager.java
@@ -46,9 +46,8 @@ public class DefaultEventSourceManager<R extends CustomResource<?, ?>>
 
   public DefaultEventSourceManager(ConfiguredController<R> controller) {
     this(new DefaultEventHandler<>(controller), true);
-    registerEventSource(
-        CUSTOM_RESOURCE_EVENT_SOURCE_NAME,
-        new CustomResourceEventSource<>(controller.getCRClient(), controller.getConfiguration()));
+    registerEventSource(CUSTOM_RESOURCE_EVENT_SOURCE_NAME,
+        new CustomResourceEventSource<>(controller));
   }
 
   @Override

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventHandler.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventHandler.java
@@ -1,11 +1,12 @@
 package io.javaoperatorsdk.operator.processing.event;
 
 import java.io.Closeable;
+import java.io.IOException;
 
 public interface EventHandler extends Closeable {
 
   void handleEvent(Event event);
 
   @Override
-  default void close() {}
+  default void close() throws IOException {}
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventSource.java
@@ -1,6 +1,7 @@
 package io.javaoperatorsdk.operator.processing.event;
 
 import java.io.Closeable;
+import java.io.IOException;
 
 public interface EventSource extends Closeable {
 
@@ -15,7 +16,7 @@ public interface EventSource extends Closeable {
    * {@link EventSourceManager}.
    */
   @Override
-  default void close() {}
+  default void close() throws IOException {}
 
   void setEventHandler(EventHandler eventHandler);
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventSourceManager.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventSourceManager.java
@@ -1,9 +1,11 @@
 package io.javaoperatorsdk.operator.processing.event;
 
-import io.javaoperatorsdk.operator.OperatorException;
 import java.io.Closeable;
+import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
+
+import io.javaoperatorsdk.operator.OperatorException;
 
 public interface EventSourceManager extends Closeable {
 
@@ -35,5 +37,5 @@ public interface EventSourceManager extends Closeable {
   Map<String, EventSource> getRegisteredEventSources();
 
   @Override
-  default void close() {}
+  default void close() throws IOException {}
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/internal/CustomResourceEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/internal/CustomResourceEventSource.java
@@ -4,6 +4,7 @@ import static io.javaoperatorsdk.operator.processing.KubernetesResourceUtils.get
 import static io.javaoperatorsdk.operator.processing.KubernetesResourceUtils.getUID;
 import static io.javaoperatorsdk.operator.processing.KubernetesResourceUtils.getVersion;
 
+import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -68,7 +69,7 @@ public class CustomResourceEventSource<T extends CustomResource<?, ?>> extends A
   }
 
   @Override
-  public void close() {
+  public void close() throws IOException {
     eventHandler.close();
     for (Watch watch : this.watches) {
       try {

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/CustomResourceSelectorTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/CustomResourceSelectorTest.java
@@ -17,9 +17,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-import io.javaoperatorsdk.operator.Metrics;
 import io.javaoperatorsdk.operator.api.config.ConfigurationService;
-import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
 import io.javaoperatorsdk.operator.processing.event.DefaultEvent;
 import io.javaoperatorsdk.operator.processing.event.DefaultEventSourceManager;
 import io.javaoperatorsdk.operator.sample.simple.TestCustomResource;
@@ -34,16 +32,12 @@ class CustomResourceSelectorTest {
   private final DefaultEventSourceManager defaultEventSourceManagerMock =
       mock(DefaultEventSourceManager.class);
 
-  private ControllerConfiguration configuration =
-      mock(ControllerConfiguration.class);
-  private final ConfigurationService configService = mock(ConfigurationService.class);
-
   private final DefaultEventHandler defaultEventHandler =
       new DefaultEventHandler(
           eventDispatcherMock,
           "Test",
           null,
-          ConfigurationService.DEFAULT_RECONCILIATION_THREADS_NUMBER, configuration);
+          ConfigurationService.DEFAULT_RECONCILIATION_THREADS_NUMBER);
 
   @BeforeEach
   public void setup() {
@@ -63,10 +57,6 @@ class CustomResourceSelectorTest {
         })
             .when(defaultEventSourceManagerMock)
             .cleanup(any());
-
-    when(configuration.getName()).thenReturn("DefaultEventHandlerTest");
-    when(configService.getMetrics()).thenReturn(Metrics.NOOP);
-    when(configuration.getConfigurationService()).thenReturn(configService);
   }
 
   @Test

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/CustomResourceSelectorTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/CustomResourceSelectorTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-import io.javaoperatorsdk.operator.api.config.ConfigurationService;
 import io.javaoperatorsdk.operator.processing.event.DefaultEvent;
 import io.javaoperatorsdk.operator.processing.event.DefaultEventSourceManager;
 import io.javaoperatorsdk.operator.sample.simple.TestCustomResource;
@@ -33,11 +32,7 @@ class CustomResourceSelectorTest {
       mock(DefaultEventSourceManager.class);
 
   private final DefaultEventHandler defaultEventHandler =
-      new DefaultEventHandler(
-          eventDispatcherMock,
-          "Test",
-          null,
-          ConfigurationService.DEFAULT_RECONCILIATION_THREADS_NUMBER);
+      new DefaultEventHandler(eventDispatcherMock, "Test", null);
 
   @BeforeEach
   public void setup() {

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/CustomResourceSelectorTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/CustomResourceSelectorTest.java
@@ -10,24 +10,22 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.fabric8.kubernetes.client.Watcher;
+import java.util.Objects;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
 import io.javaoperatorsdk.operator.Metrics;
 import io.javaoperatorsdk.operator.api.config.ConfigurationService;
 import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
 import io.javaoperatorsdk.operator.processing.event.DefaultEvent;
 import io.javaoperatorsdk.operator.processing.event.DefaultEventSourceManager;
-import io.javaoperatorsdk.operator.processing.event.internal.CustomResourceEvent;
-import io.javaoperatorsdk.operator.processing.event.internal.TimerEventSource;
 import io.javaoperatorsdk.operator.sample.simple.TestCustomResource;
-import java.util.Objects;
-import java.util.UUID;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 
 class CustomResourceSelectorTest {
 
-  public static final int FAKE_CONTROLLER_EXECUTION_DURATION = 250;
   public static final int SEPARATE_EXECUTION_TIMEOUT = 450;
 
   private final EventDispatcher eventDispatcherMock = mock(EventDispatcher.class);
@@ -36,7 +34,6 @@ class CustomResourceSelectorTest {
   private final DefaultEventSourceManager defaultEventSourceManagerMock =
       mock(DefaultEventSourceManager.class);
 
-  private TimerEventSource retryTimerEventSourceMock = mock(TimerEventSource.class);
   private ControllerConfiguration configuration =
       mock(ControllerConfiguration.class);
   private final ConfigurationService configService = mock(ConfigurationService.class);
@@ -125,13 +122,4 @@ class CustomResourceSelectorTest {
     }
   }
 
-  private CustomResourceEvent prepareCREvent() {
-    return prepareCREvent(UUID.randomUUID().toString());
-  }
-
-  private CustomResourceEvent prepareCREvent(String uid) {
-    TestCustomResource customResource = testCustomResource(uid);
-    customResourceCache.cacheResource(customResource);
-    return new CustomResourceEvent(Watcher.Action.MODIFIED, customResource, null);
-  }
 }

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/DefaultEventHandlerTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/DefaultEventHandlerTest.java
@@ -13,11 +13,19 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.fabric8.kubernetes.client.CustomResource;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.stubbing.Answer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.fabric8.kubernetes.client.Watcher;
-import io.javaoperatorsdk.operator.Metrics;
 import io.javaoperatorsdk.operator.api.config.ConfigurationService;
-import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
 import io.javaoperatorsdk.operator.processing.event.DefaultEventSourceManager;
 import io.javaoperatorsdk.operator.processing.event.Event;
 import io.javaoperatorsdk.operator.processing.event.internal.CustomResourceEvent;
@@ -25,15 +33,6 @@ import io.javaoperatorsdk.operator.processing.event.internal.TimerEvent;
 import io.javaoperatorsdk.operator.processing.event.internal.TimerEventSource;
 import io.javaoperatorsdk.operator.processing.retry.GenericRetry;
 import io.javaoperatorsdk.operator.sample.simple.TestCustomResource;
-import java.util.Arrays;
-import java.util.List;
-import java.util.UUID;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.stubbing.Answer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 class DefaultEventHandlerTest {
 
@@ -47,25 +46,20 @@ class DefaultEventHandlerTest {
       mock(DefaultEventSourceManager.class);
 
   private TimerEventSource retryTimerEventSourceMock = mock(TimerEventSource.class);
-  private ControllerConfiguration configuration =
-      mock(ControllerConfiguration.class);
-  private final ConfigurationService configService = mock(ConfigurationService.class);
 
   private DefaultEventHandler defaultEventHandler =
       new DefaultEventHandler(
           eventDispatcherMock,
           "Test",
           null,
-          ConfigurationService.DEFAULT_RECONCILIATION_THREADS_NUMBER,
-          configuration);
+          ConfigurationService.DEFAULT_RECONCILIATION_THREADS_NUMBER);
 
   private DefaultEventHandler defaultEventHandlerWithRetry =
       new DefaultEventHandler(
           eventDispatcherMock,
           "Test",
           GenericRetry.defaultLimitedExponentialRetry(),
-          ConfigurationService.DEFAULT_RECONCILIATION_THREADS_NUMBER,
-          configuration);
+          ConfigurationService.DEFAULT_RECONCILIATION_THREADS_NUMBER);
 
   @BeforeEach
   public void setup() {
@@ -73,10 +67,6 @@ class DefaultEventHandlerTest {
         .thenReturn(retryTimerEventSourceMock);
     defaultEventHandler.setEventSourceManager(defaultEventSourceManagerMock);
     defaultEventHandlerWithRetry.setEventSourceManager(defaultEventSourceManagerMock);
-
-    when(configuration.getName()).thenReturn("DefaultEventHandlerTest");
-    when(configService.getMetrics()).thenReturn(Metrics.NOOP);
-    when(configuration.getConfigurationService()).thenReturn(configService);
 
     // todo: remove
     when(defaultEventSourceManagerMock.getCache()).thenReturn(customResourceCache);

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/DefaultEventHandlerTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/DefaultEventHandlerTest.java
@@ -25,7 +25,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.fabric8.kubernetes.client.Watcher;
-import io.javaoperatorsdk.operator.api.config.ConfigurationService;
 import io.javaoperatorsdk.operator.processing.event.DefaultEventSourceManager;
 import io.javaoperatorsdk.operator.processing.event.Event;
 import io.javaoperatorsdk.operator.processing.event.internal.CustomResourceEvent;
@@ -48,18 +47,11 @@ class DefaultEventHandlerTest {
   private TimerEventSource retryTimerEventSourceMock = mock(TimerEventSource.class);
 
   private DefaultEventHandler defaultEventHandler =
-      new DefaultEventHandler(
-          eventDispatcherMock,
-          "Test",
-          null,
-          ConfigurationService.DEFAULT_RECONCILIATION_THREADS_NUMBER);
+      new DefaultEventHandler(eventDispatcherMock, "Test", null);
 
   private DefaultEventHandler defaultEventHandlerWithRetry =
-      new DefaultEventHandler(
-          eventDispatcherMock,
-          "Test",
-          GenericRetry.defaultLimitedExponentialRetry(),
-          ConfigurationService.DEFAULT_RECONCILIATION_THREADS_NUMBER);
+      new DefaultEventHandler(eventDispatcherMock, "Test",
+          GenericRetry.defaultLimitedExponentialRetry());
 
   @BeforeEach
   public void setup() {

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/EventDispatcherTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/EventDispatcherTest.java
@@ -13,6 +13,15 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.Watcher;
 import io.javaoperatorsdk.operator.Metrics;
@@ -26,13 +35,6 @@ import io.javaoperatorsdk.operator.api.config.ConfigurationService;
 import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
 import io.javaoperatorsdk.operator.processing.event.Event;
 import io.javaoperatorsdk.operator.processing.event.internal.CustomResourceEvent;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.ArgumentMatchers;
 
 class EventDispatcherTest {
 
@@ -40,15 +42,17 @@ class EventDispatcherTest {
   private CustomResource testCustomResource;
   private EventDispatcher eventDispatcher;
   private final ResourceController<CustomResource> controller = mock(ResourceController.class);
-  private ControllerConfiguration<CustomResource> configuration =
+  private final ControllerConfiguration<CustomResource> configuration =
       mock(ControllerConfiguration.class);
   private final ConfigurationService configService = mock(ConfigurationService.class);
+  private final ConfiguredController<CustomResource<?, ?>> configuredController =
+      new ConfiguredController(controller, configuration, null);
   private final EventDispatcher.CustomResourceFacade customResourceFacade =
       mock(EventDispatcher.CustomResourceFacade.class);
 
   @BeforeEach
   void setup() {
-    eventDispatcher = new EventDispatcher(controller, configuration, customResourceFacade);
+    eventDispatcher = new EventDispatcher(configuredController, customResourceFacade);
 
     testCustomResource = TestUtils.testCustomResource();
 
@@ -165,7 +169,8 @@ class EventDispatcherTest {
     when(configService.getMetrics()).thenReturn(Metrics.NOOP);
     when(configuration.getConfigurationService()).thenReturn(configService);
     when(configuration.useFinalizer()).thenReturn(false);
-    eventDispatcher = new EventDispatcher(controller, configuration, customResourceFacade);
+    eventDispatcher = new EventDispatcher(new ConfiguredController(controller, configuration, null),
+        customResourceFacade);
   }
 
   @Test

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/DefaultEventSourceManagerTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/DefaultEventSourceManagerTest.java
@@ -8,12 +8,15 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import java.io.IOException;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
 import io.fabric8.kubernetes.client.CustomResource;
 import io.javaoperatorsdk.operator.TestUtils;
 import io.javaoperatorsdk.operator.processing.DefaultEventHandler;
 import io.javaoperatorsdk.operator.processing.KubernetesResourceUtils;
-import java.util.Map;
-import org.junit.jupiter.api.Test;
 
 class DefaultEventSourceManagerTest {
 
@@ -38,7 +41,7 @@ class DefaultEventSourceManagerTest {
   }
 
   @Test
-  public void closeShouldCascadeToEventSources() {
+  public void closeShouldCascadeToEventSources() throws IOException {
     EventSource eventSource = mock(EventSource.class);
     EventSource eventSource2 = mock(EventSource.class);
     defaultEventSourceManager.registerEventSource(CUSTOM_EVENT_SOURCE_NAME, eventSource);

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/internal/CustomResourceEventSourceTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/internal/CustomResourceEventSourceTest.java
@@ -6,11 +6,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
 import java.time.LocalDateTime;
-import java.util.Arrays;
-
 import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -19,6 +17,7 @@ import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.javaoperatorsdk.operator.TestUtils;
+import io.javaoperatorsdk.operator.api.config.AbstractControllerConfiguration;
 import io.javaoperatorsdk.operator.api.config.ConfigurationService;
 import io.javaoperatorsdk.operator.processing.ConfiguredController;
 import io.javaoperatorsdk.operator.processing.event.EventHandler;
@@ -113,30 +112,15 @@ class CustomResourceEventSourceTest {
       return client;
     }
   }
-  private static class TestConfiguration implements
-      ControllerConfiguration<TestCustomResource> {
+  private static class TestConfiguration extends
+      AbstractControllerConfiguration<TestCustomResource> {
 
     final ConfigurationService service = mock(ConfigurationService.class);
-    final boolean generationAware;
 
     public TestConfiguration(boolean generationAware) {
+      super(null, null, null, FINALIZER, generationAware, null, null, null);
       when(service.getObjectMapper()).thenReturn(ConfigurationService.OBJECT_MAPPER);
-      this.generationAware = generationAware;
-    }
-
-    @Override
-    public String getAssociatedControllerClassName() {
-      return null;
-    }
-
-    @Override
-    public ConfigurationService getConfigurationService() {
-      return service;
-    }
-
-    @Override
-    public boolean isGenerationAware() {
-      return generationAware;
+      setConfigurationService(service);
     }
   }
 }

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/internal/CustomResourceEventSourceTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/internal/CustomResourceEventSourceTest.java
@@ -118,6 +118,7 @@ class CustomResourceEventSourceTest {
 
     final ConfigurationService service = mock(ConfigurationService.class);
     final boolean generationAware;
+
     public TestConfiguration(boolean generationAware) {
       when(service.getObjectMapper()).thenReturn(ConfigurationService.OBJECT_MAPPER);
       this.generationAware = generationAware;

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/internal/CustomResourceEventSourceTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/internal/CustomResourceEventSourceTest.java
@@ -115,12 +115,12 @@ class CustomResourceEventSourceTest {
   private static class TestConfiguration extends
       AbstractControllerConfiguration<TestCustomResource> {
 
-    final ConfigurationService service = mock(ConfigurationService.class);
-
     public TestConfiguration(boolean generationAware) {
-      super(null, null, null, FINALIZER, generationAware, null, null, null);
-      when(service.getObjectMapper()).thenReturn(ConfigurationService.OBJECT_MAPPER);
-      setConfigurationService(service);
+      super(null, null, null, FINALIZER, generationAware, null, null, null,
+          TestCustomResource.class,
+          mock(ConfigurationService.class));
+      when(getConfigurationService().getObjectMapper())
+          .thenReturn(ConfigurationService.OBJECT_MAPPER);
     }
   }
 }

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/IntegrationTestSupport.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/IntegrationTestSupport.java
@@ -52,7 +52,7 @@ public class IntegrationTestSupport {
     loadCRDAndApplyToCluster(crdPath);
 
     final var customResourceClass = config.getCustomResourceClass();
-    this.crOperations = k8sClient.customResources(customResourceClass);
+    this.crOperations = k8sClient.resources(customResourceClass);
 
     final var namespaces = k8sClient.namespaces();
     if (namespaces.withName(TEST_NAMESPACE).get() == null) {

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/IntegrationTestSupport.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/IntegrationTestSupport.java
@@ -3,6 +3,13 @@ package io.javaoperatorsdk.operator;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
@@ -19,11 +26,6 @@ import io.javaoperatorsdk.operator.config.runtime.DefaultConfigurationService;
 import io.javaoperatorsdk.operator.processing.retry.Retry;
 import io.javaoperatorsdk.operator.sample.simple.TestCustomResource;
 import io.javaoperatorsdk.operator.sample.simple.TestCustomResourceSpec;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.concurrent.TimeUnit;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class IntegrationTestSupport {
 
@@ -59,7 +61,7 @@ public class IntegrationTestSupport {
       namespaces.create(
           new NamespaceBuilder().withNewMetadata().withName(TEST_NAMESPACE).endMetadata().build());
     }
-    operator = new Operator(k8sClient, configurationService, Metrics.NOOP);
+    operator = new Operator(k8sClient, configurationService);
     final var overriddenConfig =
         ControllerConfigurationOverrider.override(config).settingNamespace(TEST_NAMESPACE);
     if (retry != null) {


### PR DESCRIPTION
The idea is to expand on the `ControllerRef` class to associate a controller with its configuration and propagate this entity instead of passing the controller, the configuration and very often the kube client to each object that needs that information. 
See commit message on https://github.com/java-operator-sdk/java-operator-sdk/commit/1c47ecf61f150bd241980ffff0c20afcfb003c57 for more details.

I've also taken the opportunity to clean up things from the Metrics class so that it's better decoupled from the business logic.

Fixes #496.