### PR TITLE
fix: renaming mapper primary <-> secondary

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/informer/InformerConfiguration.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/informer/InformerConfiguration.java
@@ -10,8 +10,8 @@ import io.javaoperatorsdk.operator.api.config.DefaultResourceConfiguration;
 import io.javaoperatorsdk.operator.api.config.ResourceConfiguration;
 import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
-import io.javaoperatorsdk.operator.processing.event.source.AssociatedSecondaryResourceIdentifier;
-import io.javaoperatorsdk.operator.processing.event.source.PrimaryResourcesRetriever;
+import io.javaoperatorsdk.operator.processing.event.source.PrimaryToSecondaryMapper;
+import io.javaoperatorsdk.operator.processing.event.source.SecondaryToPrimaryMapper;
 import io.javaoperatorsdk.operator.processing.event.source.informer.Mappers;
 
 public interface InformerConfiguration<R extends HasMetadata, P extends HasMetadata>
@@ -20,13 +20,13 @@ public interface InformerConfiguration<R extends HasMetadata, P extends HasMetad
   class DefaultInformerConfiguration<R extends HasMetadata, P extends HasMetadata> extends
       DefaultResourceConfiguration<R> implements InformerConfiguration<R, P> {
 
-    private final PrimaryResourcesRetriever<R> secondaryToPrimaryResourcesIdSet;
-    private final AssociatedSecondaryResourceIdentifier<P> associatedWith;
+    private final SecondaryToPrimaryMapper<R> secondaryToPrimaryResourcesIdSet;
+    private final PrimaryToSecondaryMapper<P> associatedWith;
 
     protected DefaultInformerConfiguration(ConfigurationService service, String labelSelector,
         Class<R> resourceClass,
-        PrimaryResourcesRetriever<R> secondaryToPrimaryResourcesIdSet,
-        AssociatedSecondaryResourceIdentifier<P> associatedWith,
+        SecondaryToPrimaryMapper<R> secondaryToPrimaryResourcesIdSet,
+        PrimaryToSecondaryMapper<P> associatedWith,
         Set<String> namespaces) {
       super(labelSelector, resourceClass, namespaces);
       setConfigurationService(service);
@@ -38,24 +38,24 @@ public interface InformerConfiguration<R extends HasMetadata, P extends HasMetad
     }
 
 
-    public PrimaryResourcesRetriever<R> getPrimaryResourcesRetriever() {
+    public SecondaryToPrimaryMapper<R> getPrimaryResourcesRetriever() {
       return secondaryToPrimaryResourcesIdSet;
     }
 
-    public AssociatedSecondaryResourceIdentifier<P> getAssociatedResourceIdentifier() {
+    public PrimaryToSecondaryMapper<P> getAssociatedResourceIdentifier() {
       return associatedWith;
     }
 
   }
 
-  PrimaryResourcesRetriever<R> getPrimaryResourcesRetriever();
+  SecondaryToPrimaryMapper<R> getPrimaryResourcesRetriever();
 
-  AssociatedSecondaryResourceIdentifier<P> getAssociatedResourceIdentifier();
+  PrimaryToSecondaryMapper<P> getAssociatedResourceIdentifier();
 
   class InformerConfigurationBuilder<R extends HasMetadata, P extends HasMetadata> {
 
-    private PrimaryResourcesRetriever<R> secondaryToPrimaryResourcesIdSet;
-    private AssociatedSecondaryResourceIdentifier<P> associatedWith;
+    private SecondaryToPrimaryMapper<R> secondaryToPrimaryResourcesIdSet;
+    private PrimaryToSecondaryMapper<P> associatedWith;
     private Set<String> namespaces;
     private String labelSelector;
     private final Class<R> resourceClass;
@@ -68,13 +68,13 @@ public interface InformerConfiguration<R extends HasMetadata, P extends HasMetad
     }
 
     public InformerConfigurationBuilder<R, P> withPrimaryResourcesRetriever(
-        PrimaryResourcesRetriever<R> primaryResourcesRetriever) {
-      this.secondaryToPrimaryResourcesIdSet = primaryResourcesRetriever;
+        SecondaryToPrimaryMapper<R> secondaryToPrimaryMapper) {
+      this.secondaryToPrimaryResourcesIdSet = secondaryToPrimaryMapper;
       return this;
     }
 
     public InformerConfigurationBuilder<R, P> withAssociatedSecondaryResourceIdentifier(
-        AssociatedSecondaryResourceIdentifier<P> associatedWith) {
+        PrimaryToSecondaryMapper<P> associatedWith) {
       this.associatedWith = associatedWith;
       return this;
     }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResource.java
@@ -24,9 +24,9 @@ import io.javaoperatorsdk.operator.api.reconciler.dependent.Matcher;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.Matcher.Result;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.ResourceUpdatePreProcessor;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
-import io.javaoperatorsdk.operator.processing.event.source.AssociatedSecondaryResourceIdentifier;
 import io.javaoperatorsdk.operator.processing.event.source.EventSource;
-import io.javaoperatorsdk.operator.processing.event.source.PrimaryResourcesRetriever;
+import io.javaoperatorsdk.operator.processing.event.source.PrimaryToSecondaryMapper;
+import io.javaoperatorsdk.operator.processing.event.source.SecondaryToPrimaryMapper;
 import io.javaoperatorsdk.operator.processing.event.source.informer.InformerEventSource;
 import io.javaoperatorsdk.operator.processing.event.source.informer.Mappers;
 
@@ -63,11 +63,11 @@ public abstract class KubernetesDependentResource<R extends HasMetadata, P exten
   private void configureWith(ConfigurationService configService, String labelSelector,
       Set<String> namespaces, boolean addOwnerReference) {
     final var primaryResourcesRetriever =
-        (this instanceof PrimaryResourcesRetriever) ? (PrimaryResourcesRetriever<R>) this
+        (this instanceof SecondaryToPrimaryMapper) ? (SecondaryToPrimaryMapper<R>) this
             : Mappers.fromOwnerReference();
-    final AssociatedSecondaryResourceIdentifier<P> secondaryResourceIdentifier =
-        (this instanceof AssociatedSecondaryResourceIdentifier)
-            ? (AssociatedSecondaryResourceIdentifier<P>) this
+    final PrimaryToSecondaryMapper<P> secondaryResourceIdentifier =
+        (this instanceof PrimaryToSecondaryMapper)
+            ? (PrimaryToSecondaryMapper<P>) this
             : ResourceID::fromResource;
     InformerConfiguration<R, P> ic =
         InformerConfiguration.from(configService, resourceType())

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/PrimaryToSecondaryMapper.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/PrimaryToSecondaryMapper.java
@@ -4,6 +4,6 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 
 @FunctionalInterface
-public interface AssociatedSecondaryResourceIdentifier<P extends HasMetadata> {
+public interface PrimaryToSecondaryMapper<P extends HasMetadata> {
   ResourceID associatedSecondaryID(P primary);
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/SecondaryToPrimaryMapper.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/SecondaryToPrimaryMapper.java
@@ -5,7 +5,6 @@ import java.util.Set;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 
 @FunctionalInterface
-public interface PrimaryResourcesRetriever<T> {
-
+public interface SecondaryToPrimaryMapper<T> {
   Set<ResourceID> associatedPrimaryResources(T dependentResource);
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/Mappers.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/Mappers.java
@@ -5,38 +5,38 @@ import java.util.Set;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
-import io.javaoperatorsdk.operator.processing.event.source.PrimaryResourcesRetriever;
+import io.javaoperatorsdk.operator.processing.event.source.SecondaryToPrimaryMapper;
 
 public class Mappers {
 
   private Mappers() {}
 
-  public static <T extends HasMetadata> PrimaryResourcesRetriever<T> fromAnnotation(
+  public static <T extends HasMetadata> SecondaryToPrimaryMapper<T> fromAnnotation(
       String nameKey) {
     return fromMetadata(nameKey, null, false);
   }
 
-  public static <T extends HasMetadata> PrimaryResourcesRetriever<T> fromAnnotation(
+  public static <T extends HasMetadata> SecondaryToPrimaryMapper<T> fromAnnotation(
       String nameKey, String namespaceKey) {
     return fromMetadata(nameKey, namespaceKey, false);
   }
 
-  public static <T extends HasMetadata> PrimaryResourcesRetriever<T> fromLabel(
+  public static <T extends HasMetadata> SecondaryToPrimaryMapper<T> fromLabel(
       String nameKey) {
     return fromMetadata(nameKey, null, true);
   }
 
-  public static <T extends HasMetadata> PrimaryResourcesRetriever<T> fromLabel(
+  public static <T extends HasMetadata> SecondaryToPrimaryMapper<T> fromLabel(
       String nameKey, String namespaceKey) {
     return fromMetadata(nameKey, namespaceKey, true);
   }
 
-  public static <T extends HasMetadata> PrimaryResourcesRetriever<T> fromOwnerReference() {
+  public static <T extends HasMetadata> SecondaryToPrimaryMapper<T> fromOwnerReference() {
     return resource -> ResourceID.fromFirstOwnerReference(resource).map(Set::of)
         .orElse(Collections.emptySet());
   }
 
-  private static <T extends HasMetadata> PrimaryResourcesRetriever<T> fromMetadata(
+  private static <T extends HasMetadata> SecondaryToPrimaryMapper<T> fromMetadata(
       String nameKey, String namespaceKey, boolean isLabel) {
     return resource -> {
       final var metadata = resource.getMetadata();

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSourceTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSourceTest.java
@@ -16,7 +16,7 @@ import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
 import io.javaoperatorsdk.operator.api.config.informer.InformerConfiguration;
 import io.javaoperatorsdk.operator.processing.event.EventHandler;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
-import io.javaoperatorsdk.operator.processing.event.source.PrimaryResourcesRetriever;
+import io.javaoperatorsdk.operator.processing.event.source.SecondaryToPrimaryMapper;
 import io.javaoperatorsdk.operator.sample.simple.TestCustomResource;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -50,16 +50,16 @@ class InformerEventSourceTest {
     when(labeledResourceClientMock.runnableInformer(0)).thenReturn(informer);
 
     when(informerConfiguration.getPrimaryResourcesRetriever())
-        .thenReturn(mock(PrimaryResourcesRetriever.class));
+        .thenReturn(mock(SecondaryToPrimaryMapper.class));
 
     informerEventSource = new InformerEventSource<>(informerConfiguration, clientMock);
     informerEventSource.setTemporalResourceCache(temporaryResourceCacheMock);
     informerEventSource.setEventHandler(eventHandlerMock);
 
-    PrimaryResourcesRetriever primaryResourcesRetriever = mock(PrimaryResourcesRetriever.class);
+    SecondaryToPrimaryMapper secondaryToPrimaryMapper = mock(SecondaryToPrimaryMapper.class);
     when(informerConfiguration.getPrimaryResourcesRetriever())
-        .thenReturn(primaryResourcesRetriever);
-    when(primaryResourcesRetriever.associatedPrimaryResources(any()))
+        .thenReturn(secondaryToPrimaryMapper);
+    when(secondaryToPrimaryMapper.associatedPrimaryResources(any()))
         .thenReturn(Set.of(ResourceID.fromResource(testDeployment())));
   }
 

--- a/sample-operators/mysql-schema/src/main/java/io/javaoperatorsdk/operator/sample/dependent/SecretDependentResource.java
+++ b/sample-operators/mysql-schema/src/main/java/io/javaoperatorsdk/operator/sample/dependent/SecretDependentResource.java
@@ -11,13 +11,11 @@ import io.javaoperatorsdk.operator.api.reconciler.dependent.Creator;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.Matcher.Result;
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependentResource;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
-import io.javaoperatorsdk.operator.processing.event.source.AssociatedSecondaryResourceIdentifier;
+import io.javaoperatorsdk.operator.processing.event.source.PrimaryToSecondaryMapper;
 import io.javaoperatorsdk.operator.sample.MySQLSchema;
 
-import static io.javaoperatorsdk.operator.sample.MySQLSchemaReconciler.*;
-
 public class SecretDependentResource extends KubernetesDependentResource<Secret, MySQLSchema>
-    implements AssociatedSecondaryResourceIdentifier<MySQLSchema>, Creator<Secret, MySQLSchema> {
+    implements PrimaryToSecondaryMapper<MySQLSchema>, Creator<Secret, MySQLSchema> {
 
   public static final String SECRET_FORMAT = "%s-secret";
   public static final String USERNAME_FORMAT = "%s-user";

--- a/sample-operators/tomcat-operator/src/main/java/io/javaoperatorsdk/operator/sample/WebappReconciler.java
+++ b/sample-operators/tomcat-operator/src/main/java/io/javaoperatorsdk/operator/sample/WebappReconciler.java
@@ -26,9 +26,9 @@ import io.javaoperatorsdk.operator.api.reconciler.EventSourceInitializer;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
-import io.javaoperatorsdk.operator.processing.event.source.AssociatedSecondaryResourceIdentifier;
 import io.javaoperatorsdk.operator.processing.event.source.EventSource;
-import io.javaoperatorsdk.operator.processing.event.source.PrimaryResourcesRetriever;
+import io.javaoperatorsdk.operator.processing.event.source.PrimaryToSecondaryMapper;
+import io.javaoperatorsdk.operator.processing.event.source.SecondaryToPrimaryMapper;
 import io.javaoperatorsdk.operator.processing.event.source.informer.InformerEventSource;
 
 import static io.javaoperatorsdk.operator.api.reconciler.Constants.NO_FINALIZER;
@@ -52,7 +52,7 @@ public class WebappReconciler implements Reconciler<Webapp>, EventSourceInitiali
      * customResourceId of the WebApp resource we traverse the cache and identify it based on naming
      * convention.
      */
-    final PrimaryResourcesRetriever<Tomcat> webappsMatchingTomcatName =
+    final SecondaryToPrimaryMapper<Tomcat> webappsMatchingTomcatName =
         (Tomcat t) -> context.getPrimaryCache()
             .list(webApp -> webApp.getSpec().getTomcat().equals(t.getMetadata().getName()))
             .map(ResourceID::fromResource)
@@ -61,7 +61,7 @@ public class WebappReconciler implements Reconciler<Webapp>, EventSourceInitiali
     /*
      * We retrieve the Tomcat instance associated with out Webapp from its spec
      */
-    final AssociatedSecondaryResourceIdentifier<Webapp> tomcatFromWebAppSpec =
+    final PrimaryToSecondaryMapper<Webapp> tomcatFromWebAppSpec =
         (Webapp webapp) -> new ResourceID(
             webapp.getSpec().getTomcat(),
             webapp.getMetadata().getNamespace());

--- a/sample-operators/webpage/src/main/java/io/javaoperatorsdk/operator/sample/WebPageReconcilerDependentResources.java
+++ b/sample-operators/webpage/src/main/java/io/javaoperatorsdk/operator/sample/WebPageReconcilerDependentResources.java
@@ -14,8 +14,8 @@ import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CrudKubernete
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependentResource;
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependentResourceConfig;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
-import io.javaoperatorsdk.operator.processing.event.source.AssociatedSecondaryResourceIdentifier;
 import io.javaoperatorsdk.operator.processing.event.source.EventSource;
+import io.javaoperatorsdk.operator.processing.event.source.PrimaryToSecondaryMapper;
 
 import static io.javaoperatorsdk.operator.ReconcilerUtils.loadYaml;
 import static io.javaoperatorsdk.operator.api.reconciler.Constants.NO_FINALIZER;
@@ -163,7 +163,7 @@ public class WebPageReconcilerDependentResources
   private class ConfigMapDependentResource
       extends CrudKubernetesDependentResource<ConfigMap, WebPage>
       implements
-      AssociatedSecondaryResourceIdentifier<WebPage> {
+      PrimaryToSecondaryMapper<WebPage> {
 
     @Override
     protected ConfigMap desired(WebPage webPage, Context context) {


### PR DESCRIPTION
@metacosm what do you think about this renaming. Not sure how much actual backwards compatibiilty issues it will make since usually implemented as lambda function. But we can document these minor changes.
The current names are very obscure for me, have to think about every time I check.

Also would add `glossary` page to the web page docs, to cleary define:
- Secondary Resource (what is a resource actually controller creates)
- Dependent Resource (is the dependent resource feature)

If you agree. 
Later we can extend glossary with additional notions.