### PR TITLE
Faster CI feedback loop

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,20 +11,15 @@ on:
     branches: [ main, v1 ]
   workflow_dispatch:
 jobs:
-  build:
+  check_format_and_unit_tests:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java: [ 11, 17 ]
-        distribution: [ temurin ]
-        kubernetes: [ 'v1.17.13','v1.18.20','v1.19.14','v1.20.10','v1.21.4', 'v1.22.1', 'v1.23.0' ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Java and Maven
         uses: actions/setup-java@v2
         with:
-          distribution: ${{ matrix.distribution }}
-          java-version: ${{ matrix.java }}
+          distribution: temurin
+          java-version: 17
           cache: 'maven'
       - name: Check code format
         run: |
@@ -32,6 +27,32 @@ jobs:
           ./mvnw ${MAVEN_ARGS} impsort:check --file pom.xml
       - name: Run unit tests
         run: ./mvnw ${MAVEN_ARGS} -B test --file pom.xml
+
+  integration_tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ 11, 17 ]
+        kubernetes: [ 'v1.17.13','v1.18.20','v1.19.14','v1.20.10','v1.21.4', 'v1.22.1', 'v1.23.0' ]
+        exclude:
+          - java: 11
+            kubernetes: 'v1.18.20'
+          - java: 11
+            kubernetes: 'v1.19.14'
+          - java: 11
+            kubernetes: 'v1.20.10'
+          - java: 11
+            kubernetes: 'v1.21.4'
+          - java: 11
+            kubernetes: 'v1.22.1'
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Java and Maven
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java }}
+          cache: 'maven'
       - name: Set up Minikube
         uses: manusa/actions-setup-minikube@v2.4.3
         with:


### PR DESCRIPTION
- separated check format and unit tests from the matrix build with kubernetes/Java versions
- excluded all but the first and last kubernetes version for Java 11 (keeping Java 17 for coverage)

As a "Free" GH Actions account we have 20 concurrent jobs and we are already pretty much flooding them up.

I do believe that this setup is not compromising test coverage.

This proposed setup is biased toward Java 17, open to swap it with Java 11 on request.