### PR TITLE
fix: Update examples in README to have consistent class names

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,11 +142,11 @@ The Controller implements the business logic and describes all the classes neede
 ```java
 
 @ControllerConfiguration
-public class WebServerController implements Reconciler<WebServer> {
+public class WebPageReconciler implements Reconciler<WebPage> {
 
     // Return the changed resource, so it gets updated. See javadoc for details.
     @Override
-    public UpdateControl<CustomService> reconcile(CustomService resource,
+    public UpdateControl<WebPage> reconcile(WebPage resource,
                                                   Context context) {
         // ... your logic ...
         return UpdateControl.updateStatus(resource);


### PR DESCRIPTION
Update the example in the README.md file so that class names used in the Controller/Reconciler class are consistent with the class names used in the other example classes.

I noticed this inconsistency when trying out the java operator-sdk for the first time and found it confusing.

Signed-off-by: Katherine Stanley <11195226+katheris@users.noreply.github.com>