### PR TITLE
fix: ReconcilerUtils.isFinalizerValid should account for NO_FINALIZER

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/ReconcilerUtils.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/ReconcilerUtils.java
@@ -37,7 +37,7 @@ public class ReconcilerUtils {
         throw new UnsupportedOperationException();
       }
     };
-    return validator.isFinalizerValid(finalizer);
+    return Constants.NO_FINALIZER.equals(finalizer) || validator.isFinalizerValid(finalizer);
   }
 
   public static String getResourceTypeName(Class<? extends HasMetadata> resourceClass) {
@@ -49,7 +49,10 @@ public class ReconcilerUtils {
   }
 
   public static String getDefaultFinalizerName(Class<? extends HasMetadata> resourceClass) {
-    var resourceName = getResourceTypeName(resourceClass);
+    return getDefaultFinalizerName(getResourceTypeName(resourceClass));
+  }
+
+  public static String getDefaultFinalizerName(String resourceName) {
     // resource names for historic resources such as Pods are missing periods and therefore do not
     // constitute valid domain names as mandated by Kubernetes so generate one that does
     if (resourceName.indexOf('.') < 0) {

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/ReconcilerUtilsTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/ReconcilerUtilsTest.java
@@ -3,6 +3,7 @@ package io.javaoperatorsdk.operator;
 import org.junit.jupiter.api.Test;
 
 import io.fabric8.kubernetes.api.model.Pod;
+import io.javaoperatorsdk.operator.api.reconciler.Constants;
 import io.javaoperatorsdk.operator.sample.simple.TestCustomReconciler;
 import io.javaoperatorsdk.operator.sample.simple.TestCustomResource;
 
@@ -32,5 +33,10 @@ class ReconcilerUtilsTest {
   void defaultFinalizerShouldWork() {
     assertTrue(isFinalizerValid(getDefaultFinalizerName(Pod.class)));
     assertTrue(isFinalizerValid(getDefaultFinalizerName(TestCustomResource.class)));
+  }
+
+  @Test
+  void noFinalizerMarkerShouldWork() {
+    assertTrue(isFinalizerValid(Constants.NO_FINALIZER));
   }
 }

--- a/operator-framework/src/main/java/io/javaoperatorsdk/operator/config/runtime/AnnotationConfiguration.java
+++ b/operator-framework/src/main/java/io/javaoperatorsdk/operator/config/runtime/AnnotationConfiguration.java
@@ -6,7 +6,6 @@ import java.util.function.Function;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.javaoperatorsdk.operator.ReconcilerUtils;
 import io.javaoperatorsdk.operator.api.config.ConfigurationService;
-import io.javaoperatorsdk.operator.api.reconciler.Constants;
 import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 import io.javaoperatorsdk.operator.processing.event.source.controller.ResourceEventFilter;
@@ -35,7 +34,7 @@ public class AnnotationConfiguration<R extends HasMetadata>
       return ReconcilerUtils.getDefaultFinalizerName(getResourceClass());
     } else {
       final var finalizer = annotation.finalizerName();
-      if (Constants.NO_FINALIZER.equals(finalizer) || ReconcilerUtils.isFinalizerValid(finalizer)) {
+      if (ReconcilerUtils.isFinalizerValid(finalizer)) {
         return finalizer;
       } else {
         throw new IllegalArgumentException(finalizer


### PR DESCRIPTION
Also restores ReconcilerUtils.getDefaultReconcilerName(String)
Fixes #818
