### PR TITLE
More principled way to wait for the CRD

### DIFF
--- a/operator-framework-junit5/src/main/java/io/javaoperatorsdk/operator/junit/OperatorExtension.java
+++ b/operator-framework-junit5/src/main/java/io/javaoperatorsdk/operator/junit/OperatorExtension.java
@@ -169,12 +169,9 @@ public class OperatorExtension
       }
 
       try (InputStream is = getClass().getResourceAsStream(path)) {
-        kubernetesClient.load(is).createOrReplace();
-        // this fixes an issue with CRD registration, integration tests were failing, since the CRD
-        // was not found yet
-        // when the operator started. This seems to be fixing this issue (maybe a problem with
-        // minikube?)
-        Thread.sleep(2000);
+        final var crd = kubernetesClient.load(is);
+        crd.createOrReplace();
+        crd.waitUntilReady(2, TimeUnit.SECONDS);
         LOGGER.debug("Applied CRD with name: {}", config.getResourceTypeName());
       } catch (Exception ex) {
         throw new IllegalStateException("Cannot apply CRD yaml: " + path, ex);


### PR DESCRIPTION
> this fixes an issue with CRD registration

The underlying problem is that with a small/new cluster `etcd` takes some time to propagate the state.

Unfortunately I couldn't reproduce on my machine(any suggestion on how to reproduce is welcome!), but this should be a more "kubernetes-client" idiomatic way to obtain the same result. 🙂 