### PR TITLE
feature!: throw exception if controller cannot be registered

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Operator.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Operator.java
@@ -137,7 +137,7 @@ public class Operator implements AutoCloseable, LifecycleAware {
       throws OperatorException {
     final var existing = configurationService.getConfigurationFor(controller);
     if (existing == null) {
-      throw new IllegalStateException(
+      throw new OperatorException(
           "Cannot register controller with name " + controller.getClass().getCanonicalName() +
               " controller named " + ControllerUtils.getNameFor(controller)
               + " because its configuration cannot be found.\n" +


### PR DESCRIPTION
If a controller cannot be registered because of cofirguration loading is a programatic error, should be reported asap. Logging just a warning would make it hard to find out where is the problem and why the controller not starting