### PR TITLE
Log the detailed exception when reconciliation

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/Controller.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/Controller.java
@@ -2,6 +2,9 @@ package io.javaoperatorsdk.operator.processing;
 
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
@@ -30,6 +33,8 @@ import io.javaoperatorsdk.operator.processing.event.source.EventSource;
 @SuppressWarnings({"unchecked"})
 public class Controller<R extends HasMetadata> implements Reconciler<R>,
     LifecycleAware, EventSourceInitializer<R> {
+  private static final Logger log = LoggerFactory.getLogger(Controller.class);
+
   private final Reconciler<R> reconciler;
   private final ControllerConfiguration<R> configuration;
   private final KubernetesClient kubernetesClient;
@@ -98,7 +103,12 @@ public class Controller<R extends HasMetadata> implements Reconciler<R>,
 
           @Override
           public UpdateControl<R> execute() {
-            return reconciler.reconcile(resource, context);
+            try {
+              return reconciler.reconcile(resource, context);
+            } catch (Exception e) {
+              log.error("Errors on reconciliation.", e);
+              throw e;
+            }
           }
         });
   }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/Controller.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/Controller.java
@@ -106,7 +106,8 @@ public class Controller<R extends HasMetadata> implements Reconciler<R>,
             try {
               return reconciler.reconcile(resource, context);
             } catch (Exception e) {
-              log.error("Errors on reconciliation.", e);
+              log.error("Reconciliation error for resource: " + ResourceID.fromResource(resource)
+                  + " / reconciler: " + controllerName(), e);
               throw e;
             }
           }


### PR DESCRIPTION
When implementing the controller like `TomcatReconciler` and throw exception when accepting k8s event, the log will not throw the exception stacktrace. Due to this limitation, I spent lot of time to dig operator framework and found the fundamental failure.

So i hope this PR to solve this problem.