### PR TITLE
feat: add @Ignore annotation to mark internal Reconciler implementations

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/Ignore.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/Ignore.java
@@ -1,0 +1,17 @@
+package io.javaoperatorsdk.operator.api.reconciler;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation for downstream tooling to ignore the annotated {@link Reconciler}. This allows to
+ * mark some implementations as not provided by user and should therefore be ignored by processes
+ * external to the SDK itself.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface Ignore {
+
+}

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/Controller.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/Controller.java
@@ -1,5 +1,6 @@
 package io.javaoperatorsdk.operator.processing;
 
+import io.javaoperatorsdk.operator.api.reconciler.Ignore;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
@@ -34,6 +35,7 @@ import io.javaoperatorsdk.operator.processing.event.EventSourceManager;
 import io.javaoperatorsdk.operator.processing.event.source.EventSource;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
+@Ignore
 public class Controller<R extends HasMetadata> implements Reconciler<R>,
     LifecycleAware, EventSourceInitializer<R> {
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/DependentResourceManager.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/DependentResourceManager.java
@@ -1,5 +1,6 @@
 package io.javaoperatorsdk.operator.processing.dependent;
 
+import io.javaoperatorsdk.operator.api.reconciler.Ignore;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -23,6 +24,7 @@ import io.javaoperatorsdk.operator.processing.Controller;
 import io.javaoperatorsdk.operator.processing.event.source.EventSource;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
+@Ignore
 public class DependentResourceManager<R extends HasMetadata> implements EventSourceInitializer<R>,
     EventSourceContextInjector, Reconciler<R> {
 


### PR DESCRIPTION
This allows downstream tools to safely ignore the annotated Reconciler
when considering which implementations to process.

Fixes #862
