### PR TITLE
fix: make it clear that `ConfiguredController.init` should not be called

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/ConfiguredController.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/ConfiguredController.java
@@ -105,8 +105,7 @@ public class ConfiguredController<R extends CustomResource<?, ?>> implements Res
 
   @Override
   public void init(EventSourceManager eventSourceManager) {
-    this.manager = eventSourceManager;
-    controller.init(eventSourceManager);
+    throw new UnsupportedOperationException("This method should never be called directly");
   }
 
   @Override


### PR DESCRIPTION
Fixes #554