### PR TITLE
fix: use `close` as destroyMethod of Bean

### DIFF
--- a/samples/spring-boot-plain/src/main/java/io/javaoperatorsdk/operator/sample/Config.java
+++ b/samples/spring-boot-plain/src/main/java/io/javaoperatorsdk/operator/sample/Config.java
@@ -18,7 +18,7 @@ public class Config {
   }
 
   // Register all controller beans
-  @Bean(initMethod = "start", destroyMethod = "stop")
+  @Bean(initMethod = "start", destroyMethod = "close")
   public Operator operator(List<ResourceController> controllers) {
     Operator operator = new Operator(DefaultConfigurationService.instance());
     controllers.forEach(operator::register);


### PR DESCRIPTION
`Operator` does not have a `stop` method.
In accordance with the meaning, instead of the `stop` method, the `close` method was modified to operate as `destroyMethod `.