### PR TITLE
feat: extract micrometer support into its own module

### DIFF
--- a/micrometer-support/pom.xml
+++ b/micrometer-support/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>java-operator-sdk</artifactId>
+    <groupId>io.javaoperatorsdk</groupId>
+    <version>1.9.8-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>micrometer-support</artifactId>
+  <name>Operator SDK - Micrometer Support</name>
+
+  <properties>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.javaoperatorsdk</groupId>
+      <artifactId>operator-framework-core</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/micrometer-support/src/main/java/io/javaoperatorsdk/operator/micrometer/MicrometerMetrics.java
+++ b/micrometer-support/src/main/java/io/javaoperatorsdk/operator/micrometer/MicrometerMetrics.java
@@ -1,0 +1,66 @@
+package io.javaoperatorsdk.operator.micrometer;
+
+import java.util.Collections;
+import java.util.Map;
+
+import io.javaoperatorsdk.operator.Metrics;
+import io.javaoperatorsdk.operator.Metrics.ControllerExecution;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+
+public class MicrometerMetrics implements Metrics {
+
+  public static final String PREFIX = "operator.sdk.";
+  private final MeterRegistry registry;
+
+  public MicrometerMetrics(MeterRegistry registry) {
+    this.registry = registry;
+  }
+
+  public <T> T timeControllerExecution(ControllerExecution<T> execution) {
+    final var name = execution.controllerName();
+    final var execName = PREFIX + "controllers.execution." + execution.name();
+    final var timer =
+        Timer.builder(execName)
+            .tags("controller", name)
+            .publishPercentiles(0.3, 0.5, 0.95)
+            .publishPercentileHistogram()
+            .register(registry);
+    try {
+      final var result = timer.record(execution::execute);
+      final var successType = execution.successTypeName(result);
+      registry
+          .counter(execName + ".success", "controller", name, "type", successType)
+          .increment();
+      return result;
+    } catch (Exception e) {
+      final var exception = e.getClass().getSimpleName();
+      registry
+          .counter(execName + ".failure", "controller", name, "exception", exception)
+          .increment();
+      throw e;
+    }
+  }
+
+  public void incrementControllerRetriesNumber() {
+    registry
+        .counter(
+            PREFIX + "retry.on.exception", "retry", "retryCounter", "type",
+            "retryException")
+        .increment();
+
+  }
+
+  public void incrementProcessedEventsNumber() {
+    registry
+        .counter(
+            PREFIX + "total.events.received", "events", "totalEvents", "type",
+            "eventsReceived")
+        .increment();
+
+  }
+
+  public <T extends Map<?, ?>> T monitorSizeOf(T map, String name) {
+    return registry.gaugeMapSize(PREFIX + name + ".size", Collections.emptyList(), map);
+  }
+}

--- a/operator-framework-core/pom.xml
+++ b/operator-framework-core/pom.xml
@@ -62,10 +62,6 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
-    <dependency>
-      <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-core</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Metrics.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Metrics.java
@@ -2,6 +2,9 @@ package io.javaoperatorsdk.operator;
 
 import java.util.Map;
 
