### PR TITLE
feat: remove feature of filter event with observed generation

### DIFF
--- a/docs/documentation/features.md
+++ b/docs/documentation/features.md
@@ -137,17 +137,13 @@ mostly for the cases when there is a long waiting period after a delete operatio
 you might want to either schedule a timed event to make sure
 `cleanup` is executed again or use event sources to get notified about the state changes of a deleted resource.
 
-## Generation Awareness and Automatic Observed Generation Handling
+## Automatic Observed Generation Handling
 
 Having `.observedGeneration` value on the status of the resource is a best practice to indicate the last generation of
 the resource reconciled successfully by the controller. This helps the users / administrators to check if the custom
-resource was reconciled, but it is used to decide if a reconciliation should happen or not. Filtering events based on
-generation is supported by the framework and turned on by default. There are two modes.
+resource was reconciled.
 
-### Primary (preferred) Mode
-
-The first and the **preferred** one is to check after a resource event received, if the generation of the resource is
-larger than the `.observedGeneration` field on status. In order to have this feature working:
+In order to have this feature working:
 
 - the **status class** (not the resource) must implement the
   [`ObservedGenerationAware`](https://github.com/java-operator-sdk/java-operator-sdk/blob/main/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/ObservedGenerationAware.java)
@@ -189,16 +185,18 @@ public class WebPage extends CustomResource<WebPageSpec, WebPageStatus>
 }
 ```
 
-### The Second (Fallback) Mode
+## Generation Awareness and Event Filtering
 
-The second, fallback mode is (when the conditions from above are not met to handle the observed generation automatically
-in status) to handle generation filtering in memory. Thus, if an event is received, the generation of the received
-resource is compared with the resource in the cache.
+On an operator startup, the best practice is to reconcile all the resources. Since while operator was down, changes
+might have made both to custom resource and dependent resources. 
 
-Note that the **first approach has significant benefits** in the situation when the operator is restarted and there is
-no cached resource anymore. In case two this leads to a reconciliation of every resource in all cases,
-event if the resource is not changed while the operator was not running. However, in case informers are used
-the reconciliation from startup will happen anyway, since events will be propagated by the informer.
+When the first reconciliation is done successfully, the next reconciliation is triggered if either the dependent 
+resources are changed or the custom resource `.spec` is changed. If other fields like `.metadata` is changed on the 
+custom resource, the reconciliation could be skipped. This is supported out of the box, thus the reconciliation by 
+default is not triggered if the change to the main custom resource does not increase the `.metadata.generation` field.
+Note that the increase of `.metada.generation`  is handled automatically by Kubernetes.
+
+To turn on this feature set `generationAwareEventProcessing` to `false` for the `Reconciler`.
 
 ## Support for Well Known (non-custom) Kubernetes Resources
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/ObservedGenerationAware.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/ObservedGenerationAware.java
@@ -6,9 +6,7 @@ import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 
 /**
  * If the custom resource's status implements this interface, the observed generation will be
- * automatically handled. The last observed generation will be updated on status. In addition to
- * that, controller configuration will be checked if is set to be generation aware. If generation
- * aware config is turned off, this interface is ignored.
+ * automatically handled. The last observed generation will be updated on status.
  * <p>
  * In order for this automatic handling to work the status object returned by
  * {@link CustomResource#getStatus()} should not be null.

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/controller/ResourceEventFilters.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/controller/ResourceEventFilters.java
@@ -1,8 +1,6 @@
 package io.javaoperatorsdk.operator.processing.event.source.controller;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.client.CustomResource;
-import io.javaoperatorsdk.operator.api.ObservedGenerationAware;
 
 /**
  * Convenience implementations of, and utility methods for, {@link ResourceEventFilter}.
@@ -25,16 +23,6 @@ public final class ResourceEventFilters {
   private static final ResourceEventFilter<HasMetadata> GENERATION_AWARE =
       (configuration, oldResource, newResource) -> {
         final var generationAware = configuration.isGenerationAware();
-        if (newResource instanceof CustomResource<?, ?>) {
-          var newCustomResource = (CustomResource<?, ?>) newResource;
-          final var status = newCustomResource.getStatus();
-          if (generationAware && status instanceof ObservedGenerationAware) {
-            var actualGeneration = newResource.getMetadata().getGeneration();
-            var observedGeneration = ((ObservedGenerationAware) status)
-                .getObservedGeneration();
-            return observedGeneration == null || actualGeneration > observedGeneration;
-          }
-        }
         return oldResource == null || !generationAware ||
             oldResource.getMetadata().getGeneration() < newResource.getMetadata().getGeneration();
       };

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/ResourceEventFilterTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/ResourceEventFilterTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.Test;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
-import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.javaoperatorsdk.operator.TestUtils;
@@ -20,7 +19,6 @@ import io.javaoperatorsdk.operator.processing.event.EventSourceManager;
 import io.javaoperatorsdk.operator.processing.event.source.controller.ControllerResourceEventSource;
 import io.javaoperatorsdk.operator.processing.event.source.controller.ResourceAction;
 import io.javaoperatorsdk.operator.processing.event.source.controller.ResourceEventFilter;
-import io.javaoperatorsdk.operator.sample.observedgeneration.ObservedGenCustomResource;
 import io.javaoperatorsdk.operator.sample.simple.TestCustomResource;
 
 import static org.mockito.Mockito.any;
@@ -102,27 +100,6 @@ class ResourceEventFilterTest {
   }
 
   @Test
-  public void observedGenerationFiltering() {
-    var config = new ObservedGenControllerConfig(FINALIZER, true, null);
-
-    var eventSource = init(new ObservedGenController(config));
-
-    ObservedGenCustomResource cr = new ObservedGenCustomResource();
-    cr.setMetadata(new ObjectMeta());
-    cr.getMetadata().setFinalizers(List.of(FINALIZER));
-    cr.getMetadata().setGeneration(5L);
-    cr.getStatus().setObservedGeneration(5L);
-
-    eventSource.eventReceived(ResourceAction.UPDATED, cr, null);
-    verify(eventHandler, times(0)).handleEvent(any());
-
-    cr.getMetadata().setGeneration(6L);
-
-    eventSource.eventReceived(ResourceAction.UPDATED, cr, null);
-    verify(eventHandler, times(1)).handleEvent(any());
-  }
-
-  @Test
   public void eventAlwaysFilteredByCustomPredicate() {
     var config = new TestControllerConfig(
         FINALIZER,
@@ -145,13 +122,6 @@ class ResourceEventFilterTest {
     public TestControllerConfig(String finalizer, boolean generationAware,
         ResourceEventFilter<TestCustomResource> eventFilter) {
       super(finalizer, generationAware, eventFilter, TestCustomResource.class);
-    }
-  }
-  private static class ObservedGenControllerConfig
-      extends ControllerConfig<ObservedGenCustomResource> {
-    public ObservedGenControllerConfig(String finalizer, boolean generationAware,
-        ResourceEventFilter<ObservedGenCustomResource> eventFilter) {
-      super(finalizer, generationAware, eventFilter, ObservedGenCustomResource.class);
     }
   }
 
@@ -192,22 +162,4 @@ class ResourceEventFilterTest {
     }
   }
 
-  private static class ObservedGenController
-      extends Controller<ObservedGenCustomResource> {
-
-    public ObservedGenController(
-        ControllerConfiguration<ObservedGenCustomResource> configuration) {
-      super(null, configuration, null);
-    }
-
-    @Override
-    public EventSourceManager<ObservedGenCustomResource> getEventSourceManager() {
-      return mock(EventSourceManager.class);
-    }
-
-    @Override
-    public MixedOperation<ObservedGenCustomResource, KubernetesResourceList<ObservedGenCustomResource>, Resource<ObservedGenCustomResource>> getCRClient() {
-      return mock(MixedOperation.class);
-    }
-  }
 }


### PR DESCRIPTION
From now on on startup we always reconcile the resources. Since deletes cannot be detected automatically, thus if a resource deletion happens while de operator is down, it won't trigger a reconciliation on startup. So this is important for correctness in general.