### PR TITLE
fix: NPE when no namespace is provided in kube config

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/KubernetesDependent.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/KubernetesDependent.java
@@ -1,10 +1,13 @@
 package io.javaoperatorsdk.operator.api.config;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import static io.javaoperatorsdk.operator.api.reconciler.Constants.EMPTY_STRING;
 
+@Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE})
 public @interface KubernetesDependent {
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ResourceConfiguration.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ResourceConfiguration.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.Set;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.javaoperatorsdk.operator.OperatorException;
 import io.javaoperatorsdk.operator.ReconcilerUtils;
 import io.javaoperatorsdk.operator.api.reconciler.Constants;
 
@@ -67,7 +68,12 @@ public interface ResourceConfiguration<R extends HasMetadata> {
         throw new IllegalStateException(
             "Parent ConfigurationService must be set before calling this method");
       }
-      targetNamespaces = Collections.singleton(parent.getClientConfiguration().getNamespace());
+      String namespace = parent.getClientConfiguration().getNamespace();
+      if (namespace == null) {
+        throw new OperatorException(
+            "Couldn't retrieve the currently connected namespace. Make sure it's correctly set in your ~/.kube/config file, using, e.g. 'kubectl config set-context <your context> --namespace=<your namespace>'");
+      }
+      targetNamespaces = Collections.singleton(namespace);
     }
     return targetNamespaces;
   }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerConfiguration.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerConfiguration.java
@@ -133,12 +133,12 @@ public interface InformerConfiguration<R extends HasMetadata, P extends HasMetad
       InformerConfiguration<R, P> configuration) {
     return new InformerConfigurationBuilder<R, P>(configuration.getResourceClass(),
         configuration.getConfigurationService())
-        .withNamespaces(configuration.getNamespaces())
-        .withLabelSelector(configuration.getLabelSelector())
-        .skippingEventPropagationIfUnchanged(
-            configuration.isSkipUpdateEventPropagationIfNoChange())
-        .withAssociatedSecondaryResourceIdentifier(
-            configuration.getAssociatedResourceIdentifier())
-        .withPrimaryResourcesRetriever(configuration.getPrimaryResourcesRetriever());
+            .withNamespaces(configuration.getNamespaces())
+            .withLabelSelector(configuration.getLabelSelector())
+            .skippingEventPropagationIfUnchanged(
+                configuration.isSkipUpdateEventPropagationIfNoChange())
+            .withAssociatedSecondaryResourceIdentifier(
+                configuration.getAssociatedResourceIdentifier())
+            .withPrimaryResourcesRetriever(configuration.getPrimaryResourcesRetriever());
   }
 }

--- a/operator-framework/src/main/java/io/javaoperatorsdk/operator/config/runtime/AnnotationConfiguration.java
+++ b/operator-framework/src/main/java/io/javaoperatorsdk/operator/config/runtime/AnnotationConfiguration.java
@@ -123,7 +123,7 @@ public class AnnotationConfiguration<R extends HasMetadata>
   public List<DependentResourceConfiguration> getDependentResources() {
     if (dependentConfigurations == null) {
       final var dependents = valueOrDefault(annotation, ControllerConfiguration::dependents,
-          new Dependent[]{});
+          new Dependent[] {});
       if (dependents.length > 0) {
         dependentConfigurations = new ArrayList<>(dependents.length);
         for (Dependent dependent : dependents) {
@@ -133,7 +133,7 @@ public class AnnotationConfiguration<R extends HasMetadata>
           if (HasMetadata.class.isAssignableFrom(resourceType)) {
             final var kubeDependent = dependentType.getAnnotation(KubernetesDependent.class);
             final var namespaces =
-                valueOrDefault(kubeDependent, KubernetesDependent::namespaces, new String[]{});
+                valueOrDefault(kubeDependent, KubernetesDependent::namespaces, new String[] {});
             final var labelSelector =
                 valueOrDefault(kubeDependent, KubernetesDependent::labelSelector, null);
             final var owned = valueOrDefault(kubeDependent, KubernetesDependent::owned,


### PR DESCRIPTION
- fix: fail explicitly if current namespace is requested but not available
- fix: retain annotation for reflective access

Fixes #897
