### PR TITLE
Disable Sonar check on forks

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    if: ${{ ( github.event_name == 'push' ) || ( github.event_name == 'pull_request' && github.event.pull_request.repository_owner == 'java-operator-sdk' ) }}
     steps:
       - uses: actions/checkout@v2
       - name: Set up Java and Maven


### PR DESCRIPTION
This prevents the Sonar check to run on the forks (will be marked as "Skipped") instead of failing.