### PR TITLE
feat: dependent resource inherits namespaces from controller config

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/informer/InformerConfiguration.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/informer/InformerConfiguration.java
@@ -105,7 +105,8 @@ public interface InformerConfiguration<R extends HasMetadata, P extends HasMetad
 
   static <R extends HasMetadata, P extends HasMetadata> InformerConfigurationBuilder<R, P> from(
       EventSourceContext<P> context, Class<R> resourceClass) {
-    return new InformerConfigurationBuilder<>(resourceClass, context.getConfigurationService());
+    return new InformerConfigurationBuilder<>(resourceClass, context.getControllerConfiguration()
+        .getConfigurationService());
   }
 
   static InformerConfigurationBuilder from(ConfigurationService configurationService,

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/Context.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/Context.java
@@ -2,10 +2,11 @@ package io.javaoperatorsdk.operator.api.reconciler;
 
 import java.util.Optional;
 
-import io.javaoperatorsdk.operator.api.config.ConfigurationService;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.ManagedDependentResourceContext;
 
-public interface Context {
+public interface Context<P extends HasMetadata> {
 
   Optional<RetryInfo> getRetryInfo();
 
@@ -15,7 +16,7 @@ public interface Context {
 
   <T> Optional<T> getSecondaryResource(Class<T> expectedType, String eventSourceName);
 
-  ConfigurationService getConfigurationService();
+  ControllerConfiguration<P> getControllerConfiguration();
 
   ManagedDependentResourceContext managedDependentResourceContext();
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/DefaultContext.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/DefaultContext.java
@@ -3,23 +3,23 @@ package io.javaoperatorsdk.operator.api.reconciler;
 import java.util.Optional;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.javaoperatorsdk.operator.api.config.ConfigurationService;
+import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.ManagedDependentResourceContext;
 import io.javaoperatorsdk.operator.processing.Controller;
 
-public class DefaultContext<P extends HasMetadata> implements Context {
+public class DefaultContext<P extends HasMetadata> implements Context<P> {
 
   private final RetryInfo retryInfo;
   private final Controller<P> controller;
   private final P primaryResource;
-  private final ConfigurationService configurationService;
+  private final ControllerConfiguration<P> controllerConfiguration;
   private ManagedDependentResourceContext managedDependentResourceContext;
 
   public DefaultContext(RetryInfo retryInfo, Controller<P> controller, P primaryResource) {
     this.retryInfo = retryInfo;
     this.controller = controller;
     this.primaryResource = primaryResource;
-    this.configurationService = controller.getConfiguration().getConfigurationService();
+    this.controllerConfiguration = controller.getConfiguration();
     this.managedDependentResourceContext = new ManagedDependentResourceContext(
         controller.getDependents());
   }
@@ -37,8 +37,8 @@ public class DefaultContext<P extends HasMetadata> implements Context {
   }
 
   @Override
-  public ConfigurationService getConfigurationService() {
-    return configurationService;
+  public ControllerConfiguration<P> getControllerConfiguration() {
+    return controllerConfiguration;
   }
 
   public ManagedDependentResourceContext managedDependentResourceContext() {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/EventSourceContext.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/EventSourceContext.java
@@ -2,7 +2,7 @@ package io.javaoperatorsdk.operator.api.reconciler;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.javaoperatorsdk.operator.api.config.ConfigurationService;
+import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
 import io.javaoperatorsdk.operator.processing.event.source.EventSource;
 import io.javaoperatorsdk.operator.processing.event.source.ResourceCache;
 
@@ -14,13 +14,14 @@ import io.javaoperatorsdk.operator.processing.event.source.ResourceCache;
 public class EventSourceContext<P extends HasMetadata> {
 
   private final ResourceCache<P> primaryCache;
-  private final ConfigurationService configurationService;
+  private final ControllerConfiguration<P> controllerConfiguration;
   private final KubernetesClient client;
 
   public EventSourceContext(ResourceCache<P> primaryCache,
-      ConfigurationService configurationService, KubernetesClient client) {
+      ControllerConfiguration<P> controllerConfiguration,
+      KubernetesClient client) {
     this.primaryCache = primaryCache;
-    this.configurationService = configurationService;
+    this.controllerConfiguration = controllerConfiguration;
     this.client = client;
   }
 
@@ -34,16 +35,13 @@ public class EventSourceContext<P extends HasMetadata> {
   }
 
   /**
-   * Retrieves the {@link ConfigurationService} associated with the operator. This allows, in
-   * particular, to lookup global configuration information such as the configured
-   * {@link io.javaoperatorsdk.operator.api.monitoring.Metrics} or
-   * {@link io.javaoperatorsdk.operator.api.config.Cloner} implementations, which could be useful to
-   * event sources.
+   * Retrieves the {@link ControllerConfiguration} associated with the operator. This allows, in
+   * particular, to lookup controller and global configuration information such as the configured*
    *
-   * @return the {@link ConfigurationService} associated with the operator
+   * @return the {@link ControllerConfiguration} associated with the operator
    */
-  public ConfigurationService getConfigurationService() {
-    return configurationService;
+  public ControllerConfiguration<P> getControllerConfiguration() {
+    return controllerConfiguration;
   }
 
   /**

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/Reconciler.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/Reconciler.java
@@ -13,7 +13,7 @@ public interface Reconciler<R extends HasMetadata> {
    * @return UpdateControl to manage updates on the custom resource (usually the status) after
    *         reconciliation.
    */
-  UpdateControl<R> reconcile(R resource, Context context);
+  UpdateControl<R> reconcile(R resource, Context<R> context);
 
   /**
    * Note that this method is used in combination with finalizers. If automatic finalizer handling
@@ -37,7 +37,7 @@ public interface Reconciler<R extends HasMetadata> {
    *         finalizer to indicate that the resource should not be deleted after all, in which case
    *         the controller should restore the resource's state appropriately.
    */
-  default DeleteControl cleanup(R resource, Context context) {
+  default DeleteControl cleanup(R resource, Context<R> context) {
     return DeleteControl.defaultDelete();
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/AbstractDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/AbstractDependentResource.java
@@ -36,7 +36,7 @@ public abstract class AbstractDependentResource<R, P extends HasMetadata>
   }
 
   @Override
-  public void reconcile(P primary, Context context) {
+  public void reconcile(P primary, Context<P> context) {
     final var creatable = isCreatable(primary, context);
     final var updatable = isUpdatable(primary, context);
     if (creatable || updatable) {
@@ -67,7 +67,7 @@ public abstract class AbstractDependentResource<R, P extends HasMetadata>
     }
   }
 
-  protected void handleCreate(R desired, P primary, Context context) {
+  protected void handleCreate(R desired, P primary, Context<P> context) {
     ResourceID resourceID = ResourceID.fromResource(primary);
     R created = null;
     try {
@@ -107,7 +107,7 @@ public abstract class AbstractDependentResource<R, P extends HasMetadata>
     }
   }
 
-  protected void handleUpdate(R actual, R desired, P primary, Context context) {
+  protected void handleUpdate(R actual, R desired, P primary, Context<P> context) {
     ResourceID resourceID = ResourceID.fromResource(primary);
     R updated = null;
     try {
@@ -131,29 +131,29 @@ public abstract class AbstractDependentResource<R, P extends HasMetadata>
   }
 
   @Override
-  public void cleanup(P primary, Context context) {
+  public void cleanup(P primary, Context<P> context) {
     if (isDeletable(primary, context)) {
       deleter.delete(primary, context);
     }
   }
 
-  protected R desired(P primary, Context context) {
+  protected R desired(P primary, Context<P> context) {
     throw new IllegalStateException(
         "desired method must be implemented if this DependentResource can be created and/or updated");
   }
 
   @SuppressWarnings("unused")
-  protected boolean isCreatable(P primary, Context context) {
+  protected boolean isCreatable(P primary, Context<P> context) {
     return creatable;
   }
 
   @SuppressWarnings("unused")
-  protected boolean isUpdatable(P primary, Context context) {
+  protected boolean isUpdatable(P primary, Context<P> context) {
     return updatable;
   }
 
   @SuppressWarnings("unused")
-  protected boolean isDeletable(P primary, Context context) {
+  protected boolean isDeletable(P primary, Context<P> context) {
     return deletable;
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/Creator.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/Creator.java
@@ -5,5 +5,5 @@ import io.javaoperatorsdk.operator.api.reconciler.Context;
 
 @FunctionalInterface
 public interface Creator<R, P extends HasMetadata> {
-  R create(R desired, P primary, Context context);
+  R create(R desired, P primary, Context<P> context);
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/Deleter.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/Deleter.java
@@ -5,5 +5,5 @@ import io.javaoperatorsdk.operator.api.reconciler.Context;
 
 @FunctionalInterface
 public interface Deleter<P extends HasMetadata> {
-  void delete(P primary, Context context);
+  void delete(P primary, Context<P> context);
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/DependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/DependentResource.java
@@ -6,9 +6,9 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 
 public interface DependentResource<R, P extends HasMetadata> {
-  void reconcile(P primary, Context context);
+  void reconcile(P primary, Context<P> context);
 
-  default void cleanup(P primary, Context context) {}
+  default void cleanup(P primary, Context<P> context) {}
 
   Optional<R> getResource(P primaryResource);
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/DesiredEqualsMatcher.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/DesiredEqualsMatcher.java
@@ -12,7 +12,7 @@ public class DesiredEqualsMatcher<R, P extends HasMetadata> implements Matcher<R
   }
 
   @Override
-  public Result<R> match(R actualResource, P primary, Context context) {
+  public Result<R> match(R actualResource, P primary, Context<P> context) {
     var desired = abstractDependentResource.desired(primary, context);
     return Result.computed(actualResource.equals(desired), desired);
   }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/Matcher.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/Matcher.java
@@ -32,5 +32,5 @@ public interface Matcher<R, P extends HasMetadata> {
     }
   }
 
-  Result<R> match(R actualResource, P primary, Context context);
+  Result<R> match(R actualResource, P primary, Context<P> context);
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/Updater.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/Updater.java
@@ -5,7 +5,7 @@ import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.Matcher.Result;
 
 public interface Updater<R, P extends HasMetadata> {
-  R update(R actual, R desired, P primary, Context context);
+  R update(R actual, R desired, P primary, Context<P> context);
 
-  Result<R> match(R actualResource, P primary, Context context);
+  Result<R> match(R actualResource, P primary, Context<P> context);
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/Controller.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/Controller.java
@@ -61,7 +61,7 @@ public class Controller<P extends HasMetadata> implements Reconciler<P>,
   }
 
   @Override
-  public DeleteControl cleanup(P resource, Context context) {
+  public DeleteControl cleanup(P resource, Context<P> context) {
     dependents.cleanup(resource, context);
 
     return metrics().timeControllerExecution(
@@ -89,7 +89,7 @@ public class Controller<P extends HasMetadata> implements Reconciler<P>,
   }
 
   @Override
-  public UpdateControl<P> reconcile(P resource, Context context) {
+  public UpdateControl<P> reconcile(P resource, Context<P> context) {
     dependents.reconcile(resource, context);
 
     return metrics().timeControllerExecution(

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/DependentResourceManager.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/DependentResourceManager.java
@@ -63,14 +63,14 @@ public class DependentResourceManager<P extends HasMetadata>
   }
 
   @Override
-  public UpdateControl<P> reconcile(P resource, Context context) {
+  public UpdateControl<P> reconcile(P resource, Context<P> context) {
     initContextIfNeeded(resource, context);
     dependents.forEach(dependent -> dependent.reconcile(resource, context));
     return UpdateControl.noUpdate();
   }
 
   @Override
-  public DeleteControl cleanup(P resource, Context context) {
+  public DeleteControl cleanup(P resource, Context<P> context) {
     initContextIfNeeded(resource, context);
     dependents.forEach(dependent -> dependent.cleanup(resource, context));
     return Reconciler.super.cleanup(resource, context);

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/external/AbstractSimpleDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/external/AbstractSimpleDependentResource.java
@@ -43,26 +43,26 @@ public abstract class AbstractSimpleDependentResource<R, P extends HasMetadata>
   public abstract Optional<R> fetchResource(HasMetadata primaryResource);
 
   @Override
-  public void reconcile(P primary, Context context) {
+  public void reconcile(P primary, Context<P> context) {
     var resourceId = ResourceID.fromResource(primary);
     Optional<R> resource = fetchResource(primary);
     resource.ifPresentOrElse(r -> cache.put(resourceId, r), () -> cache.remove(resourceId));
     super.reconcile(primary, context);
   }
 
-  public void cleanup(P primary, Context context) {
+  public void cleanup(P primary, Context<P> context) {
     super.cleanup(primary, context);
     cache.remove(ResourceID.fromResource(primary));
   }
 
   @Override
-  protected void handleCreate(R desired, P primary, Context context) {
+  protected void handleCreate(R desired, P primary, Context<P> context) {
     var res = this.creator.create(desired, primary, context);
     cache.put(ResourceID.fromResource(primary), res);
   }
 
   @Override
-  protected void handleUpdate(R actual, R desired, P primary, Context context) {
+  protected void handleUpdate(R actual, R desired, P primary, Context<P> context) {
     var res = updater.update(actual, desired, primary, context);
     cache.put(ResourceID.fromResource(primary), res);
   }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/GenericKubernetesResourceMatcher.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/GenericKubernetesResourceMatcher.java
@@ -39,8 +39,9 @@ public class GenericKubernetesResourceMatcher<R extends HasMetadata, P extends H
   }
 
   @Override
-  public Result<R> match(R actualResource, P primary, Context context) {
-    final var objectMapper = context.getConfigurationService().getObjectMapper();
+  public Result<R> match(R actualResource, P primary, Context<P> context) {
+    final var objectMapper =
+        context.getControllerConfiguration().getConfigurationService().getObjectMapper();
     final var desired = dependentResource.desired(primary, context);
 
     // reflection will be replaced by this:

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/GenericResourceUpdatePreProcessor.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/GenericResourceUpdatePreProcessor.java
@@ -44,7 +44,8 @@ public abstract class GenericResourceUpdatePreProcessor<R extends HasMetadata> i
   }
 
   public R replaceSpecOnActual(R actual, R desired, Context context) {
-    var clonedActual = context.getConfigurationService().getResourceCloner().clone(actual);
+    var clonedActual = context.getControllerConfiguration().getConfigurationService()
+        .getResourceCloner().clone(actual);
     updateClonedActual(clonedActual, desired);
     return clonedActual;
   }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResource.java
@@ -92,11 +92,11 @@ public abstract class KubernetesDependentResource<R extends HasMetadata, P exten
     this.addOwnerReference = addOwnerReference;
   }
 
-  public R create(R target, P primary, Context context) {
+  public R create(R target, P primary, Context<P> context) {
     return prepare(target, primary, "Creating").create(target);
   }
 
-  public R update(R actual, R target, P primary, Context context) {
+  public R update(R actual, R target, P primary, Context<P> context) {
     var updatedActual = processor.replaceSpecOnActual(actual, target, context);
     return prepare(target, primary, "Updating").replace(updatedActual);
   }
@@ -105,7 +105,7 @@ public abstract class KubernetesDependentResource<R extends HasMetadata, P exten
     return matcher.match(actualResource, primary, context);
   }
 
-  public void delete(P primary, Context context) {
+  public void delete(P primary, Context<P> context) {
     if (!addOwnerReference) {
       var resource = getResource(primary);
       resource.ifPresent(r -> client.resource(r).delete());
@@ -160,7 +160,7 @@ public abstract class KubernetesDependentResource<R extends HasMetadata, P exten
   }
 
   @Override
-  protected R desired(P primary, Context context) {
+  protected R desired(P primary, Context<P> context) {
     return super.desired(primary, context);
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResource.java
@@ -129,7 +129,8 @@ public abstract class KubernetesDependentResource<R extends HasMetadata, P exten
   @Override
   public EventSource initEventSource(EventSourceContext<P> context) {
     if (informerEventSource == null) {
-      configureWith(context.getConfigurationService(), null, null,
+      configureWith(context.getControllerConfiguration().getConfigurationService(), null,
+          context.getControllerConfiguration().getNamespaces(),
           KubernetesDependent.ADD_OWNER_REFERENCE_DEFAULT);
       log.warn("Using default configuration for " + resourceType().getSimpleName()
           + " KubernetesDependentResource, call configureWith to provide configuration");

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/ReconciliationDispatcher.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/ReconciliationDispatcher.java
@@ -163,11 +163,11 @@ class ReconciliationDispatcher<R extends HasMetadata> {
     return createPostExecutionControl(updatedCustomResource, updateControl);
   }
 
-  private void handleErrorStatusHandler(R resource, Context context,
+  private void handleErrorStatusHandler(R resource, Context<R> context,
       RuntimeException e) {
     if (isErrorStatusHandlerPresent()) {
       try {
-        var retryInfo = context.getRetryInfo().orElse(new RetryInfo() {
+        RetryInfo retryInfo = context.getRetryInfo().orElse(new RetryInfo() {
           @Override
           public int getAttemptCount() {
             return 0;

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/GenericKubernetesResourceMatcherTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/GenericKubernetesResourceMatcherTest.java
@@ -9,6 +9,7 @@ import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.javaoperatorsdk.operator.ReconcilerUtils;
 import io.javaoperatorsdk.operator.api.config.ConfigurationService;
+import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -22,8 +23,10 @@ class GenericKubernetesResourceMatcherTest {
   private static final Context context = mock(Context.class);
   static {
     final var configurationService = mock(ConfigurationService.class);
+    final var controllerConfiguration = mock(ControllerConfiguration.class);
     when(configurationService.getObjectMapper()).thenReturn(new ObjectMapper());
-    when(context.getConfigurationService()).thenReturn(configurationService);
+    when(controllerConfiguration.getConfigurationService()).thenReturn(configurationService);
+    when(context.getControllerConfiguration()).thenReturn(controllerConfiguration);
   }
 
   @Test

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/GenericResourceUpdatePreProcessorTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/GenericResourceUpdatePreProcessorTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.javaoperatorsdk.operator.ReconcilerUtils;
 import io.javaoperatorsdk.operator.api.config.ConfigurationService;
+import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.ResourceUpdatePreProcessor;
 
@@ -20,8 +21,10 @@ class GenericResourceUpdatePreProcessorTest {
 
   static {
     final var configurationService = mock(ConfigurationService.class);
+    final var controllerConfiguration = mock(ControllerConfiguration.class);
+    when(controllerConfiguration.getConfigurationService()).thenReturn(configurationService);
     when(configurationService.getResourceCloner()).thenReturn(ConfigurationService.DEFAULT_CLONER);
-    when(context.getConfigurationService()).thenReturn(configurationService);
+    when(context.getControllerConfiguration()).thenReturn(controllerConfiguration);
   }
 
   ResourceUpdatePreProcessor<Deployment> processor =

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/ReconciliationDispatcherTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/ReconciliationDispatcherTest.java
@@ -296,7 +296,7 @@ class ReconciliationDispatcherTest {
         ArgumentCaptor.forClass(Context.class);
     verify(reconciler, times(1))
         .reconcile(any(), contextArgumentCaptor.capture());
-    Context context = contextArgumentCaptor.getValue();
+    Context<?> context = contextArgumentCaptor.getValue();
     final var retryInfo = context.getRetryInfo().get();
     assertThat(retryInfo.getAttemptCount()).isEqualTo(2);
     assertThat(retryInfo.isLastAttempt()).isEqualTo(true);

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/errorstatushandler/ErrorStatusHandlerTestReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/errorstatushandler/ErrorStatusHandlerTestReconciler.java
@@ -22,7 +22,8 @@ public class ErrorStatusHandlerTestReconciler
 
   @Override
   public UpdateControl<ErrorStatusHandlerTestCustomResource> reconcile(
-      ErrorStatusHandlerTestCustomResource resource, Context context) {
+      ErrorStatusHandlerTestCustomResource resource,
+      Context<ErrorStatusHandlerTestCustomResource> context) {
     var number = numberOfExecutions.addAndGet(1);
     var retryAttempt = -1;
     if (context.getRetryInfo().isPresent()) {

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/retry/RetryTestCustomReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/retry/RetryTestCustomReconciler.java
@@ -31,7 +31,7 @@ public class RetryTestCustomReconciler
 
   @Override
   public UpdateControl<RetryTestCustomResource> reconcile(RetryTestCustomResource resource,
-      Context context) {
+      Context<RetryTestCustomResource> context) {
     numberOfExecutions.addAndGet(1);
 
     if (!resource.getMetadata().getFinalizers().contains(FINALIZER_NAME)) {

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/standalonedependent/StandaloneDependentTestReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/standalonedependent/StandaloneDependentTestReconciler.java
@@ -85,7 +85,8 @@ public class StandaloneDependentTestReconciler
       Updater<Deployment, StandaloneDependentTestCustomResource> {
 
     @Override
-    protected Deployment desired(StandaloneDependentTestCustomResource primary, Context context) {
+    protected Deployment desired(StandaloneDependentTestCustomResource primary,
+        Context<StandaloneDependentTestCustomResource> context) {
       Deployment deployment =
           ReconcilerUtils.loadYaml(Deployment.class, getClass(), "nginx-deployment.yaml");
       deployment.getMetadata().setName(primary.getMetadata().getName());

--- a/sample-operators/mysql-schema/src/main/java/io/javaoperatorsdk/operator/sample/MySQLSchemaReconciler.java
+++ b/sample-operators/mysql-schema/src/main/java/io/javaoperatorsdk/operator/sample/MySQLSchemaReconciler.java
@@ -35,7 +35,7 @@ public class MySQLSchemaReconciler
 
 
   @Override
-  public UpdateControl<MySQLSchema> reconcile(MySQLSchema schema, Context context) {
+  public UpdateControl<MySQLSchema> reconcile(MySQLSchema schema, Context<MySQLSchema> context) {
     // we only need to update the status if we just built the schema, i.e. when it's present in the
     // context
     Secret secret = context.getSecondaryResource(Secret.class).orElseThrow();

--- a/sample-operators/mysql-schema/src/main/java/io/javaoperatorsdk/operator/sample/dependent/SchemaDependentResource.java
+++ b/sample-operators/mysql-schema/src/main/java/io/javaoperatorsdk/operator/sample/dependent/SchemaDependentResource.java
@@ -42,12 +42,12 @@ public class SchemaDependentResource
   }
 
   @Override
-  public Schema desired(MySQLSchema primary, Context context) {
+  public Schema desired(MySQLSchema primary, Context<MySQLSchema> context) {
     return new Schema(primary.getMetadata().getName(), primary.getSpec().getEncoding());
   }
 
   @Override
-  public Schema create(Schema target, MySQLSchema mySQLSchema, Context context) {
+  public Schema create(Schema target, MySQLSchema mySQLSchema, Context<MySQLSchema> context) {
     try (Connection connection = getConnection()) {
       Secret secret = context.getSecondaryResource(Secret.class).orElseThrow();
       var username = decode(secret.getData().get(MYSQL_SECRET_USERNAME));
@@ -70,7 +70,7 @@ public class SchemaDependentResource
   }
 
   @Override
-  public void delete(MySQLSchema primary, Context context) {
+  public void delete(MySQLSchema primary, Context<MySQLSchema> context) {
     try (Connection connection = getConnection()) {
       var userName = primary.getStatus() != null ? primary.getStatus().getUserName() : null;
       SchemaService.deleteSchemaAndRelatedUser(connection, primary.getMetadata().getName(),

--- a/sample-operators/tomcat-operator/src/main/java/io/javaoperatorsdk/operator/sample/TomcatReconciler.java
+++ b/sample-operators/tomcat-operator/src/main/java/io/javaoperatorsdk/operator/sample/TomcatReconciler.java
@@ -30,7 +30,7 @@ public class TomcatReconciler implements Reconciler<Tomcat> {
   private final Logger log = LoggerFactory.getLogger(getClass());
 
   @Override
-  public UpdateControl<Tomcat> reconcile(Tomcat tomcat, Context context) {
+  public UpdateControl<Tomcat> reconcile(Tomcat tomcat, Context<Tomcat> context) {
     return context.getSecondaryResource(Deployment.class).map(deployment -> {
       Tomcat updatedTomcat = updateTomcatStatus(tomcat, deployment);
       log.info(

--- a/sample-operators/tomcat-operator/src/main/java/io/javaoperatorsdk/operator/sample/WebappReconciler.java
+++ b/sample-operators/tomcat-operator/src/main/java/io/javaoperatorsdk/operator/sample/WebappReconciler.java
@@ -79,7 +79,7 @@ public class WebappReconciler implements Reconciler<Webapp>, EventSourceInitiali
    * change.
    */
   @Override
-  public UpdateControl<Webapp> reconcile(Webapp webapp, Context context) {
+  public UpdateControl<Webapp> reconcile(Webapp webapp, Context<Webapp> context) {
     if (webapp.getStatus() != null
         && Objects.equals(webapp.getSpec().getUrl(), webapp.getStatus().getDeployedArtifact())) {
       return UpdateControl.noUpdate();
@@ -120,7 +120,7 @@ public class WebappReconciler implements Reconciler<Webapp>, EventSourceInitiali
   }
 
   @Override
-  public DeleteControl cleanup(Webapp webapp, Context context) {
+  public DeleteControl cleanup(Webapp webapp, Context<Webapp> context) {
 
     String[] command = new String[] {"rm", "/data/" + webapp.getSpec().getContextPath() + ".war"};
     String[] commandStatusInAllPods = executeCommandInAllPods(kubernetesClient, webapp, command);

--- a/sample-operators/webpage/src/main/java/io/javaoperatorsdk/operator/sample/WebPageReconciler.java
+++ b/sample-operators/webpage/src/main/java/io/javaoperatorsdk/operator/sample/WebPageReconciler.java
@@ -56,7 +56,7 @@ public class WebPageReconciler
   }
 
   @Override
-  public UpdateControl<WebPage> reconcile(WebPage webPage, Context context) {
+  public UpdateControl<WebPage> reconcile(WebPage webPage, Context<WebPage> context) {
     log.info("Reconciling web page: {}", webPage);
     if (webPage.getSpec().getHtml().contains("error")) {
       throw new ErrorSimulationException("Simulating error");

--- a/sample-operators/webpage/src/main/java/io/javaoperatorsdk/operator/sample/WebPageReconcilerDependentResources.java
+++ b/sample-operators/webpage/src/main/java/io/javaoperatorsdk/operator/sample/WebPageReconcilerDependentResources.java
@@ -128,7 +128,7 @@ public class WebPageReconcilerDependentResources
         new CrudKubernetesDependentResource<>() {
 
           @Override
-          protected Service desired(WebPage webPage, Context context) {
+          protected Service desired(WebPage webPage, Context<WebPage> context) {
             Service service = loadYaml(Service.class, getClass(), "service.yaml");
             service.getMetadata().setName(serviceName(webPage));
             service.getMetadata().setNamespace(webPage.getMetadata().getNamespace());


### PR DESCRIPTION
The primary objective was to inherit the default namespace to the dependent informers if not configured explicitly (standalone). 
For the we need the `ControllerConfiguration` not `ConfigurationService` ( but that is accessible from controller config). So unified also the contexts to provide the controller configuration instead of configuration service. (This part is optional)