### PR TITLE
fix!: remove periodic schedule from timer event source

### DIFF
--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/internal/TimerEventSourceTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/internal/TimerEventSourceTest.java
@@ -24,7 +24,6 @@ class TimerEventSourceTest {
 
   public static final int INITIAL_DELAY = 50;
   public static final int PERIOD = 50;
-  public static final int TESTING_TIME_SLACK = 40;
 
   private TimerEventSource<TestCustomResource> timerEventSource;
   private CapturingEventHandler eventHandlerMock;

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/internal/TimerEventSourceTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/internal/TimerEventSourceTest.java
@@ -39,35 +39,6 @@ class TimerEventSourceTest {
   }
 
   @Test
-  public void producesEventsPeriodically() {
-    TestCustomResource customResource = TestUtils.testCustomResource();
-    timerEventSource.schedule(customResource, INITIAL_DELAY, PERIOD);
-
-    untilAsserted(() -> {
-      assertThat(eventHandlerMock.events)
-          .hasSizeGreaterThan(2);
-      assertThat(eventHandlerMock.events)
-          .allMatch(e -> e.getRelatedCustomResourceID()
-              .equals(CustomResourceID.fromResource(customResource)));
-
-    });
-  }
-
-  @Test
-  public void deRegistersPeriodicalEventSources() {
-    TestCustomResource customResource = TestUtils.testCustomResource();
-
-    timerEventSource.schedule(customResource, INITIAL_DELAY, PERIOD);
-    untilAsserted(() -> assertThat(eventHandlerMock.events).hasSizeGreaterThan(1));
-
-    timerEventSource
-        .cleanupForCustomResource(CustomResourceID.fromResource(customResource));
-
-    int size = eventHandlerMock.events.size();
-    untilAsserted(() -> assertThat(eventHandlerMock.events).hasSize(size));
-  }
-
-  @Test
   public void schedulesOnce() {
     TestCustomResource customResource = TestUtils.testCustomResource();
 

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/event/EventSourceTestCustomResourceController.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/event/EventSourceTestCustomResourceController.java
@@ -2,9 +2,6 @@ package io.javaoperatorsdk.operator.sample.event;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.fabric8.kubernetes.client.CustomResource;
 import io.javaoperatorsdk.operator.ControllerUtils;
 import io.javaoperatorsdk.operator.api.Context;
@@ -24,9 +21,6 @@ public class EventSourceTestCustomResourceController
   public static final String FINALIZER_NAME =
       ControllerUtils.getDefaultFinalizerName(
           CustomResource.getCRDName(EventSourceTestCustomResource.class));
-  private static final Logger log =
-      LoggerFactory.getLogger(EventSourceTestCustomResourceController.class);
-  public static final int TIMER_DELAY = 300;
   public static final int TIMER_PERIOD = 500;
   private final AtomicInteger numberOfExecutions = new AtomicInteger(0);
   private final TimerEventSource<EventSourceTestCustomResource> timerEventSource =
@@ -41,13 +35,11 @@ public class EventSourceTestCustomResourceController
   public UpdateControl<EventSourceTestCustomResource> createOrUpdateResource(
       EventSourceTestCustomResource resource, Context context) {
 
-    timerEventSource.schedule(resource, TIMER_DELAY, TIMER_PERIOD);
-
     numberOfExecutions.addAndGet(1);
     ensureStatusExists(resource);
     resource.getStatus().setState(EventSourceTestCustomResourceStatus.State.SUCCESS);
 
-    return UpdateControl.updateStatusSubResource(resource);
+    return UpdateControl.updateStatusSubResource(resource).rescheduleAfter(TIMER_PERIOD);
   }
 
   private void ensureStatusExists(EventSourceTestCustomResource resource) {


### PR DESCRIPTION
This periodic part in the `TimerEventSource` does not makes that much sense anymore, with the new API on update and delete controls. It makes more confusion imho than help. 