### PR TITLE
fix: flaky integration test

### DIFF
--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/SubResourceUpdateIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/SubResourceUpdateIT.java
@@ -20,6 +20,7 @@ import static org.awaitility.Awaitility.await;
 
 class SubResourceUpdateIT {
 
+  public static final int WAIT_AFTER_EXECUTION = 1000;
   @RegisterExtension
   OperatorExtension operator =
       OperatorExtension.builder()
@@ -34,7 +35,7 @@ class SubResourceUpdateIT {
 
     awaitStatusUpdated(resource.getMetadata().getName());
     // wait for sure, there are no more events
-    waitXms(200);
+    waitXms(WAIT_AFTER_EXECUTION);
     // there is no event on status update processed
     assertThat(TestUtils.getNumberOfExecutions(operator))
         .isEqualTo(2);
@@ -49,7 +50,7 @@ class SubResourceUpdateIT {
 
     awaitStatusUpdated(resource.getMetadata().getName());
     // wait for sure, there are no more events
-    waitXms(200);
+    waitXms(WAIT_AFTER_EXECUTION);
     // there is no event on status update processed
     assertThat(TestUtils.getNumberOfExecutions(operator))
         .isEqualTo(2);
@@ -64,7 +65,7 @@ class SubResourceUpdateIT {
 
     awaitStatusUpdated(resource.getMetadata().getName());
     // wait for sure, there are no more events
-    waitXms(200);
+    waitXms(WAIT_AFTER_EXECUTION);
     // there is no event on status update processed
     assertThat(TestUtils.getNumberOfExecutions(operator))
         .isEqualTo(2);
@@ -81,13 +82,15 @@ class SubResourceUpdateIT {
     SubResourceTestCustomResource resource = createTestCustomResource("1");
     operator.create(SubResourceTestCustomResource.class, resource);
 
+    // waits that the resorce
+    waitXms(200);
     resource.getSpec().setValue("new value");
     operator.resources(SubResourceTestCustomResource.class).createOrReplace(resource);
 
     awaitStatusUpdated(resource.getMetadata().getName());
 
     // wait for sure, there are no more events
-    waitXms(500);
+    waitXms(WAIT_AFTER_EXECUTION);
     // there is no event on status update processed
     assertThat(TestUtils.getNumberOfExecutions(operator))
         .isEqualTo(3);
@@ -121,7 +124,7 @@ class SubResourceUpdateIT {
     return resource;
   }
 
-  private void waitXms(int x) {
+  public static void waitXms(int x) {
     try {
       Thread.sleep(x);
     } catch (InterruptedException e) {

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/SubResourceUpdateIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/SubResourceUpdateIT.java
@@ -20,7 +20,10 @@ import static org.awaitility.Awaitility.await;
 
 class SubResourceUpdateIT {
 
-  public static final int WAIT_AFTER_EXECUTION = 1000;
+  public static final int WAIT_AFTER_EXECUTION = 500;
+  public static final int RECONCILER_MIN_EXEC_TIME = 300;
+  public static final int EVENT_RECEIVE_WAIT = 200;
+
   @RegisterExtension
   OperatorExtension operator =
       OperatorExtension.builder()
@@ -82,8 +85,8 @@ class SubResourceUpdateIT {
     SubResourceTestCustomResource resource = createTestCustomResource("1");
     operator.create(SubResourceTestCustomResource.class, resource);
 
-    // waits that the resorce
-    waitXms(200);
+    // waits for the resource to start processing
+    waitXms(EVENT_RECEIVE_WAIT);
     resource.getSpec().setValue("new value");
     operator.resources(SubResourceTestCustomResource.class).createOrReplace(resource);
 

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/SubResourceUpdateIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/SubResourceUpdateIT.java
@@ -21,7 +21,6 @@ import static org.awaitility.Awaitility.await;
 class SubResourceUpdateIT {
 
   public static final int WAIT_AFTER_EXECUTION = 500;
-  public static final int RECONCILER_MIN_EXEC_TIME = 300;
   public static final int EVENT_RECEIVE_WAIT = 200;
 
   @RegisterExtension

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/subresource/SubResourceTestCustomReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/subresource/SubResourceTestCustomReconciler.java
@@ -12,6 +12,7 @@ import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import io.javaoperatorsdk.operator.support.TestExecutionInfoProvider;
 
+import static io.javaoperatorsdk.operator.SubResourceUpdateIT.RECONCILER_MIN_EXEC_TIME;
 import static io.javaoperatorsdk.operator.support.TestUtils.waitXms;
 
 @ControllerConfiguration(generationAwareEventProcessing = false)
@@ -36,7 +37,7 @@ public class SubResourceTestCustomReconciler
 
     ensureStatusExists(resource);
     resource.getStatus().setState(SubResourceTestCustomResourceStatus.State.SUCCESS);
-    waitXms(500);
+    waitXms(RECONCILER_MIN_EXEC_TIME);
     return UpdateControl.updateStatus(resource);
   }
 

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/subresource/SubResourceTestCustomReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/subresource/SubResourceTestCustomReconciler.java
@@ -12,6 +12,8 @@ import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import io.javaoperatorsdk.operator.support.TestExecutionInfoProvider;
 
+import static io.javaoperatorsdk.operator.support.TestUtils.waitXms;
+
 @ControllerConfiguration(generationAwareEventProcessing = false)
 public class SubResourceTestCustomReconciler
     implements Reconciler<SubResourceTestCustomResource>, TestExecutionInfoProvider {
@@ -21,6 +23,7 @@ public class SubResourceTestCustomReconciler
   private static final Logger log =
       LoggerFactory.getLogger(SubResourceTestCustomReconciler.class);
   private final AtomicInteger numberOfExecutions = new AtomicInteger(0);
+
 
   @Override
   public UpdateControl<SubResourceTestCustomResource> reconcile(
@@ -33,7 +36,7 @@ public class SubResourceTestCustomReconciler
 
     ensureStatusExists(resource);
     resource.getStatus().setState(SubResourceTestCustomResourceStatus.State.SUCCESS);
-
+    waitXms(500);
     return UpdateControl.updateStatus(resource);
   }
 

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/subresource/SubResourceTestCustomReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/subresource/SubResourceTestCustomReconciler.java
@@ -12,12 +12,13 @@ import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import io.javaoperatorsdk.operator.support.TestExecutionInfoProvider;
 
-import static io.javaoperatorsdk.operator.SubResourceUpdateIT.RECONCILER_MIN_EXEC_TIME;
 import static io.javaoperatorsdk.operator.support.TestUtils.waitXms;
 
 @ControllerConfiguration(generationAwareEventProcessing = false)
 public class SubResourceTestCustomReconciler
     implements Reconciler<SubResourceTestCustomResource>, TestExecutionInfoProvider {
+
+  public static final int RECONCILER_MIN_EXEC_TIME = 300;
 
   public static final String FINALIZER_NAME =
       ReconcilerUtils.getDefaultFinalizerName(SubResourceTestCustomResource.class);


### PR DESCRIPTION
A not very elegant fix for this integration test, that fails some times:
`SubResourceUpdateIT.updateCustomResourceAfterSubResourceChange:89`
https://github.com/java-operator-sdk/java-operator-sdk/runs/5512866209?check_suite_focus=true