### PR TITLE
fix: Update createOrUpdateResource example to reference correct class

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ public class WebServerController implements ResourceController<WebServer> {
 
   // Return the changed resource, so it gets updated. See javadoc for details.
   @Override
-  public UpdateControl<CustomService> createOrUpdateResource(CustomService resource,
+  public UpdateControl<WebServer> createOrUpdateResource(WebServer resource,
       Context<WebServer> context) {
     // ... your logic ...
     return UpdateControl.updateStatusSubResource(resource);


### PR DESCRIPTION
Based on the other examples, the createOrUpdateResource function should reference the same class for both arguments, not two separate classes.

I noticed this inconsistency when trying out the java-operator-sdk for the first time and found it confusing.

Signed-off-by: Katherine Stanley <11195226+katheris@users.noreply.github.com>