### PR TITLE
Prepare for upgrade to fabric8 5.10

### DIFF
--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/internal/CustomResourceSelectorTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/internal/CustomResourceSelectorTest.java
@@ -1,7 +1,5 @@
 package io.javaoperatorsdk.operator.processing.event.internal;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -15,8 +13,6 @@ import org.slf4j.LoggerFactory;
 
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.VersionInfo;
-import io.fabric8.kubernetes.client.VersionInfo.VersionKeys;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.javaoperatorsdk.operator.Operator;
@@ -49,22 +45,7 @@ public class CustomResourceSelectorTest {
 
   @SuppressWarnings("unchecked")
   @BeforeEach
-  void setUpResources() throws ParseException {
-    String buildDate = new SimpleDateFormat(VersionKeys.BUILD_DATE_FORMAT).format(new Date());
-
-    server
-        .expect()
-        .get()
-        .withPath("/version")
-        .andReturn(
-            200,
-            new VersionInfo.Builder()
-                .withBuildDate(buildDate)
-                .withMajor("1")
-                .withMinor("21")
-                .build())
-        .always();
-
+  void setUpResources() {
     configurationService = spy(ConfigurationService.class);
     when(configurationService.checkCRDAndValidateLocalModel()).thenReturn(false);
     when(configurationService.getVersion()).thenReturn(new Version("1", "1", new Date()));

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/internal/CustomResourceSelectorTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/internal/CustomResourceSelectorTest.java
@@ -1,8 +1,7 @@
 package io.javaoperatorsdk.operator.processing.event.internal;
 
 import java.text.ParseException;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -17,6 +16,7 @@ import org.slf4j.LoggerFactory;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.VersionInfo;
+import io.fabric8.kubernetes.client.VersionInfo.VersionKeys;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.javaoperatorsdk.operator.Operator;
@@ -50,9 +50,7 @@ public class CustomResourceSelectorTest {
   @SuppressWarnings("unchecked")
   @BeforeEach
   void setUpResources() throws ParseException {
-    String buildDate =
-        DateTimeFormatter.ofPattern(VersionInfo.VersionKeys.BUILD_DATE_FORMAT)
-            .format(LocalDateTime.now());
+    String buildDate = new SimpleDateFormat(VersionKeys.BUILD_DATE_FORMAT).format(new Date());
 
     server
         .expect()

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
 
         <junit.version>5.8.1</junit.version>
-        <fabric8-client.version>5.8.0</fabric8-client.version>
+        <fabric8-client.version>5.10.0</fabric8-client.version>
         <slf4j.version>1.7.32</slf4j.version>
         <log4j.version>2.14.1</log4j.version>
         <mokito.version>4.0.0</mokito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
 
         <junit.version>5.8.1</junit.version>
-        <fabric8-client.version>5.10.0</fabric8-client.version>
+        <fabric8-client.version>5.10.1</fabric8-client.version>
         <slf4j.version>1.7.32</slf4j.version>
         <log4j.version>2.14.1</log4j.version>
         <mokito.version>4.0.0</mokito.version>


### PR DESCRIPTION
Note that this waits on https://github.com/fabric8io/kubernetes-client/pull/3562 at least to be able to solve the testing issue we've encountered since 5.9.0.