### PR TITLE
chore(ci): drop actions/cache@v2

### DIFF
--- a/.github/workflows/master-snapshot-release.yml
+++ b/.github/workflows/master-snapshot-release.yml
@@ -20,12 +20,6 @@ jobs:
         kubernetes: ['v1.17.13','v1.18.20','v1.19.14','v1.20.10','v1.21.4']
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - name: Set up Java and Maven
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,12 +20,6 @@ jobs:
         kubernetes: ['v1.17.13','v1.18.20','v1.19.14','v1.20.10','v1.21.4']
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - name: Set up Java and Maven
         uses: actions/setup-java@v2
         with:
@@ -44,4 +38,3 @@ jobs:
           driver: 'docker'
       - name: Run integration tests
         run: ./mvnw ${MAVEN_ARGS} -B package -P no-unit-tests --file pom.xml
-


### PR DESCRIPTION
We no longer need to use actions/cache.

Maven dependencies are cached via actions/setup-java

https://github.blog/changelog/2021-08-30-github-actions-setup-java-now-supports-dependency-caching/
