### PR TITLE
fix: only throw MissingCRDException if we get a 404 on the target CRD

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/EventDispatcher.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/EventDispatcher.java
@@ -24,7 +24,7 @@ import static io.javaoperatorsdk.operator.processing.KubernetesResourceUtils.get
 /**
  * Dispatches events to the Controller and handles Finalizers for a single type of Custom Resource.
  */
-class EventDispatcher<R extends CustomResource<?, ?>> {
+public class EventDispatcher<R extends CustomResource<?, ?>> {
 
   private static final Logger log = LoggerFactory.getLogger(EventDispatcher.class);
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/internal/CustomResourceEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/internal/CustomResourceEventSource.java
@@ -11,10 +11,12 @@ import org.slf4j.LoggerFactory;
 
 import io.fabric8.kubernetes.api.model.ListOptions;
 import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.WatcherException;
 import io.fabric8.kubernetes.client.utils.Utils;
+import io.javaoperatorsdk.operator.MissingCRDException;
 import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
 import io.javaoperatorsdk.operator.processing.ConfiguredController;
 import io.javaoperatorsdk.operator.processing.CustomResourceCache;
@@ -54,17 +56,31 @@ public class CustomResourceEventSource<T extends CustomResource<?, ?>> extends A
       options.setLabelSelector(labelSelector);
     }
 
-    if (ControllerConfiguration.allNamespacesWatched(targetNamespaces)) {
-      var w = client.inAnyNamespace().watch(options, this);
-      watches.add(w);
-      log.debug("Registered {} -> {} for any namespace", controller, w);
-    } else {
-      targetNamespaces.forEach(
-          ns -> {
-            var w = client.inNamespace(ns).watch(options, this);
-            watches.add(w);
-            log.debug("Registered {} -> {} for namespace: {}", controller, w, ns);
-          });
+    try {
+      if (ControllerConfiguration.allNamespacesWatched(targetNamespaces)) {
+        var w = client.inAnyNamespace().watch(options, this);
+        watches.add(w);
+        log.debug("Registered {} -> {} for any namespace", controller, w);
+      } else {
+        targetNamespaces.forEach(
+            ns -> {
+              var w = client.inNamespace(ns).watch(options, this);
+              watches.add(w);
+              log.debug("Registered {} -> {} for namespace: {}", controller, w, ns);
+            });
+      }
+    } catch (Exception e) {
+      if (e instanceof KubernetesClientException) {
+        KubernetesClientException ke = (KubernetesClientException) e;
+        if (404 == ke.getCode()) {
+          // only throw MissingCRDException if the 404 error occurs on the target CRD
+          final var targetCRDName = controller.getConfiguration().getCRDName();
+          if (targetCRDName.equals(ke.getFullResourceName())) {
+            throw new MissingCRDException(targetCRDName, null);
+          }
+        }
+      }
+      throw e;
     }
   }
 

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/DefaultEventSourceManagerTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/DefaultEventSourceManagerTest.java
@@ -9,7 +9,6 @@ import io.fabric8.kubernetes.client.CustomResource;
 import io.javaoperatorsdk.operator.TestUtils;
 import io.javaoperatorsdk.operator.processing.DefaultEventHandler;
 import io.javaoperatorsdk.operator.processing.KubernetesResourceUtils;
-import io.javaoperatorsdk.operator.sample.simple.TestCustomResource;
 
 import static io.javaoperatorsdk.operator.processing.KubernetesResourceUtils.getUID;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -25,8 +24,7 @@ class DefaultEventSourceManagerTest {
 
   private DefaultEventHandler defaultEventHandlerMock = mock(DefaultEventHandler.class);
   private DefaultEventSourceManager defaultEventSourceManager =
-      new DefaultEventSourceManager(defaultEventHandlerMock, false,
-          CustomResource.getCRDName(TestCustomResource.class));
+      new DefaultEventSourceManager(defaultEventHandlerMock, false);
 
   @Test
   public void registersEventSource() {

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/DefaultEventSourceManagerTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/DefaultEventSourceManagerTest.java
@@ -9,6 +9,7 @@ import io.fabric8.kubernetes.client.CustomResource;
 import io.javaoperatorsdk.operator.TestUtils;
 import io.javaoperatorsdk.operator.processing.DefaultEventHandler;
 import io.javaoperatorsdk.operator.processing.KubernetesResourceUtils;
+import io.javaoperatorsdk.operator.sample.simple.TestCustomResource;
 
 import static io.javaoperatorsdk.operator.processing.KubernetesResourceUtils.getUID;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,7 +25,8 @@ class DefaultEventSourceManagerTest {
 
   private DefaultEventHandler defaultEventHandlerMock = mock(DefaultEventHandler.class);
   private DefaultEventSourceManager defaultEventSourceManager =
-      new DefaultEventSourceManager(defaultEventHandlerMock, false);
+      new DefaultEventSourceManager(defaultEventHandlerMock, false,
+          CustomResource.getCRDName(TestCustomResource.class));
 
   @Test
   public void registersEventSource() {

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
 
         <junit.version>5.8.1</junit.version>
-        <fabric8-client.version>5.7.2</fabric8-client.version>
+        <fabric8-client.version>5.8.0</fabric8-client.version>
         <slf4j.version>1.7.32</slf4j.version>
         <log4j.version>2.14.1</log4j.version>
         <mokito.version>3.12.4</mokito.version>


### PR DESCRIPTION
Note that this relies on fabric8io/kubernetes-client#3492 so won't build
until this PR is merged and available in a release.
Fixes #552