### PR TITLE
fix: change log level of no cr found

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventProcessor.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventProcessor.java
@@ -158,7 +158,7 @@ class EventProcessor<R extends HasMetadata> implements EventHandler, LifecycleAw
             controllerUnderExecution,
             latest.isPresent());
         if (latest.isEmpty()) {
-          log.warn("no custom resource found in cache for ResourceID: {}", resourceID);
+          log.debug("no custom resource found in cache for ResourceID: {}", resourceID);
         }
       }
     } finally {


### PR DESCRIPTION
It's can happen that after a custom resource deleted, event sources,
normally also informers still receive events about dependent resources deleted.