### PR TITLE
fix(micrometer): fix NPE when reconciling already marked events

### DIFF
--- a/micrometer-support/src/main/java/io/javaoperatorsdk/operator/monitoring/micrometer/MicrometerMetrics.java
+++ b/micrometer-support/src/main/java/io/javaoperatorsdk/operator/monitoring/micrometer/MicrometerMetrics.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import io.javaoperatorsdk.operator.api.monitoring.Metrics;
 import io.javaoperatorsdk.operator.api.reconciler.RetryInfo;
@@ -57,11 +58,13 @@ public class MicrometerMetrics implements Metrics {
     incrementCounter(customResourceUid, "events.delete");
   }
 
-  public void reconcileCustomResource(ResourceID resourceID,
-      RetryInfo retryInfo) {
+  public void reconcileCustomResource(ResourceID resourceID, RetryInfo retryInfoNullable) {
+    Optional<RetryInfo> retryInfo = Optional.ofNullable(retryInfoNullable);
     incrementCounter(resourceID, RECONCILIATIONS + "started",
-        RECONCILIATIONS + "retries.number", "" + retryInfo.getAttemptCount(),
-        RECONCILIATIONS + "retries.last", "" + retryInfo.isLastAttempt());
+        RECONCILIATIONS + "retries.number",
+        "" + retryInfo.map(RetryInfo::getAttemptCount).orElse(0),
+        RECONCILIATIONS + "retries.last",
+        "" + retryInfo.map(RetryInfo::isLastAttempt).orElse(true));
   }
 
   @Override

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventProcessor.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventProcessor.java
@@ -81,6 +81,22 @@ class EventProcessor<R extends HasMetadata> implements EventHandler, LifecycleAw
         eventSourceManager);
   }
 
+  EventProcessor(
+      ReconciliationDispatcher<R> reconciliationDispatcher,
+      EventSourceManager<R> eventSourceManager,
+      String relatedControllerName,
+      Retry retry,
+      Metrics metrics) {
+    this(
+        eventSourceManager.getControllerResourceEventSource().getResourceCache(),
+        null,
+        relatedControllerName,
+        reconciliationDispatcher,
+        retry,
+        metrics,
+        eventSourceManager);
+  }
+
   private EventProcessor(
       Cache<R> cache,
       ExecutorService executor,


### PR DESCRIPTION
Refs: java-operator-sdk/java-operator-sdk#836