### PR TITLE
fix: only check for CRD if we're dealing with CustomResources

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/Controller.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/Controller.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
+import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
@@ -167,10 +168,10 @@ public class Controller<R extends HasMetadata> implements Reconciler<R>,
     try {
       // check that the custom resource is known by the cluster if configured that way
       final CustomResourceDefinition crd; // todo: check proper CRD spec version based on config
-      if (configurationService().checkCRDAndValidateLocalModel()) {
-        crd =
-            kubernetesClient.apiextensions().v1().customResourceDefinitions().withName(crdName)
-                .get();
+      if (configurationService().checkCRDAndValidateLocalModel()
+          && CustomResource.class.isAssignableFrom(resClass)) {
+        crd = kubernetesClient.apiextensions().v1().customResourceDefinitions().withName(crdName)
+            .get();
         if (crd == null) {
           throwMissingCRDException(crdName, specVersion, controllerName);
         }

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/ControllerTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/ControllerTest.java
@@ -1,0 +1,79 @@
+package io.javaoperatorsdk.operator.processing;
+
+import org.junit.jupiter.api.Test;
+
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.V1ApiextensionAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.ApiextensionsAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.javaoperatorsdk.operator.MissingCRDException;
+import io.javaoperatorsdk.operator.api.config.ConfigurationService;
+import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
+import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
+import io.javaoperatorsdk.operator.sample.simple.TestCustomResource;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ControllerTest {
+
+  @Test
+  void crdShouldNotBeCheckedForNativeResources() {
+    final var client = mock(KubernetesClient.class);
+    final var configurationService = mock(ConfigurationService.class);
+    final var reconciler = mock(Reconciler.class);
+    final var configuration = mock(ControllerConfiguration.class);
+    when(configuration.getResourceClass()).thenReturn(Secret.class);
+    when(configuration.getConfigurationService()).thenReturn(configurationService);
+
+    final var controller = new Controller<Secret>(reconciler, configuration, client);
+    controller.start();
+    verify(client, never()).apiextensions();
+  }
+
+  @Test
+  void crdShouldNotBeCheckedForCustomResourcesIfDisabled() {
+    final var client = mock(KubernetesClient.class);
+    final var configurationService = mock(ConfigurationService.class);
+    when(configurationService.checkCRDAndValidateLocalModel()).thenReturn(false);
+    final var reconciler = mock(Reconciler.class);
+    final var configuration = mock(ControllerConfiguration.class);
+    when(configuration.getResourceClass()).thenReturn(TestCustomResource.class);
+    when(configuration.getConfigurationService()).thenReturn(configurationService);
+
+    final var controller = new Controller<TestCustomResource>(reconciler, configuration, client);
+    controller.start();
+    verify(client, never()).apiextensions();
+  }
+
+  @Test
+  void crdShouldBeCheckedForCustomResourcesByDefault() {
+    final var client = mock(KubernetesClient.class);
+    final var configurationService = mock(ConfigurationService.class);
+    when(configurationService.checkCRDAndValidateLocalModel()).thenCallRealMethod();
+    final var reconciler = mock(Reconciler.class);
+    final var configuration = mock(ControllerConfiguration.class);
+    when(configuration.getResourceClass()).thenReturn(TestCustomResource.class);
+    when(configuration.getConfigurationService()).thenReturn(configurationService);
+    final var apiGroupDSL = mock(ApiextensionsAPIGroupDSL.class);
+    when(client.apiextensions()).thenReturn(apiGroupDSL);
+    final var v1 = mock(V1ApiextensionAPIGroupDSL.class);
+    when(apiGroupDSL.v1()).thenReturn(v1);
+    final var operation = mock(NonNamespaceOperation.class);
+    when(v1.customResourceDefinitions()).thenReturn(operation);
+    when(operation.withName(any())).thenReturn(mock(Resource.class));
+
+    final var controller = new Controller<TestCustomResource>(reconciler, configuration, client);
+    // since we're not really connected to a cluster and the CRD wouldn't be deployed anyway, we
+    // expect a MissingCRDException to be thrown
+    assertThrows(MissingCRDException.class, controller::start);
+    verify(client, times(1)).apiextensions();
+  }
+}


### PR DESCRIPTION
Fixes #810