+import io.javaoperatorsdk.operator.processing.DefaultEventHandler;
+import io.javaoperatorsdk.operator.processing.DefaultEventHandler.EventMonitor;
+
 public interface Metrics {
   Metrics NOOP = new Metrics() {};
 
@@ -26,5 +29,9 @@ public interface Metrics {
 
   default <T extends Map<?, ?>> T monitorSizeOf(T map, String name) {
     return map;
+  }
+
+  default DefaultEventHandler.EventMonitor getEventMonitor() {
+    return EventMonitor.NOOP;
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Metrics.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Metrics.java
@@ -1,41 +1,12 @@
 package io.javaoperatorsdk.operator;
 
-import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.function.ToDoubleFunction;
-import java.util.function.ToLongFunction;
 
-import io.micrometer.core.instrument.Clock;
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.DistributionSummary;
-import io.micrometer.core.instrument.FunctionCounter;
-import io.micrometer.core.instrument.FunctionTimer;
-import io.micrometer.core.instrument.Gauge;
-import io.micrometer.core.instrument.Measurement;
-import io.micrometer.core.instrument.Meter;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Timer;
-import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
-import io.micrometer.core.instrument.distribution.pause.PauseDetector;
-import io.micrometer.core.instrument.noop.NoopCounter;
-import io.micrometer.core.instrument.noop.NoopDistributionSummary;
-import io.micrometer.core.instrument.noop.NoopFunctionCounter;
-import io.micrometer.core.instrument.noop.NoopFunctionTimer;
-import io.micrometer.core.instrument.noop.NoopGauge;
-import io.micrometer.core.instrument.noop.NoopMeter;
-import io.micrometer.core.instrument.noop.NoopTimer;
+public interface Metrics {
+  Metrics NOOP = new Metrics() {};
 
-public class Metrics {
-  public static final Metrics NOOP = new Metrics(new NoopMeterRegistry(Clock.SYSTEM));
-  public static final String PREFIX = "operator.sdk.";
-  private final MeterRegistry registry;
 
-  public Metrics(MeterRegistry registry) {
-    this.registry = registry;
-  }
-
-  public interface ControllerExecution<T> {
+  interface ControllerExecution<T> {
     String name();
 
     String controllerName();
@@ -45,111 +16,15 @@ public class Metrics {
     T execute();
   }
 
-  public <T> T timeControllerExecution(ControllerExecution<T> execution) {
-    final var name = execution.controllerName();
-    final var execName = PREFIX + "controllers.execution." + execution.name();
-    final var timer =
-        Timer.builder(execName)
-            .tags("controller", name)
-            .publishPercentiles(0.3, 0.5, 0.95)
-            .publishPercentileHistogram()
-            .register(registry);
-    try {
-      final var result = timer.record(execution::execute);
-      final var successType = execution.successTypeName(result);
-      registry
-          .counter(execName + ".success", "controller", name, "type", successType)
-          .increment();
-      return result;
-    } catch (Exception e) {
-      final var exception = e.getClass().getSimpleName();
-      registry
-          .counter(execName + ".failure", "controller", name, "exception", exception)
-          .increment();
-      throw e;
-    }
+  default <T> T timeControllerExecution(ControllerExecution<T> execution) {
+    return execution.execute();
   }
 
-  public void incrementControllerRetriesNumber() {
-    registry
-        .counter(
-            PREFIX + "retry.on.exception", "retry", "retryCounter", "type",
-            "retryException")
-        .increment();
+  default void incrementControllerRetriesNumber() {}
 
-  }
+  default void incrementProcessedEventsNumber() {}
 
-  public void incrementProcessedEventsNumber() {
-    registry
-        .counter(
-            PREFIX + "total.events.received", "events", "totalEvents", "type",
-            "eventsReceived")
-        .increment();
-
-  }
-
-  public <T extends Map<?, ?>> T monitorSizeOf(T map, String name) {
-    return registry.gaugeMapSize(PREFIX + name + ".size", Collections.emptyList(), map);
-  }
-
-  public static class NoopMeterRegistry extends MeterRegistry {
-    public NoopMeterRegistry(Clock clock) {
-      super(clock);
-    }
-
-    @Override
-    protected <T> Gauge newGauge(Meter.Id id, T t, ToDoubleFunction<T> toDoubleFunction) {
-      return new NoopGauge(id);
-    }
-
-    @Override
-    protected Counter newCounter(Meter.Id id) {
-      return new NoopCounter(id);
-    }
-
-    @Override
-    protected Timer newTimer(
-        Meter.Id id,
-        DistributionStatisticConfig distributionStatisticConfig,
-        PauseDetector pauseDetector) {
-      return new NoopTimer(id);
-    }
-
-    @Override
-    protected DistributionSummary newDistributionSummary(
-        Meter.Id id, DistributionStatisticConfig distributionStatisticConfig, double v) {
-      return new NoopDistributionSummary(id);
-    }
-
-    @Override
-    protected Meter newMeter(Meter.Id id, Meter.Type type, Iterable<Measurement> iterable) {
-      return new NoopMeter(id);
-    }
-
-    @Override
-    protected <T> FunctionTimer newFunctionTimer(
-        Meter.Id id,
-        T t,
-        ToLongFunction<T> toLongFunction,
-        ToDoubleFunction<T> toDoubleFunction,
-        TimeUnit timeUnit) {
-      return new NoopFunctionTimer(id);
-    }
-
-    @Override
-    protected <T> FunctionCounter newFunctionCounter(
-        Meter.Id id, T t, ToDoubleFunction<T> toDoubleFunction) {
-      return new NoopFunctionCounter(id);
-    }
-
-    @Override
-    protected TimeUnit getBaseTimeUnit() {
-      return TimeUnit.SECONDS;
-    }
-
-    @Override
-    protected DistributionStatisticConfig defaultHistogramConfig() {
-      return DistributionStatisticConfig.NONE;
-    }
+  default <T extends Map<?, ?>> T monitorSizeOf(T map, String name) {
+    return map;
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Operator.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Operator.java
@@ -18,9 +18,6 @@ import io.javaoperatorsdk.operator.api.config.ConfigurationService;
 import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
 import io.javaoperatorsdk.operator.api.config.ExecutorServiceManager;
 import io.javaoperatorsdk.operator.processing.ConfiguredController;
-import io.javaoperatorsdk.operator.processing.DefaultEventHandler;
-import io.javaoperatorsdk.operator.processing.DefaultEventHandler.EventMonitor;
-import io.javaoperatorsdk.operator.processing.event.Event;
 
 @SuppressWarnings("rawtypes")
 public class Operator implements AutoCloseable {
@@ -32,17 +29,6 @@ public class Operator implements AutoCloseable {
   public Operator(KubernetesClient k8sClient, ConfigurationService configurationService) {
     this.k8sClient = k8sClient;
     this.configurationService = configurationService;
-    DefaultEventHandler.setEventMonitor(new EventMonitor() {
-      @Override
-      public void processedEvent(String uid, Event event) {
-        configurationService.getMetrics().incrementProcessedEventsNumber();
-      }
-
-      @Override
-      public void failedEvent(String uid, Event event) {
-        configurationService.getMetrics().incrementControllerRetriesNumber();
-      }
-    });
   }
 
   /** Adds a shutdown hook that automatically calls {@link #close()} when the app shuts down. */

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
         <module>operator-framework-junit5</module>
         <module>operator-framework</module>
         <module>samples</module>
+      <module>micrometer-support</module>
     </modules>
 
 


### PR DESCRIPTION
Fixes #576. This allows getting rid of mandatory micrometer dependency
if users are not interested in having metrics.