### PR TITLE
fix README instructions for webpage sample

### DIFF
--- a/sample-operators/webpage/README.md
+++ b/sample-operators/webpage/README.md
@@ -28,7 +28,11 @@ spec:
 The quickest way to try the operator is to run it on your local machine, while it connects to a local or remote
 Kubernetes cluster. When you start it, it will use the current kubectl context on your machine to connect to the cluster.
 
-Before you run it you have to install the CRD on your cluster by running `kubectl apply -f k8s/crd.yaml`
+Before you run it you have to install the CRD on your cluster by running
+`kubectl apply -f target/classes/META-INF/fabric8/webpages.sample.javaoperatorsdk-v1.yml`.
+
+The CRD is generated automatically from your code by simply adding the `crd-generator-apt`
+dependency to your `pom.xml` file.
 
 When the Operator is running you can create some Webserver Custom Resources. You can find a sample custom resource in
 `k8s/webpage.yaml`. You can create it by running `kubectl apply -f k8s/webpage.yaml`
@@ -42,6 +46,8 @@ page. Otherwise you can change the service to a LoadBalancer (e.g on a public cl
 You can also try to change the HTML code in `k8s/webpage.yaml` and do another `kubectl apply -f k8s/webpage.yaml`.
 This should update the actual NGINX deployment with the new configuration.  
 
+If you want the Operator to be running as a deployment in your cluster, follow the below steps.
+
 ### Build
 
 You can build the sample using `mvn jib:dockerBuild` this will produce a Docker image you can push to the registry 
@@ -49,5 +55,5 @@ of your choice. The JAR file is built using your local Maven and JDK and then co
 
 ### Deployment
 
-1. Deploy the CRD: `kubectl apply -f k8s/crd.yaml`
+1. Deploy the CRD: `kubectl apply -f target/classes/META-INF/fabric8/webpages.sample.javaoperatorsdk-v1.yml`
 2. Deploy the operator: `kubectl apply -f k8s/operator.yaml`


### PR DESCRIPTION
k8s/crd.yml no longer exists as the CRDs for Samples
are automatically generated by the fabric8 maven plugin.

I've aligned to:
https://github.com/java-operator-sdk/java-operator-sdk/blob/main/sample-operators/tomcat-operator/README.md?plain=1#L40-L45