### PR TITLE
fix: retrieve DependentResource based on name instead of class

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/AggregatedOperatorException.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/AggregatedOperatorException.java
@@ -1,0 +1,23 @@
+package io.javaoperatorsdk.operator;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class AggregatedOperatorException extends OperatorException {
+  private final List<Exception> causes;
+
+  public AggregatedOperatorException(String message, Exception... exceptions) {
+    super(message);
+    this.causes = exceptions != null ? Arrays.asList(exceptions) : Collections.emptyList();
+  }
+
+  public AggregatedOperatorException(String message, List<Exception> exceptions) {
+    super(message);
+    this.causes = exceptions != null ? exceptions : Collections.emptyList();
+  }
+
+  public List<Exception> getAggregatedExceptions() {
+    return causes;
+  }
+}

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/AnnotationControllerConfiguration.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/AnnotationControllerConfiguration.java
@@ -1,9 +1,9 @@
 package io.javaoperatorsdk.operator.api.config;
 
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -26,7 +26,7 @@ public class AnnotationControllerConfiguration<R extends HasMetadata>
 
   protected final Reconciler<R> reconciler;
   private final ControllerConfiguration annotation;
-  private List<DependentResourceSpec<?, ?>> specs;
+  private Map<String, DependentResourceSpec<?, ?>> specs;
 
   public AnnotationControllerConfiguration(Reconciler<R> reconciler) {
     this.reconciler = reconciler;
@@ -135,15 +135,15 @@ public class AnnotationControllerConfiguration<R extends HasMetadata>
 
   @SuppressWarnings({"rawtypes", "unchecked"})
   @Override
-  public List<DependentResourceSpec<?, ?>> getDependentResources() {
+  public Map<String, DependentResourceSpec<?, ?>> getDependentResources() {
     if (specs == null) {
       final var dependents =
           valueOrDefault(annotation, ControllerConfiguration::dependents, new Dependent[] {});
       if (dependents.length == 0) {
-        return Collections.emptyList();
+        return Collections.emptyMap();
       }
 
-      specs = new ArrayList<>(dependents.length);
+      specs = new HashMap<>(dependents.length);
       for (Dependent dependent : dependents) {
         Object config = null;
         final Class<? extends DependentResource> dependentType = dependent.type();
@@ -159,9 +159,18 @@ public class AnnotationControllerConfiguration<R extends HasMetadata>
           config =
               new KubernetesDependentResourceConfig(namespaces, labelSelector);
         }
-        specs.add(new DependentResourceSpec(dependentType, config));
+        var name = dependent.name();
+        if (name.isBlank()) {
+          name = DependentResource.defaultNameFor(dependentType);
+        }
+        final DependentResourceSpec<?, ?> spec = specs.get(name);
+        if (spec != null) {
+          throw new IllegalArgumentException(
+              "A DependentResource named: " + name + " already exists: " + spec);
+        }
+        specs.put(name, new DependentResourceSpec(dependentType, config, name));
       }
     }
-    return specs;
+    return Collections.unmodifiableMap(specs);
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ControllerConfiguration.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ControllerConfiguration.java
@@ -2,7 +2,7 @@ package io.javaoperatorsdk.operator.api.config;
 
 import java.time.Duration;
 import java.util.Collections;
-import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
@@ -46,8 +46,8 @@ public interface ControllerConfiguration<R extends HasMetadata> extends Resource
     return ResourceEventFilters.passthrough();
   }
 
-  default List<DependentResourceSpec<?, ?>> getDependentResources() {
-    return Collections.emptyList();
+  default Map<String, DependentResourceSpec<?, ?>> getDependentResources() {
+    return Collections.emptyMap();
   }
 
   default Optional<Duration> reconciliationMaxInterval() {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ControllerConfigurationOverrider.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ControllerConfigurationOverrider.java
@@ -90,7 +90,7 @@ public class ControllerConfigurationOverrider<R extends HasMetadata> {
     return this;
   }
 
-  public ControllerConfigurationOverrider<R> replaceNamedDependentResourceConfig(String name,
+  public ControllerConfigurationOverrider<R> replacingNamedDependentResourceConfig(String name,
       Object dependentResourceConfig) {
     final var currentConfig = dependentResourceSpecs.get(name);
     if (currentConfig == null) {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ControllerConfigurationOverrider.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ControllerConfigurationOverrider.java
@@ -1,6 +1,7 @@
 package io.javaoperatorsdk.operator.api.config;
 
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -31,7 +32,8 @@ public class ControllerConfigurationOverrider<R extends HasMetadata> {
     labelSelector = original.getLabelSelector();
     customResourcePredicate = original.getEventFilter();
     reconciliationMaxInterval = original.reconciliationMaxInterval().orElse(null);
-    dependentResourceSpecs = original.getDependentResources();
+    // make the original specs modifiable
+    dependentResourceSpecs = new HashMap<>(original.getDependentResources());
     this.original = original;
   }
 
@@ -88,7 +90,8 @@ public class ControllerConfigurationOverrider<R extends HasMetadata> {
     return this;
   }
 
-  public void replaceNamedDependentResourceConfig(String name, Object dependentResourceConfig) {
+  public ControllerConfigurationOverrider<R> replaceNamedDependentResourceConfig(String name,
+      Object dependentResourceConfig) {
     final var currentConfig = dependentResourceSpecs.get(name);
     if (currentConfig == null) {
       throw new IllegalArgumentException("Cannot find a DependentResource named: " + name);
@@ -97,6 +100,7 @@ public class ControllerConfigurationOverrider<R extends HasMetadata> {
     dependentResourceSpecs.put(name,
         new DependentResourceSpec(currentConfig.getDependentResourceClass(),
             dependentResourceConfig, name));
+    return this;
   }
 
   public ControllerConfiguration<R> build() {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/DefaultControllerConfiguration.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/DefaultControllerConfiguration.java
@@ -2,7 +2,7 @@ package io.javaoperatorsdk.operator.api.config;
 
 import java.time.Duration;
 import java.util.Collections;
-import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -10,7 +10,6 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.javaoperatorsdk.operator.api.config.dependent.DependentResourceSpec;
 import io.javaoperatorsdk.operator.processing.event.source.controller.ResourceEventFilter;
 
-@SuppressWarnings("rawtypes")
 public class DefaultControllerConfiguration<R extends HasMetadata>
     extends DefaultResourceConfiguration<R>
     implements ControllerConfiguration<R> {
@@ -22,7 +21,7 @@ public class DefaultControllerConfiguration<R extends HasMetadata>
   private final boolean generationAware;
   private final RetryConfiguration retryConfiguration;
   private final ResourceEventFilter<R> resourceEventFilter;
-  private final List<DependentResourceSpec<?, ?>> dependents;
+  private final Map<String, DependentResourceSpec<?, ?>> dependents;
   private final Duration reconciliationMaxInterval;
 
   // NOSONAR constructor is meant to provide all information
@@ -38,7 +37,7 @@ public class DefaultControllerConfiguration<R extends HasMetadata>
       ResourceEventFilter<R> resourceEventFilter,
       Class<R> resourceClass,
       Duration reconciliationMaxInterval,
-      List<DependentResourceSpec<?, ?>> dependents) {
+      Map<String, DependentResourceSpec<?, ?>> dependents) {
     super(labelSelector, resourceClass, namespaces);
     this.associatedControllerClassName = associatedControllerClassName;
     this.name = name;
@@ -52,7 +51,7 @@ public class DefaultControllerConfiguration<R extends HasMetadata>
             : retryConfiguration;
     this.resourceEventFilter = resourceEventFilter;
 
-    this.dependents = dependents != null ? dependents : Collections.emptyList();
+    this.dependents = dependents != null ? dependents : Collections.emptyMap();
   }
 
   @Override
@@ -91,7 +90,7 @@ public class DefaultControllerConfiguration<R extends HasMetadata>
   }
 
   @Override
-  public List<DependentResourceSpec<?, ?>> getDependentResources() {
+  public Map<String, DependentResourceSpec<?, ?>> getDependentResources() {
     return dependents;
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/dependent/DependentResourceSpec.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/dependent/DependentResourceSpec.java
@@ -1,5 +1,6 @@
 package io.javaoperatorsdk.operator.api.config.dependent;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
@@ -10,9 +11,13 @@ public class DependentResourceSpec<T extends DependentResource<?, ?>, C> {
 
   private final C dependentResourceConfig;
 
-  public DependentResourceSpec(Class<T> dependentResourceClass, C dependentResourceConfig) {
+  private final String name;
+
+  public DependentResourceSpec(Class<T> dependentResourceClass, C dependentResourceConfig,
+      String name) {
     this.dependentResourceClass = dependentResourceClass;
     this.dependentResourceConfig = dependentResourceConfig;
+    this.name = name;
   }
 
   public Class<T> getDependentResourceClass() {
@@ -21,5 +26,33 @@ public class DependentResourceSpec<T extends DependentResource<?, ?>, C> {
 
   public Optional<C> getDependentResourceConfiguration() {
     return Optional.ofNullable(dependentResourceConfig);
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String toString() {
+    return "DependentResourceSpec{ name='" + name +
+        "', type=" + dependentResourceClass.getCanonicalName() +
+        ", config=" + dependentResourceConfig + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DependentResourceSpec<?, ?> that = (DependentResourceSpec<?, ?>) o;
+    return name.equals(that.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name);
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/DefaultContext.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/DefaultContext.java
@@ -20,8 +20,7 @@ public class DefaultContext<P extends HasMetadata> implements Context<P> {
     this.controller = controller;
     this.primaryResource = primaryResource;
     this.controllerConfiguration = controller.getConfiguration();
-    this.managedDependentResourceContext = new ManagedDependentResourceContext(
-        controller.getDependents());
+    this.managedDependentResourceContext = new ManagedDependentResourceContext();
   }
 
   @Override

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/EventSourceInitializer.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/EventSourceInitializer.java
@@ -1,6 +1,6 @@
 package io.javaoperatorsdk.operator.api.reconciler;
 
-import java.util.List;
+import java.util.Map;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.javaoperatorsdk.operator.processing.event.source.EventSource;
@@ -20,6 +20,6 @@ public interface EventSourceInitializer<P extends HasMetadata> {
    *        sources
    * @return list of event sources to register
    */
-  List<EventSource> prepareEventSources(EventSourceContext<P> context);
+  Map<String, EventSource> prepareEventSources(EventSourceContext<P> context);
 
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/Dependent.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/Dependent.java
@@ -1,6 +1,11 @@
 package io.javaoperatorsdk.operator.api.reconciler.dependent;
 
+import static io.javaoperatorsdk.operator.api.reconciler.Constants.EMPTY_STRING;
+
 public @interface Dependent {
 
+  @SuppressWarnings("rawtypes")
   Class<? extends DependentResource> type();
+
+  String name() default EMPTY_STRING;
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/DependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/DependentResource.java
@@ -12,7 +12,8 @@ public interface DependentResource<R, P extends HasMetadata> {
 
   Class<R> resourceType();
 
-  default String name() {
-    return getClass().getCanonicalName();
+  @SuppressWarnings("rawtypes")
+  static String defaultNameFor(Class<? extends DependentResource> dependentResourceClass) {
+    return dependentResourceClass.getCanonicalName();
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/DependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/DependentResource.java
@@ -9,4 +9,10 @@ public interface DependentResource<R, P extends HasMetadata> {
   ReconcileResult<R> reconcile(P primary, Context<P> context);
 
   Optional<R> getResource(P primaryResource);
+
+  Class<R> resourceType();
+
+  default String name() {
+    return getClass().getCanonicalName();
+  }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/DependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/DependentResource.java
@@ -5,13 +5,47 @@ import java.util.Optional;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 
+/**
+ * An interface to implement and provide dependent resource support.
+ *
+ * @param <R> the dependent resource type
+ * @param <P> the associated primary resource type
+ */
 public interface DependentResource<R, P extends HasMetadata> {
+
+  /**
+   * Reconciles the dependent resource given the desired primary state
+   *
+   * @param primary the primary resource for which we want to reconcile the dependent state
+   * @param context {@link Context} providing useful contextual information
+   * @return a {@link ReconcileResult} providing information about the reconciliation result
+   */
   ReconcileResult<R> reconcile(P primary, Context<P> context);
 
+  /**
+   * Retrieves the dependent resource associated with the specified primary one
+   *
+   * @param primaryResource the primary resource for which we want to retrieve the secondary
+   *        resource
+   * @return an {@link Optional} containing the secondary resource or {@link Optional#empty()} if it
+   *         doesn't exist
+   */
   Optional<R> getResource(P primaryResource);
 
+  /**
+   * Retrieves the resource type associated with this DependentResource
+   *
+   * @return the resource type associated with this DependentResource
+   */
   Class<R> resourceType();
 
+  /**
+   * Computes a default name for the specified DependentResource class
+   *
+   * @param dependentResourceClass the DependentResource class for which we want to compute a
+   *        default name
+   * @return the default name for the specified DependentResource class
+   */
   @SuppressWarnings("rawtypes")
   static String defaultNameFor(Class<? extends DependentResource> dependentResourceClass) {
     return dependentResourceClass.getCanonicalName();

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/DependentResourceFactory.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/DependentResourceFactory.java
@@ -7,12 +7,16 @@ import io.javaoperatorsdk.operator.api.config.dependent.DependentResourceSpec;
 public interface DependentResourceFactory {
 
   default <T extends DependentResource<?, ?>> T createFrom(DependentResourceSpec<T, ?> spec) {
+    return createFrom(spec.getDependentResourceClass());
+  }
+
+  default <T extends DependentResource<?, ?>> T createFrom(Class<T> dependentResourceClass) {
     try {
-      return spec.getDependentResourceClass().getConstructor().newInstance();
+      return dependentResourceClass.getConstructor().newInstance();
     } catch (InstantiationException | NoSuchMethodException | IllegalAccessException
         | InvocationTargetException e) {
       throw new IllegalArgumentException("Cannot instantiate DependentResource "
-          + spec.getDependentResourceClass().getCanonicalName(), e);
+          + dependentResourceClass.getCanonicalName(), e);
     }
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/ReconcileResult.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/ReconcileResult.java
@@ -2,26 +2,44 @@ package io.javaoperatorsdk.operator.api.reconciler.dependent;
 
 import java.util.Optional;
 
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.javaoperatorsdk.operator.processing.event.ResourceID;
+
 public class ReconcileResult<R> {
 
   private final R resource;
   private final Operation operation;
+  private final Exception error;
 
   public static <T> ReconcileResult<T> resourceCreated(T resource) {
-    return new ReconcileResult<>(resource, Operation.CREATED);
+    return new ReconcileResult<>(resource, Operation.CREATED, null);
   }
 
   public static <T> ReconcileResult<T> resourceUpdated(T resource) {
-    return new ReconcileResult<>(resource, Operation.UPDATED);
+    return new ReconcileResult<>(resource, Operation.UPDATED, null);
   }
 
   public static <T> ReconcileResult<T> noOperation(T resource) {
-    return new ReconcileResult<>(resource, Operation.NONE);
+    return new ReconcileResult<>(resource, Operation.NONE, null);
   }
 
-  private ReconcileResult(R resource, Operation operation) {
+  public static <T> ReconcileResult<T> error(T resource, Exception error) {
+    return new ReconcileResult<>(resource, Operation.ERROR, error);
+  }
+
+  @Override
+  public String toString() {
+    return getResource()
+        .map(r -> r instanceof HasMetadata ? ResourceID.fromResource((HasMetadata) r) : r)
+        .orElse("no resource")
+        + " -> " + operation
+        + getError().map(e -> " (" + e.getMessage() + ")").orElse("");
+  }
+
+  private ReconcileResult(R resource, Operation operation, Exception error) {
     this.resource = resource;
     this.operation = operation;
+    this.error = error;
   }
 
   public Optional<R> getResource() {
@@ -32,7 +50,11 @@ public class ReconcileResult<R> {
     return operation;
   }
 
+  public Optional<Exception> getError() {
+    return Optional.ofNullable(error);
+  }
+
   public enum Operation {
-    CREATED, UPDATED, NONE
+    CREATED, UPDATED, NONE, ERROR
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/ReconcileResult.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/ReconcileResult.java
@@ -9,22 +9,17 @@ public class ReconcileResult<R> {
 
   private final R resource;
   private final Operation operation;
-  private final Exception error;
 
   public static <T> ReconcileResult<T> resourceCreated(T resource) {
-    return new ReconcileResult<>(resource, Operation.CREATED, null);
+    return new ReconcileResult<>(resource, Operation.CREATED);
   }
 
   public static <T> ReconcileResult<T> resourceUpdated(T resource) {
-    return new ReconcileResult<>(resource, Operation.UPDATED, null);
+    return new ReconcileResult<>(resource, Operation.UPDATED);
   }
 
   public static <T> ReconcileResult<T> noOperation(T resource) {
-    return new ReconcileResult<>(resource, Operation.NONE, null);
-  }
-
-  public static <T> ReconcileResult<T> error(T resource, Exception error) {
-    return new ReconcileResult<>(resource, Operation.ERROR, error);
+    return new ReconcileResult<>(resource, Operation.NONE);
   }
 
   @Override
@@ -32,14 +27,12 @@ public class ReconcileResult<R> {
     return getResource()
         .map(r -> r instanceof HasMetadata ? ResourceID.fromResource((HasMetadata) r) : r)
         .orElse("no resource")
-        + " -> " + operation
-        + getError().map(e -> " (" + e.getMessage() + ")").orElse("");
+        + " -> " + operation;
   }
 
-  private ReconcileResult(R resource, Operation operation, Exception error) {
+  private ReconcileResult(R resource, Operation operation) {
     this.resource = resource;
     this.operation = operation;
-    this.error = error;
   }
 
   public Optional<R> getResource() {
@@ -50,11 +43,7 @@ public class ReconcileResult<R> {
     return operation;
   }
 
-  public Optional<Exception> getError() {
-    return Optional.ofNullable(error);
-  }
-
   public enum Operation {
-    CREATED, UPDATED, NONE, ERROR
+    CREATED, UPDATED, NONE
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/ResourceTypeAware.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/ResourceTypeAware.java
@@ -1,6 +1,0 @@
-package io.javaoperatorsdk.operator.api.reconciler.dependent;
-
-public interface ResourceTypeAware<R> {
-
-  Class<R> resourceType();
-}

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/managed/ManagedDependentResourceContext.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/managed/ManagedDependentResourceContext.java
@@ -94,10 +94,7 @@ public class ManagedDependentResourceContext {
    */
   @SuppressWarnings({"unchecked"})
   public <T> DependentResource<T, ?> getDependentResource(String name, Class<T> resourceClass) {
-    var dependentResource = dependentResources.get(name);
-    if (dependentResource == null) {
-      throw new OperatorException("No dependent resource found with name: " + name);
-    }
+    DependentResource dependentResource = getDependentResource(name);
     final var actual = dependentResource.resourceType();
     if (!actual.equals(resourceClass)) {
       throw new OperatorException(
@@ -105,5 +102,25 @@ public class ManagedDependentResourceContext {
               + actual.getName() + " instead of: " + resourceClass.getName());
     }
     return dependentResource;
+  }
+
+  private DependentResource getDependentResource(String name) {
+    var dependentResource = dependentResources.get(name);
+    if (dependentResource == null) {
+      throw new OperatorException("No dependent resource found with name: " + name);
+    }
+    return dependentResource;
+  }
+
+  @SuppressWarnings("unchecked")
+  public <T extends DependentResource> T getAdaptedDependentResource(String name,
+      Class<T> dependentResourceClass) {
+    DependentResource dependentResource = getDependentResource(name);
+    if (dependentResourceClass.isInstance(dependentResource)) {
+      return (T) dependentResource;
+    } else {
+      throw new IllegalArgumentException("Dependent resource associated with name: " + name
+          + " is not adaptable to type: " + dependentResourceClass.getCanonicalName());
+    }
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/managed/ManagedDependentResourceException.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/managed/ManagedDependentResourceException.java
@@ -1,0 +1,17 @@
+package io.javaoperatorsdk.operator.api.reconciler.dependent.managed;
+
+import io.javaoperatorsdk.operator.OperatorException;
+
+public class ManagedDependentResourceException extends OperatorException {
+  private final String associatedDependentName;
+
+  public ManagedDependentResourceException(String associatedDependentName, String message,
+      Throwable cause) {
+    super(message, cause);
+    this.associatedDependentName = associatedDependentName;
+  }
+
+  public String getAssociatedDependentName() {
+    return associatedDependentName;
+  }
+}

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/Controller.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/Controller.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -196,15 +197,16 @@ public class Controller<P extends HasMetadata>
                 log.info("Reconciled dependent '{}' -> {}", name, reconcileResult.getOperation());
               } catch (Exception e) {
                 final var message = e.getMessage();
-                exceptions.add(new ManagedDependentResourceException(name,
-                    "Couldn't reconcile DependentResource named: " + name + ", cause: " + message,
-                    e));
-                log.warn("Error reconciling dependent '{}': {}", name, message);
+                exceptions.add(new ManagedDependentResourceException(
+                    name, "Error reconciling dependent '" + name + "': " + message, e));
               }
             });
 
             if (!exceptions.isEmpty()) {
-              throw new AggregatedOperatorException("One or more DependentResource(s) failed",
+              throw new AggregatedOperatorException("One or more DependentResource(s) failed:\n" +
+                  exceptions.stream()
+                      .map(e -> "\t\t- " + e.getMessage())
+                      .collect(Collectors.joining("\n")),
                   exceptions);
             }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/AbstractDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/AbstractDependentResource.java
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.Deleter;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.EventSourceProvider;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.RecentOperationCacheFiller;

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/AbstractDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/AbstractDependentResource.java
@@ -5,7 +5,11 @@ import org.slf4j.LoggerFactory;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
-import io.javaoperatorsdk.operator.api.reconciler.dependent.*;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.EventSourceProvider;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.RecentOperationCacheFiller;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.RecentOperationEventFilter;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.ReconcileResult;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 
 public abstract class AbstractDependentResource<R, P extends HasMetadata>
@@ -31,6 +35,8 @@ public abstract class AbstractDependentResource<R, P extends HasMetadata>
       if (maybeActual.isEmpty()) {
         if (creatable) {
           var desired = desired(primary, context);
+          log.info("Creating {} for primary {}", desired.getClass().getSimpleName(),
+              ResourceID.fromResource(primary));
           log.debug("Creating dependent {} for primary {}", desired, primary);
           var createdResource = handleCreate(desired, primary, context);
           return ReconcileResult.resourceCreated(createdResource);
@@ -41,6 +47,8 @@ public abstract class AbstractDependentResource<R, P extends HasMetadata>
           final var match = updater.match(actual, primary, context);
           if (!match.matched()) {
             final var desired = match.computedDesired().orElse(desired(primary, context));
+            log.info("Updating {} for primary {}", desired.getClass().getSimpleName(),
+                ResourceID.fromResource(primary));
             log.debug("Updating dependent {} for primary {}", desired, primary);
             var updatedResource = handleUpdate(actual, desired, primary, context);
             return ReconcileResult.resourceUpdated(updatedResource);

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/external/AbstractCachingDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/external/AbstractCachingDependentResource.java
@@ -4,14 +4,13 @@ import java.util.Optional;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.EventSourceProvider;
-import io.javaoperatorsdk.operator.api.reconciler.dependent.ResourceTypeAware;
 import io.javaoperatorsdk.operator.processing.dependent.AbstractDependentResource;
 import io.javaoperatorsdk.operator.processing.event.ExternalResourceCachingEventSource;
 import io.javaoperatorsdk.operator.processing.event.source.EventSource;
 
 public abstract class AbstractCachingDependentResource<R, P extends HasMetadata>
     extends AbstractDependentResource<R, P>
-    implements EventSourceProvider<P>, ResourceTypeAware<R> {
+    implements EventSourceProvider<P> {
 
   protected ExternalResourceCachingEventSource<R, P> eventSource;
   private final Class<R> resourceType;

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResource.java
@@ -15,7 +15,6 @@ import io.javaoperatorsdk.operator.api.config.informer.InformerConfiguration;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.EventSourceProvider;
-import io.javaoperatorsdk.operator.api.reconciler.dependent.ResourceTypeAware;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.managed.DependentResourceConfigurator;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.managed.KubernetesClientAware;
 import io.javaoperatorsdk.operator.processing.dependent.AbstractDependentResource;
@@ -30,7 +29,7 @@ import io.javaoperatorsdk.operator.processing.event.source.informer.Mappers;
 
 public abstract class KubernetesDependentResource<R extends HasMetadata, P extends HasMetadata>
     extends AbstractDependentResource<R, P>
-    implements KubernetesClientAware, EventSourceProvider<P>, ResourceTypeAware<R>,
+    implements KubernetesClientAware, EventSourceProvider<P>,
     DependentResourceConfigurator<KubernetesDependentResourceConfig> {
 
   private static final Logger log = LoggerFactory.getLogger(KubernetesDependentResource.class);

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventSources.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventSources.java
@@ -1,0 +1,142 @@
+package io.javaoperatorsdk.operator.processing.event;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentNavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.stream.Stream;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.javaoperatorsdk.operator.processing.Controller;
+import io.javaoperatorsdk.operator.processing.event.source.EventSource;
+import io.javaoperatorsdk.operator.processing.event.source.ResourceEventSource;
+import io.javaoperatorsdk.operator.processing.event.source.controller.ControllerResourceEventSource;
+import io.javaoperatorsdk.operator.processing.event.source.timer.TimerEventSource;
+
+class EventSources<R extends HasMetadata> implements Iterable<NamedEventSource> {
+
+  private final ConcurrentNavigableMap<String, Map<String, EventSource>> sources =
+      new ConcurrentSkipListMap<>();
+  private final TimerEventSource<R> retryAndRescheduleTimerEventSource = new TimerEventSource<>();
+  private ControllerResourceEventSource<R> controllerResourceEventSource;
+
+
+  ControllerResourceEventSource<R> initControllerEventSource(Controller<R> controller) {
+    controllerResourceEventSource = new ControllerResourceEventSource<>(controller);
+    return controllerResourceEventSource;
+  }
+
+  ControllerResourceEventSource<R> controllerResourceEventSource() {
+    return controllerResourceEventSource;
+  }
+
+  TimerEventSource<R> retryEventSource() {
+    return retryAndRescheduleTimerEventSource;
+  }
+
+  @Override
+  public Iterator<NamedEventSource> iterator() {
+    return flatMappedSources().iterator();
+  }
+
+  Stream<NamedEventSource> flatMappedSources() {
+    return sources.values().stream().flatMap(c -> c.entrySet().stream()
+        .map(esEntry -> new NamedEventSource(esEntry.getValue(), esEntry.getKey())));
+  }
+
+  public void clear() {
+    sources.clear();
+  }
+
+  public boolean contains(String name, EventSource source) {
+    final var eventSources = sources.get(keyFor(source));
+    if (eventSources == null || eventSources.isEmpty()) {
+      return false;
+    }
+    return eventSources.containsKey(name);
+  }
+
+  public void add(String name, EventSource eventSource) {
+    if (contains(name, eventSource)) {
+      throw new IllegalArgumentException("An event source is already registered for the "
+          + keyAsString(getDependentType(eventSource), name)
+          + " class/name combination");
+    }
+    sources.computeIfAbsent(keyFor(eventSource), k -> new HashMap<>()).put(name, eventSource);
+  }
+
+  @SuppressWarnings("rawtypes")
+  private Class<?> getDependentType(EventSource source) {
+    return source instanceof ResourceEventSource
+        ? ((ResourceEventSource) source).getResourceClass()
+        : source.getClass();
+  }
+
+  private String keyFor(EventSource source) {
+    return keyFor(getDependentType(source));
+  }
+
+  private String keyFor(Class<?> dependentType) {
+    var key = dependentType.getCanonicalName();
+
+    // make sure timer event source is started first, then controller event source
+    // this is needed so that these sources are set when informer sources start so that events can
+    // properly be processed
+    if (controllerResourceEventSource != null
+        && key.equals(controllerResourceEventSource.getResourceClass().getCanonicalName())) {
+      key = 1 + "-" + key;
+    } else if (key.equals(retryAndRescheduleTimerEventSource.getClass().getCanonicalName())) {
+      key = 0 + "-" + key;
+    }
+    return key;
+  }
+
+  @SuppressWarnings("unchecked")
+  public <S> ResourceEventSource<R, S> get(Class<S> dependentType, String name) {
+    final var sourcesForType = sources.get(keyFor(dependentType));
+    if (sourcesForType == null || sourcesForType.isEmpty()) {
+      return null;
+    }
+
+    final var size = sourcesForType.size();
+    final EventSource source;
+    if (size == 1) {
+      source = sourcesForType.values().stream().findFirst().orElse(null);
+    } else {
+      if (name == null || name.isBlank()) {
+        throw new IllegalArgumentException("There are multiple EventSources registered for type "
+            + dependentType.getCanonicalName()
+            + ", you need to provide a name to specify which EventSource you want to query. Known names: "
+            + String.join(",", sourcesForType.keySet()));
+      }
+      source = sourcesForType.get(name);
+
+      if (source == null) {
+        return null;
+      }
+    }
+
+    if (!(source instanceof ResourceEventSource)) {
+      throw new IllegalArgumentException(source + " associated with "
+          + keyAsString(dependentType, name) + " is not a "
+          + ResourceEventSource.class.getSimpleName());
+    }
+    final var res = (ResourceEventSource<R, S>) source;
+    final var resourceClass = res.getResourceClass();
+    if (!resourceClass.isAssignableFrom(dependentType)) {
+      throw new IllegalArgumentException(source + " associated with "
+          + keyAsString(dependentType, name)
+          + " is handling " + resourceClass.getName() + " resources but asked for "
+          + dependentType.getName());
+    }
+    return res;
+  }
+
+  @SuppressWarnings("rawtypes")
+  private String keyAsString(Class dependentType, String name) {
+    return name != null && name.length() > 0
+        ? "(" + dependentType.getName() + ", " + name + ")"
+        : dependentType.getName();
+  }
+}

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/NamedEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/NamedEventSource.java
@@ -1,0 +1,43 @@
+package io.javaoperatorsdk.operator.processing.event;
+
+import io.javaoperatorsdk.operator.OperatorException;
+import io.javaoperatorsdk.operator.processing.event.source.EventSource;
+
+class NamedEventSource implements EventSource {
+
+  private final EventSource original;
+  private final String name;
+
+  NamedEventSource(EventSource original, String name) {
+    this.original = original;
+    this.name = name;
+  }
+
+  @Override
+  public void start() throws OperatorException {
+    original.start();
+  }
+
+  @Override
+  public void stop() throws OperatorException {
+    original.stop();
+  }
+
+  @Override
+  public void setEventHandler(EventHandler handler) {
+    original.setEventHandler(handler);
+  }
+
+  public String name() {
+    return name;
+  }
+
+  @Override
+  public String toString() {
+    return original + " named: '" + name + "'}";
+  }
+
+  public EventSource original() {
+    return original;
+  }
+}

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/EventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/EventSource.java
@@ -13,20 +13,14 @@ import io.javaoperatorsdk.operator.processing.event.EventHandler;
 public interface EventSource extends LifecycleAware {
 
   /**
-   * An optional name for your EventSource. This is only required if you need to register multiple
-   * EventSources for the same resource type (e.g. {@code Deployment}).
-   *
-   * @return the name associated with this EventSource
-   */
-  default String name() {
-    return getClass().getCanonicalName();
-  }
-
-  /**
    * Sets the {@link EventHandler} that is linked to your reconciler when this EventSource is
    * registered.
    *
    * @param handler the {@link EventHandler} associated with your reconciler
    */
   void setEventHandler(EventHandler handler);
+
+  static String defaultNameFor(EventSource source) {
+    return source.getClass().getCanonicalName();
+  }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSource.java
@@ -97,7 +97,7 @@ public class InformerEventSource<R extends HasMetadata, P extends HasMetadata>
   private synchronized void onAddOrUpdate(String operation, R newObject, Runnable superOnOp) {
     var resourceID = ResourceID.fromResource(newObject);
     if (eventRecorder.isRecordingFor(resourceID)) {
-      log.info("Recording event for: " + resourceID);
+      log.debug("Recording event for: {}", resourceID);
       eventRecorder.recordEvent(newObject);
       return;
     }
@@ -224,7 +224,7 @@ public class InformerEventSource<R extends HasMetadata, P extends HasMetadata>
   @Override
   public synchronized void prepareForCreateOrUpdateEventFiltering(ResourceID resourceID,
       R resource) {
-    log.info("Starting event recording for: {}", resourceID);
+    log.debug("Starting event recording for: {}", resourceID);
     eventRecorder.startEventRecording(resourceID);
   }
 
@@ -237,7 +237,7 @@ public class InformerEventSource<R extends HasMetadata, P extends HasMetadata>
   @Override
   public synchronized void cleanupOnCreateOrUpdateEventFiltering(ResourceID resourceID,
       R resource) {
-    log.info("Stopping event recording for: {}", resourceID);
+    log.debug("Stopping event recording for: {}", resourceID);
     eventRecorder.stopEventRecording(resourceID);
   }
 

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/config/ControllerConfigurationOverriderTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/config/ControllerConfigurationOverriderTest.java
@@ -42,7 +42,7 @@ class ControllerConfigurationOverriderTest {
     final var overriddenNS = "newNS";
     final var labelSelector = "foo=bar";
     final var overridden = ControllerConfigurationOverrider.override(configuration)
-        .replaceNamedDependentResourceConfig(
+        .replacingNamedDependentResourceConfig(
             DependentResource.defaultNameFor(ReadOnlyDependent.class),
             new KubernetesDependentResourceConfig(true, new String[] {overriddenNS}, labelSelector))
         .build();

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/config/ControllerConfigurationOverriderTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/config/ControllerConfigurationOverriderTest.java
@@ -1,0 +1,77 @@
+package io.javaoperatorsdk.operator.api.config;
+
+import org.junit.jupiter.api.Test;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
+import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.Dependent;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependentResource;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependentResourceConfig;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ControllerConfigurationOverriderTest {
+
+  @Test
+  void replaceNamedDependentResourceConfigShouldWork() {
+    var configuration = new AnnotationControllerConfiguration<>(new OneDepReconciler());
+    var dependents = configuration.getDependentResources();
+    assertFalse(dependents.isEmpty());
+    assertEquals(1, dependents.size());
+    final var dependentResourceName = DependentResource.defaultNameFor(ReadOnlyDependent.class);
+    assertTrue(dependents.containsKey(dependentResourceName));
+    var dependentSpec = dependents.get(dependentResourceName);
+    assertEquals(ReadOnlyDependent.class, dependentSpec.getDependentResourceClass());
+    var maybeConfig = dependentSpec.getDependentResourceConfiguration();
+    assertTrue(maybeConfig.isPresent());
+    assertTrue(maybeConfig.get() instanceof KubernetesDependentResourceConfig);
+    var config = (KubernetesDependentResourceConfig) maybeConfig.orElseThrow();
+    // check that the DependentResource inherits the controller's configuration if applicable
+    assertEquals(1, config.namespaces().length);
+    assertNull(config.labelSelector());
+    assertEquals(OneDepReconciler.CONFIGURED_NS, config.namespaces()[0]);
+
+    // override the namespaces for the dependent resource
+    final var overriddenNS = "newNS";
+    final var labelSelector = "foo=bar";
+    final var overridden = ControllerConfigurationOverrider.override(configuration)
+        .replaceNamedDependentResourceConfig(
+            DependentResource.defaultNameFor(ReadOnlyDependent.class),
+            new KubernetesDependentResourceConfig(true, new String[] {overriddenNS}, labelSelector))
+        .build();
+    dependents = overridden.getDependentResources();
+    dependentSpec = dependents.get(dependentResourceName);
+    config = (KubernetesDependentResourceConfig) dependentSpec.getDependentResourceConfiguration()
+        .orElseThrow();
+    assertEquals(1, config.namespaces().length);
+    assertEquals(labelSelector, config.labelSelector());
+    assertEquals(overriddenNS, config.namespaces()[0]);
+  }
+
+  @ControllerConfiguration(namespaces = OneDepReconciler.CONFIGURED_NS,
+      dependents = @Dependent(type = ReadOnlyDependent.class))
+  private static class OneDepReconciler implements Reconciler<ConfigMap> {
+
+    private static final String CONFIGURED_NS = "foo";
+
+    @Override
+    public UpdateControl<ConfigMap> reconcile(ConfigMap resource, Context<ConfigMap> context) {
+      return null;
+    }
+  }
+
+  private static class ReadOnlyDependent extends KubernetesDependentResource<ConfigMap, ConfigMap> {
+
+    public ReadOnlyDependent() {
+      super(ConfigMap.class);
+    }
+  }
+
+}

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/config/ControllerConfigurationOverriderTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/config/ControllerConfigurationOverriderTest.java
@@ -44,7 +44,7 @@ class ControllerConfigurationOverriderTest {
     final var overridden = ControllerConfigurationOverrider.override(configuration)
         .replacingNamedDependentResourceConfig(
             DependentResource.defaultNameFor(ReadOnlyDependent.class),
-            new KubernetesDependentResourceConfig(true, new String[] {overriddenNS}, labelSelector))
+            new KubernetesDependentResourceConfig(new String[] {overriddenNS}, labelSelector))
         .build();
     dependents = overridden.getDependentResources();
     dependentSpec = dependents.get(dependentResourceName);

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/config/UtilsTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/config/UtilsTest.java
@@ -101,6 +101,12 @@ class UtilsTest {
     public Optional<Deployment> getResource(TestCustomResource primaryResource) {
       return Optional.empty();
     }
+
+    @Override
+    public Class<Deployment> resourceType() {
+      return Deployment.class;
+    }
+
   }
 
   public static class TestKubernetesDependentResource

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/external/AbstractSimpleDependentResourceTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/external/AbstractSimpleDependentResourceTest.java
@@ -18,7 +18,11 @@ import io.javaoperatorsdk.operator.processing.event.source.UpdatableCache;
 import io.javaoperatorsdk.operator.sample.simple.TestCustomResource;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @SuppressWarnings("unchecked")
 class AbstractSimpleDependentResourceTest {
@@ -135,6 +139,11 @@ class AbstractSimpleDependentResourceTest {
     protected SampleExternalResource desired(TestCustomResource primary,
         Context<TestCustomResource> context) {
       return SampleExternalResource.testResource1();
+    }
+
+    @Override
+    public Class<SampleExternalResource> resourceType() {
+      return SampleExternalResource.class;
     }
   }
 }

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/EventSourceManagerTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/EventSourceManagerTest.java
@@ -1,6 +1,5 @@
 package io.javaoperatorsdk.operator.processing.event;
 
-import java.io.IOException;
 import java.util.Iterator;
 import java.util.Optional;
 import java.util.Set;
@@ -30,6 +29,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@SuppressWarnings({"rawtypes", "unchecked"})
 class EventSourceManagerTest {
 
   private final EventProcessor eventHandler = mock(EventProcessor.class);
@@ -48,7 +48,7 @@ class EventSourceManagerTest {
   }
 
   @Test
-  public void closeShouldCascadeToEventSources() throws IOException {
+  public void closeShouldCascadeToEventSources() {
     EventSource eventSource = mock(EventSource.class);
     EventSource eventSource2 = mock(TimerEventSource.class);
 
@@ -97,23 +97,23 @@ class EventSourceManagerTest {
   @Test
   void shouldNotBePossibleToAddEventSourcesForSameTypeAndName() {
     EventSourceManager manager = initManager();
+    final var name = "name1";
 
     CachingEventSource eventSource = mock(CachingEventSource.class);
     when(eventSource.getResourceClass()).thenReturn(TestCustomResource.class);
-    when(eventSource.name()).thenReturn("name1");
-    manager.registerEventSource(eventSource);
+    manager.registerEventSource(name, eventSource);
 
     eventSource = mock(CachingEventSource.class);
     when(eventSource.getResourceClass()).thenReturn(TestCustomResource.class);
-    when(eventSource.name()).thenReturn("name1");
     final var source = eventSource;
 
     final var exception = assertThrows(OperatorException.class,
-        () -> manager.registerEventSource(source));
+        () -> manager.registerEventSource(name, source));
     final var cause = exception.getCause();
     assertTrue(cause instanceof IllegalArgumentException);
     assertThat(cause.getMessage()).contains(
-        "An event source is already registered for the (io.javaoperatorsdk.operator.sample.simple.TestCustomResource, name1) class/name combination");
+        "An event source is already registered for the (io.javaoperatorsdk.operator.sample.simple.TestCustomResource, "
+            + name + ") class/name combination");
   }
 
   @Test
@@ -122,13 +122,11 @@ class EventSourceManagerTest {
 
     CachingEventSource eventSource = mock(CachingEventSource.class);
     when(eventSource.getResourceClass()).thenReturn(TestCustomResource.class);
-    when(eventSource.name()).thenReturn("name1");
-    manager.registerEventSource(eventSource);
+    manager.registerEventSource("name1", eventSource);
 
     CachingEventSource eventSource2 = mock(CachingEventSource.class);
     when(eventSource2.getResourceClass()).thenReturn(TestCustomResource.class);
-    when(eventSource2.name()).thenReturn("name2");
-    manager.registerEventSource(eventSource2);
+    manager.registerEventSource("name2", eventSource2);
 
     final var exception = assertThrows(IllegalArgumentException.class,
         () -> manager.getResourceEventSourceFor(TestCustomResource.class));

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/createupdateeventfilter/CreateUpdateEventFilterTestReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/createupdateeventfilter/CreateUpdateEventFilterTestReconciler.java
@@ -1,7 +1,7 @@
 package io.javaoperatorsdk.operator.sample.createupdateeventfilter;
 
 import java.util.HashMap;
-import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -9,7 +9,12 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.config.informer.InformerConfiguration;
-import io.javaoperatorsdk.operator.api.reconciler.*;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
+import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
+import io.javaoperatorsdk.operator.api.reconciler.EventSourceInitializer;
+import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import io.javaoperatorsdk.operator.junit.KubernetesClientAware;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import io.javaoperatorsdk.operator.processing.event.source.EventSource;
@@ -94,14 +99,14 @@ public class CreateUpdateEventFilterTestReconciler
   }
 
   @Override
-  public List<EventSource> prepareEventSources(
+  public Map<String, EventSource> prepareEventSources(
       EventSourceContext<CreateUpdateEventFilterTestCustomResource> context) {
     InformerConfiguration<ConfigMap, CreateUpdateEventFilterTestCustomResource> informerConfiguration =
         InformerConfiguration.from(context, ConfigMap.class)
             .withLabelSelector("integrationtest = " + this.getClass().getSimpleName())
             .build();
     informerEventSource = new InformerEventSource<>(informerConfiguration, client);
-    return List.of(informerEventSource);
+    return Map.of("test-informer", informerEventSource);
   }
 
   @Override

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/informereventsource/InformerEventSourceTestCustomReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/informereventsource/InformerEventSourceTestCustomReconciler.java
@@ -1,6 +1,6 @@
 package io.javaoperatorsdk.operator.sample.informereventsource;
 
-import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -9,7 +9,12 @@ import org.slf4j.LoggerFactory;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.javaoperatorsdk.operator.api.config.informer.InformerConfiguration;
-import io.javaoperatorsdk.operator.api.reconciler.*;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
+import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
+import io.javaoperatorsdk.operator.api.reconciler.EventSourceInitializer;
+import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import io.javaoperatorsdk.operator.processing.event.source.EventSource;
 import io.javaoperatorsdk.operator.processing.event.source.informer.InformerEventSource;
 import io.javaoperatorsdk.operator.processing.event.source.informer.Mappers;
@@ -33,7 +38,7 @@ public class InformerEventSourceTestCustomReconciler
   private final AtomicInteger numberOfExecutions = new AtomicInteger(0);
 
   @Override
-  public List<EventSource> prepareEventSources(
+  public Map<String, EventSource> prepareEventSources(
       EventSourceContext<InformerEventSourceTestCustomResource> context) {
 
     InformerConfiguration<ConfigMap, InformerEventSourceTestCustomResource> config =
@@ -41,7 +46,7 @@ public class InformerEventSourceTestCustomReconciler
             .withPrimaryResourcesRetriever(Mappers.fromAnnotation(RELATED_RESOURCE_NAME))
             .build();
 
-    return List.of(new InformerEventSource<>(config, context));
+    return Map.of("test-informer", new InformerEventSource<>(config, context));
   }
 
   @Override

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/standalonedependent/StandaloneDependentTestReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/standalonedependent/StandaloneDependentTestReconciler.java
@@ -1,13 +1,20 @@
 package io.javaoperatorsdk.operator.sample.standalonedependent;
 
-import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.javaoperatorsdk.operator.ReconcilerUtils;
-import io.javaoperatorsdk.operator.api.reconciler.*;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
+import io.javaoperatorsdk.operator.api.reconciler.ErrorStatusHandler;
+import io.javaoperatorsdk.operator.api.reconciler.ErrorStatusUpdateControl;
+import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
+import io.javaoperatorsdk.operator.api.reconciler.EventSourceInitializer;
+import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import io.javaoperatorsdk.operator.junit.KubernetesClientAware;
 import io.javaoperatorsdk.operator.processing.dependent.Creator;
 import io.javaoperatorsdk.operator.processing.dependent.Updater;
@@ -30,9 +37,9 @@ public class StandaloneDependentTestReconciler
   }
 
   @Override
-  public List<EventSource> prepareEventSources(
+  public Map<String, EventSource> prepareEventSources(
       EventSourceContext<StandaloneDependentTestCustomResource> context) {
-    return List.of(deploymentDependent.initEventSource(context));
+    return Map.of("deployment", deploymentDependent.initEventSource(context));
   }
 
   @Override

--- a/sample-operators/mysql-schema/src/main/java/io/javaoperatorsdk/operator/sample/MySQLSchemaOperator.java
+++ b/sample-operators/mysql-schema/src/main/java/io/javaoperatorsdk/operator/sample/MySQLSchemaOperator.java
@@ -35,8 +35,8 @@ public class MySQLSchemaOperator {
 
     // override the default configuration
     operator.register(schemaReconciler,
-        configOverrider -> configOverrider.replaceDependentResourceConfig(
-            SchemaDependentResource.class,
+        configOverrider -> configOverrider.replaceNamedDependentResourceConfig(
+            SchemaDependentResource.NAME,
             new ResourcePollerConfig(300, MySQLDbConfig.loadFromEnvironmentVars())));
     operator.installShutdownHook();
     operator.start();

--- a/sample-operators/mysql-schema/src/main/java/io/javaoperatorsdk/operator/sample/MySQLSchemaOperator.java
+++ b/sample-operators/mysql-schema/src/main/java/io/javaoperatorsdk/operator/sample/MySQLSchemaOperator.java
@@ -35,7 +35,7 @@ public class MySQLSchemaOperator {
 
     // override the default configuration
     operator.register(schemaReconciler,
-        configOverrider -> configOverrider.replaceNamedDependentResourceConfig(
+        configOverrider -> configOverrider.replacingNamedDependentResourceConfig(
             SchemaDependentResource.NAME,
             new ResourcePollerConfig(300, MySQLDbConfig.loadFromEnvironmentVars())));
     operator.installShutdownHook();

--- a/sample-operators/mysql-schema/src/main/java/io/javaoperatorsdk/operator/sample/MySQLSchemaReconciler.java
+++ b/sample-operators/mysql-schema/src/main/java/io/javaoperatorsdk/operator/sample/MySQLSchemaReconciler.java
@@ -11,6 +11,7 @@ import io.javaoperatorsdk.operator.api.reconciler.ErrorStatusUpdateControl;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.Dependent;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
 import io.javaoperatorsdk.operator.sample.dependent.SchemaDependentResource;
 import io.javaoperatorsdk.operator.sample.dependent.SecretDependentResource;
 
@@ -36,7 +37,12 @@ public class MySQLSchemaReconciler
     // we only need to update the status if we just built the schema, i.e. when it's present in the
     // context
     Secret secret = context.getSecondaryResource(Secret.class).orElseThrow();
-    return context.getSecondaryResource(MySQLSchema.class).map(s -> {
+
+    SchemaDependentResource schemaDependentResource =
+        context.managedDependentResourceContext().getAdaptedDependentResource(
+            DependentResource.defaultNameFor(SchemaDependentResource.class),
+            SchemaDependentResource.class);
+    return schemaDependentResource.fetchResource(schema).map(s -> {
       updateStatusPojo(schema, secret.getMetadata().getName(),
           decode(secret.getData().get(MYSQL_SECRET_USERNAME)));
       log.info("Schema {} created - updating CR status", schema.getMetadata().getName());

--- a/sample-operators/mysql-schema/src/main/java/io/javaoperatorsdk/operator/sample/MySQLSchemaReconciler.java
+++ b/sample-operators/mysql-schema/src/main/java/io/javaoperatorsdk/operator/sample/MySQLSchemaReconciler.java
@@ -11,7 +11,6 @@ import io.javaoperatorsdk.operator.api.reconciler.ErrorStatusUpdateControl;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.Dependent;
-import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
 import io.javaoperatorsdk.operator.sample.dependent.SchemaDependentResource;
 import io.javaoperatorsdk.operator.sample.dependent.SecretDependentResource;
 
@@ -40,7 +39,7 @@ public class MySQLSchemaReconciler
 
     SchemaDependentResource schemaDependentResource =
         context.managedDependentResourceContext().getAdaptedDependentResource(
-            DependentResource.defaultNameFor(SchemaDependentResource.class),
+            SchemaDependentResource.NAME,
             SchemaDependentResource.class);
     return schemaDependentResource.fetchResource(schema).map(s -> {
       updateStatusPojo(schema, secret.getMetadata().getName(),

--- a/sample-operators/mysql-schema/src/main/java/io/javaoperatorsdk/operator/sample/MySQLSchemaReconciler.java
+++ b/sample-operators/mysql-schema/src/main/java/io/javaoperatorsdk/operator/sample/MySQLSchemaReconciler.java
@@ -4,7 +4,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.fabric8.kubernetes.api.model.Secret;
-import io.javaoperatorsdk.operator.api.reconciler.*;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
+import io.javaoperatorsdk.operator.api.reconciler.ErrorStatusHandler;
+import io.javaoperatorsdk.operator.api.reconciler.ErrorStatusUpdateControl;
+import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.Dependent;
 import io.javaoperatorsdk.operator.sample.dependent.SchemaDependentResource;
 import io.javaoperatorsdk.operator.sample.dependent.SecretDependentResource;
@@ -31,9 +36,7 @@ public class MySQLSchemaReconciler
     // we only need to update the status if we just built the schema, i.e. when it's present in the
     // context
     Secret secret = context.getSecondaryResource(Secret.class).orElseThrow();
-    SchemaDependentResource schemaDependentResource = context.managedDependentResourceContext()
-        .getDependentResource(SchemaDependentResource.class);
-    return schemaDependentResource.getResource(schema).map(s -> {
+    return context.getSecondaryResource(MySQLSchema.class).map(s -> {
       updateStatusPojo(schema, secret.getMetadata().getName(),
           decode(secret.getData().get(MYSQL_SECRET_USERNAME)));
       log.info("Schema {} created - updating CR status", schema.getMetadata().getName());

--- a/sample-operators/mysql-schema/src/main/java/io/javaoperatorsdk/operator/sample/MySQLSchemaReconciler.java
+++ b/sample-operators/mysql-schema/src/main/java/io/javaoperatorsdk/operator/sample/MySQLSchemaReconciler.java
@@ -21,7 +21,7 @@ import static java.lang.String.format;
 @ControllerConfiguration(
     dependents = {
         @Dependent(type = SecretDependentResource.class),
-        @Dependent(type = SchemaDependentResource.class)
+        @Dependent(type = SchemaDependentResource.class, name = SchemaDependentResource.NAME)
     })
 public class MySQLSchemaReconciler
     implements Reconciler<MySQLSchema>, ErrorStatusHandler<MySQLSchema> {

--- a/sample-operators/mysql-schema/src/main/java/io/javaoperatorsdk/operator/sample/MySQLSchemaReconciler.java
+++ b/sample-operators/mysql-schema/src/main/java/io/javaoperatorsdk/operator/sample/MySQLSchemaReconciler.java
@@ -37,11 +37,7 @@ public class MySQLSchemaReconciler
     // context
     Secret secret = context.getSecondaryResource(Secret.class).orElseThrow();
 
-    SchemaDependentResource schemaDependentResource =
-        context.managedDependentResourceContext().getAdaptedDependentResource(
-            SchemaDependentResource.NAME,
-            SchemaDependentResource.class);
-    return schemaDependentResource.fetchResource(schema).map(s -> {
+    return context.getSecondaryResource(MySQLSchema.class, SchemaDependentResource.NAME).map(s -> {
       updateStatusPojo(schema, secret.getMetadata().getName(),
           decode(secret.getData().get(MYSQL_SECRET_USERNAME)));
       log.info("Schema {} created - updating CR status", schema.getMetadata().getName());

--- a/sample-operators/mysql-schema/src/main/java/io/javaoperatorsdk/operator/sample/dependent/SchemaDependentResource.java
+++ b/sample-operators/mysql-schema/src/main/java/io/javaoperatorsdk/operator/sample/dependent/SchemaDependentResource.java
@@ -30,7 +30,7 @@ public class SchemaDependentResource
     implements EventSourceProvider<MySQLSchema>,
     DependentResourceConfigurator<ResourcePollerConfig>,
     Creator<Schema, MySQLSchema>, Deleter<MySQLSchema> {
-
+  public static final String NAME = "schema";
   private static final Logger log = LoggerFactory.getLogger(SchemaDependentResource.class);
 
   private MySQLDbConfig dbConfig;

--- a/sample-operators/mysql-schema/src/test/java/io/javaoperatorsdk/operator/sample/MySQLSchemaOperatorE2E.java
+++ b/sample-operators/mysql-schema/src/test/java/io/javaoperatorsdk/operator/sample/MySQLSchemaOperatorE2E.java
@@ -70,7 +70,7 @@ class MySQLSchemaOperatorE2E {
                       SchemaDependentResource.NAME,
                       new ResourcePollerConfig(
                           700, new MySQLDbConfig("127.0.0.1", LOCAL_PORT.toString(), "root",
-                                "password"))))
+                              "password"))))
               .withInfrastructure(infrastructure)
               .withPortForward(MY_SQL_NS, "app", "mysql", 3306, LOCAL_PORT)
               .build()

--- a/sample-operators/mysql-schema/src/test/java/io/javaoperatorsdk/operator/sample/MySQLSchemaOperatorE2E.java
+++ b/sample-operators/mysql-schema/src/test/java/io/javaoperatorsdk/operator/sample/MySQLSchemaOperatorE2E.java
@@ -66,7 +66,7 @@ class MySQLSchemaOperatorE2E {
           ? OperatorExtension.builder()
               .withReconciler(
                   new MySQLSchemaReconciler(),
-                  c -> c.replaceNamedDependentResourceConfig(
+                  c -> c.replacingNamedDependentResourceConfig(
                       SchemaDependentResource.NAME,
                       new ResourcePollerConfig(
                           700, new MySQLDbConfig("127.0.0.1", LOCAL_PORT.toString(), "root",

--- a/sample-operators/mysql-schema/src/test/java/io/javaoperatorsdk/operator/sample/MySQLSchemaOperatorE2E.java
+++ b/sample-operators/mysql-schema/src/test/java/io/javaoperatorsdk/operator/sample/MySQLSchemaOperatorE2E.java
@@ -61,19 +61,16 @@ class MySQLSchemaOperatorE2E {
   }
 
   @RegisterExtension
-  @SuppressWarnings("unchecked")
   AbstractOperatorExtension operator =
       isLocal()
           ? OperatorExtension.builder()
               .withReconciler(
                   new MySQLSchemaReconciler(),
-                  c -> {
-                    c.replaceDependentResourceConfig(
-                        SchemaDependentResource.class,
-                        new ResourcePollerConfig(
-                            700, new MySQLDbConfig("127.0.0.1", LOCAL_PORT.toString(), "root",
-                                "password")));
-                  })
+                  c -> c.replaceNamedDependentResourceConfig(
+                      SchemaDependentResource.NAME,
+                      new ResourcePollerConfig(
+                          700, new MySQLDbConfig("127.0.0.1", LOCAL_PORT.toString(), "root",
+                                "password"))))
               .withInfrastructure(infrastructure)
               .withPortForward(MY_SQL_NS, "app", "mysql", 3306, LOCAL_PORT)
               .build()

--- a/sample-operators/webpage/src/main/java/io/javaoperatorsdk/operator/sample/WebPageReconciler.java
+++ b/sample-operators/webpage/src/main/java/io/javaoperatorsdk/operator/sample/WebPageReconciler.java
@@ -1,7 +1,6 @@
 package io.javaoperatorsdk.operator.sample;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
@@ -53,7 +52,7 @@ public class WebPageReconciler
   }
 
   @Override
-  public List<EventSource> prepareEventSources(EventSourceContext<WebPage> context) {
+  public Map<String, EventSource> prepareEventSources(EventSourceContext<WebPage> context) {
     var configMapEventSource =
         new InformerEventSource<>(InformerConfiguration.from(context, ConfigMap.class)
             .withLabelSelector(LOW_LEVEL_LABEL_KEY)
@@ -66,7 +65,8 @@ public class WebPageReconciler
         new InformerEventSource<>(InformerConfiguration.from(context, Service.class)
             .withLabelSelector(LOW_LEVEL_LABEL_KEY)
             .build(), context);
-    return List.of(configMapEventSource, deploymentEventSource, serviceEventSource);
+    return Map.of("configmap", configMapEventSource, "deployment", deploymentEventSource, "service",
+        serviceEventSource);
   }
 
   @Override

--- a/sample-operators/webpage/src/main/java/io/javaoperatorsdk/operator/sample/WebPageStandaloneDependentsReconciler.java
+++ b/sample-operators/webpage/src/main/java/io/javaoperatorsdk/operator/sample/WebPageStandaloneDependentsReconciler.java
@@ -1,6 +1,6 @@
 package io.javaoperatorsdk.operator.sample;
 
-import java.util.List;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,11 +46,11 @@ public class WebPageStandaloneDependentsReconciler
   }
 
   @Override
-  public List<EventSource> prepareEventSources(EventSourceContext<WebPage> context) {
-    return List.of(
-        configMapDR.initEventSource(context),
-        deploymentDR.initEventSource(context),
-        serviceDR.initEventSource(context));
+  public Map<String, EventSource> prepareEventSources(EventSourceContext<WebPage> context) {
+    return Map.of(
+        "configmap", configMapDR.initEventSource(context),
+        "deployment", deploymentDR.initEventSource(context),
+        "service", serviceDR.initEventSource(context));
   }
 
   @Override


### PR DESCRIPTION
This causes issues if the class is proxied for any reason (e.g. because
it's a CDI bean).
