### PR TITLE
fix with resource filter bug and related behavior update

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/ControllerConfiguration.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/ControllerConfiguration.java
@@ -55,5 +55,5 @@ public @interface ControllerConfiguration {
    * @return the list of event filters.
    */
   @SuppressWarnings("rawtypes")
-  Class<ResourceEventFilter>[] eventFilters() default {};
+  Class<? extends ResourceEventFilter>[] eventFilters() default {};
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/controller/ControllerResourceEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/controller/ControllerResourceEventSource.java
@@ -54,9 +54,7 @@ public class ControllerResourceEventSource<T extends HasMetadata>
     var filters = new ResourceEventFilter[] {
         ResourceEventFilters.finalizerNeededAndApplied(),
         ResourceEventFilters.markedForDeletion(),
-        ResourceEventFilters.and(
-            controller.getConfiguration().getEventFilter(),
-            ResourceEventFilters.generationAware()),
+        ResourceEventFilters.generationAware(),
         null
     };
 
@@ -66,7 +64,11 @@ public class ControllerResourceEventSource<T extends HasMetadata>
     } else {
       onceWhitelistEventFilterEventFilter = null;
     }
-    filter = ResourceEventFilters.or(filters);
+    if (controller.getConfiguration().getEventFilter() != null) {
+      filter = controller.getConfiguration().getEventFilter().and(ResourceEventFilters.or(filters));
+    } else {
+      filter = ResourceEventFilters.or(filters);
+    }
   }
 
   @Override

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/ResourceEventFilterTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/ResourceEventFilterTest.java
@@ -123,7 +123,7 @@ class ResourceEventFilterTest {
   }
 
   @Test
-  public void eventNotFilteredByCustomPredicateIfFinalizerIsRequired() {
+  public void eventAlwaysFilteredByCustomPredicate() {
     var config = new TestControllerConfig(
         FINALIZER,
         false,
@@ -138,13 +138,7 @@ class ResourceEventFilterTest {
     cr.getStatus().setConfigMapStatus("1");
 
     eventSource.eventReceived(ResourceAction.UPDATED, cr, cr);
-    verify(eventHandler, times(1)).handleEvent(any());
-
-    cr.getMetadata().setGeneration(1L);
-    cr.getStatus().setConfigMapStatus("1");
-
-    eventSource.eventReceived(ResourceAction.UPDATED, cr, cr);
-    verify(eventHandler, times(2)).handleEvent(any());
+    verify(eventHandler, times(0)).handleEvent(any());
   }
 
   private static class TestControllerConfig extends ControllerConfig<TestCustomResource> {

--- a/operator-framework/src/main/java/io/javaoperatorsdk/operator/config/runtime/AnnotationConfiguration.java
+++ b/operator-framework/src/main/java/io/javaoperatorsdk/operator/config/runtime/AnnotationConfiguration.java
@@ -90,7 +90,7 @@ public class AnnotationConfiguration<R extends HasMetadata>
           if (answer == null) {
             answer = filter;
           } else {
-            answer = filter.and(filter);
+            answer = answer.and(filter);
           }
         } catch (Exception e) {
           throw new RuntimeException(e);

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/CustomResourceFilterIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/CustomResourceFilterIT.java
@@ -1,0 +1,27 @@
+package io.javaoperatorsdk.operator;
+
+import io.javaoperatorsdk.operator.config.runtime.DefaultConfigurationService;
+import io.javaoperatorsdk.operator.junit.OperatorExtension;
+import io.javaoperatorsdk.operator.sample.customfilter.CustomFilteringTestReconciler;
+import io.javaoperatorsdk.operator.sample.simple.TestReconciler;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class CustomResourceFilterIT {
+
+    @RegisterExtension
+    OperatorExtension operator =
+            OperatorExtension.builder()
+                    .withConfigurationService(DefaultConfigurationService.instance())
+                    .withReconciler(new CustomFilteringTestReconciler())
+                    .build();
+
+    @Test
+    public void customFiltering() {
+
+
+
+    }
+
+
+}

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/CustomResourceFilterIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/CustomResourceFilterIT.java
@@ -1,27 +1,51 @@
 package io.javaoperatorsdk.operator;
 
-import io.javaoperatorsdk.operator.config.runtime.DefaultConfigurationService;
-import io.javaoperatorsdk.operator.junit.OperatorExtension;
-import io.javaoperatorsdk.operator.sample.customfilter.CustomFilteringTestReconciler;
-import io.javaoperatorsdk.operator.sample.simple.TestReconciler;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.javaoperatorsdk.operator.config.runtime.DefaultConfigurationService;
+import io.javaoperatorsdk.operator.junit.OperatorExtension;
+import io.javaoperatorsdk.operator.sample.customfilter.CustomFilteringTestReconciler;
+import io.javaoperatorsdk.operator.sample.customfilter.CustomFilteringTestResource;
+import io.javaoperatorsdk.operator.sample.customfilter.CustomFilteringTestResourceSpec;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class CustomResourceFilterIT {
 
-    @RegisterExtension
-    OperatorExtension operator =
-            OperatorExtension.builder()
-                    .withConfigurationService(DefaultConfigurationService.instance())
-                    .withReconciler(new CustomFilteringTestReconciler())
-                    .build();
+  @RegisterExtension
+  OperatorExtension operator =
+      OperatorExtension.builder()
+          .withConfigurationService(DefaultConfigurationService.instance())
+          .withReconciler(new CustomFilteringTestReconciler())
+          .build();
 
-    @Test
-    public void customFiltering() {
+  @Test
+  public void doesCustomFiltering() throws InterruptedException {
+    var filtered1 = createTestResource("filtered1", true, false);
+    var filtered2 = createTestResource("filtered2", false, true);
+    var notFiltered = createTestResource("notfiltered", true, true);
+    operator.create(CustomFilteringTestResource.class, filtered1);
+    operator.create(CustomFilteringTestResource.class, filtered2);
+    operator.create(CustomFilteringTestResource.class, notFiltered);
+
+    Thread.sleep(300);
+
+    assertThat(
+        ((CustomFilteringTestReconciler) operator.getReconcilers().get(0)).getNumberOfExecutions())
+            .isEqualTo(1);
+  }
 
 
-
-    }
-
+  CustomFilteringTestResource createTestResource(String name, boolean filter1, boolean filter2) {
+    CustomFilteringTestResource resource = new CustomFilteringTestResource();
+    resource.setMetadata(new ObjectMeta());
+    resource.getMetadata().setName(name);
+    resource.setSpec(new CustomFilteringTestResourceSpec());
+    resource.getSpec().setFilter1(filter1);
+    resource.getSpec().setFilter2(filter2);
+    return resource;
+  }
 
 }

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/customfilter/CustomFilteringTestReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/customfilter/CustomFilteringTestReconciler.java
@@ -1,26 +1,25 @@
 package io.javaoperatorsdk.operator.sample.customfilter;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
-import io.javaoperatorsdk.operator.sample.observedgeneration.ObservedGenerationTestCustomResource;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
-import static io.javaoperatorsdk.operator.api.reconciler.Constants.NO_FINALIZER;
-
-@ControllerConfiguration(eventFilters = CustomFlagFilter.class)
+@ControllerConfiguration(eventFilters = {CustomFlagFilter.class, CustomFlagFilter2.class})
 public class CustomFilteringTestReconciler implements Reconciler<CustomFilteringTestResource> {
 
-    private final AtomicInteger numberOfExecutions = new AtomicInteger(0);
+  private final AtomicInteger numberOfExecutions = new AtomicInteger(0);
 
-    @Override
-    public UpdateControl<CustomFilteringTestResource> reconcile(CustomFilteringTestResource resource, Context context) {
-        numberOfExecutions.incrementAndGet();
-        if (!resource.getSpec().isReconcile()) {
-            throw new IllegalStateException("This should not happen!");
-        }
-        return UpdateControl.noUpdate();
-    }
+  @Override
+  public UpdateControl<CustomFilteringTestResource> reconcile(CustomFilteringTestResource resource,
+      Context context) {
+    numberOfExecutions.incrementAndGet();
+    return UpdateControl.noUpdate();
+  }
+
+  public int getNumberOfExecutions() {
+    return numberOfExecutions.get();
+  }
 }

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/customfilter/CustomFilteringTestReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/customfilter/CustomFilteringTestReconciler.java
@@ -1,0 +1,26 @@
+package io.javaoperatorsdk.operator.sample.customfilter;
+
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
+import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+import io.javaoperatorsdk.operator.sample.observedgeneration.ObservedGenerationTestCustomResource;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.javaoperatorsdk.operator.api.reconciler.Constants.NO_FINALIZER;
+
+@ControllerConfiguration(eventFilters = CustomFlagFilter.class)
+public class CustomFilteringTestReconciler implements Reconciler<CustomFilteringTestResource> {
+
+    private final AtomicInteger numberOfExecutions = new AtomicInteger(0);
+
+    @Override
+    public UpdateControl<CustomFilteringTestResource> reconcile(CustomFilteringTestResource resource, Context context) {
+        numberOfExecutions.incrementAndGet();
+        if (!resource.getSpec().isReconcile()) {
+            throw new IllegalStateException("This should not happen!");
+        }
+        return UpdateControl.noUpdate();
+    }
+}

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/customfilter/CustomFilteringTestResource.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/customfilter/CustomFilteringTestResource.java
@@ -3,14 +3,11 @@ package io.javaoperatorsdk.operator.sample.customfilter;
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
-import io.fabric8.kubernetes.model.annotation.Kind;
 import io.fabric8.kubernetes.model.annotation.ShortNames;
 import io.fabric8.kubernetes.model.annotation.Version;
-import io.javaoperatorsdk.operator.sample.doubleupdate.DoubleUpdateTestCustomResourceStatus;
 
 @Group("sample.javaoperatorsdk")
 @Version("v1")
-@Kind("CustomFilteringTest")
 @ShortNames("cft")
 public class CustomFilteringTestResource
     extends CustomResource<CustomFilteringTestResourceSpec, Void>

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/customfilter/CustomFilteringTestResource.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/customfilter/CustomFilteringTestResource.java
@@ -1,0 +1,18 @@
+package io.javaoperatorsdk.operator.sample.customfilter;
+
+import io.fabric8.kubernetes.api.model.Namespaced;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Kind;
+import io.fabric8.kubernetes.model.annotation.ShortNames;
+import io.fabric8.kubernetes.model.annotation.Version;
+import io.javaoperatorsdk.operator.sample.doubleupdate.DoubleUpdateTestCustomResourceStatus;
+
+@Group("sample.javaoperatorsdk")
+@Version("v1")
+@Kind("CustomFilteringTest")
+@ShortNames("cft")
+public class CustomFilteringTestResource
+    extends CustomResource<CustomFilteringTestResourceSpec, Void>
+    implements Namespaced {
+}

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/customfilter/CustomFilteringTestResourceSpec.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/customfilter/CustomFilteringTestResourceSpec.java
@@ -1,0 +1,26 @@
+package io.javaoperatorsdk.operator.sample.customfilter;
+
+public class CustomFilteringTestResourceSpec {
+
+  private boolean reconcile = true;
+
+  private String value;
+
+  public String getValue() {
+    return value;
+  }
+
+  public CustomFilteringTestResourceSpec setValue(String value) {
+    this.value = value;
+    return this;
+  }
+
+  public boolean isReconcile() {
+    return reconcile;
+  }
+
+  public CustomFilteringTestResourceSpec setReconcile(boolean reconcile) {
+    this.reconcile = reconcile;
+    return this;
+  }
+}

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/customfilter/CustomFilteringTestResourceSpec.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/customfilter/CustomFilteringTestResourceSpec.java
@@ -2,25 +2,25 @@ package io.javaoperatorsdk.operator.sample.customfilter;
 
 public class CustomFilteringTestResourceSpec {
 
-  private boolean reconcile = true;
+  private boolean filter1;
 
-  private String value;
+  private boolean filter2;
 
-  public String getValue() {
-    return value;
+  public boolean isFilter1() {
+    return filter1;
   }
 
-  public CustomFilteringTestResourceSpec setValue(String value) {
-    this.value = value;
+  public CustomFilteringTestResourceSpec setFilter1(boolean filter1) {
+    this.filter1 = filter1;
     return this;
   }
 
-  public boolean isReconcile() {
-    return reconcile;
+  public boolean isFilter2() {
+    return filter2;
   }
 
-  public CustomFilteringTestResourceSpec setReconcile(boolean reconcile) {
-    this.reconcile = reconcile;
+  public CustomFilteringTestResourceSpec setFilter2(boolean filter2) {
+    this.filter2 = filter2;
     return this;
   }
 }

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/customfilter/CustomFlagFilter.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/customfilter/CustomFlagFilter.java
@@ -1,0 +1,14 @@
+package io.javaoperatorsdk.operator.sample.customfilter;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
+import io.javaoperatorsdk.operator.processing.event.source.controller.ResourceEventFilter;
+
+public class CustomFlagFilter implements ResourceEventFilter<CustomFilteringTestResource> {
+
+    @Override
+    public boolean acceptChange(ControllerConfiguration<CustomFilteringTestResource> configuration,
+                                CustomFilteringTestResource oldResource, CustomFilteringTestResource newResource) {
+        return newResource.getSpec().isReconcile();
+    }
+}

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/customfilter/CustomFlagFilter2.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/customfilter/CustomFlagFilter2.java
@@ -3,11 +3,11 @@ package io.javaoperatorsdk.operator.sample.customfilter;
 import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
 import io.javaoperatorsdk.operator.processing.event.source.controller.ResourceEventFilter;
 
-public class CustomFlagFilter implements ResourceEventFilter<CustomFilteringTestResource> {
+public class CustomFlagFilter2 implements ResourceEventFilter<CustomFilteringTestResource> {
 
   @Override
   public boolean acceptChange(ControllerConfiguration<CustomFilteringTestResource> configuration,
       CustomFilteringTestResource oldResource, CustomFilteringTestResource newResource) {
-    return newResource.getSpec().isFilter1();
+    return newResource.getSpec().isFilter2();
   }
 }

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/retry/RetryTestCustomReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/retry/RetryTestCustomReconciler.java
@@ -24,10 +24,11 @@ public class RetryTestCustomReconciler
       LoggerFactory.getLogger(RetryTestCustomReconciler.class);
   private final AtomicInteger numberOfExecutions = new AtomicInteger(0);
 
-  private int numberOfExecutionFails;
+  private final AtomicInteger numberOfExecutionFails;
+
 
   public RetryTestCustomReconciler(int numberOfExecutionFails) {
-    this.numberOfExecutionFails = numberOfExecutionFails;
+    this.numberOfExecutionFails = new AtomicInteger(numberOfExecutionFails);
   }
 
   @Override
@@ -40,7 +41,7 @@ public class RetryTestCustomReconciler
     }
     log.info("Value: " + resource.getSpec().getValue());
 
-    if (numberOfExecutions.get() < numberOfExecutionFails + 1) {
+    if (numberOfExecutions.get() < numberOfExecutionFails.get() + 1) {
       throw new RuntimeException("Testing Retry");
     }
     if (context.getRetryInfo().isEmpty() || context.getRetryInfo().get().isLastAttempt()) {

--- a/sample-operators/tomcat-operator/src/main/java/io/javaoperatorsdk/operator/sample/CustomFilter.java
+++ b/sample-operators/tomcat-operator/src/main/java/io/javaoperatorsdk/operator/sample/CustomFilter.java
@@ -1,0 +1,12 @@
+package io.javaoperatorsdk.operator.sample;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
+import io.javaoperatorsdk.operator.processing.event.source.controller.ResourceEventFilter;
+
+public class CustomFilter implements ResourceEventFilter {
+    @Override
+    public boolean acceptChange(ControllerConfiguration configuration, HasMetadata oldResource, HasMetadata newResource) {
+        return false;
+    }
+}

--- a/sample-operators/tomcat-operator/src/main/java/io/javaoperatorsdk/operator/sample/CustomFilter.java
+++ b/sample-operators/tomcat-operator/src/main/java/io/javaoperatorsdk/operator/sample/CustomFilter.java
@@ -5,8 +5,9 @@ import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
 import io.javaoperatorsdk.operator.processing.event.source.controller.ResourceEventFilter;
 
 public class CustomFilter implements ResourceEventFilter {
-    @Override
-    public boolean acceptChange(ControllerConfiguration configuration, HasMetadata oldResource, HasMetadata newResource) {
-        return false;
-    }
+  @Override
+  public boolean acceptChange(ControllerConfiguration configuration, HasMetadata oldResource,
+      HasMetadata newResource) {
+    return false;
+  }
 }

--- a/sample-operators/tomcat-operator/src/main/java/io/javaoperatorsdk/operator/sample/WebappReconciler.java
+++ b/sample-operators/tomcat-operator/src/main/java/io/javaoperatorsdk/operator/sample/WebappReconciler.java
@@ -28,7 +28,7 @@ import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import io.javaoperatorsdk.operator.processing.event.source.EventSource;
 import io.javaoperatorsdk.operator.processing.event.source.informer.InformerEventSource;
 
-@ControllerConfiguration
+@ControllerConfiguration(eventFilters = {CustomFilter.class})
 public class WebappReconciler implements Reconciler<Webapp>, EventSourceInitializer<Webapp> {
 
   private KubernetesClient kubernetesClient;


### PR DESCRIPTION
The behavior changed with this PR, if a resource event filtered out, we don't even add predicat.