### PR TITLE
Metrics

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/Controller.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/Controller.java
@@ -105,7 +105,6 @@ public class Controller<P extends HasMetadata> implements Reconciler<P>, Cleaner
 
   @Override
   public DeleteControl cleanup(P resource, Context<P> context) {
-    initContextIfNeeded(resource, context);
     try {
       return metrics()
           .timeControllerExecution(
@@ -127,6 +126,7 @@ public class Controller<P extends HasMetadata> implements Reconciler<P>, Cleaner
 
                 @Override
                 public DeleteControl execute() {
+                  initContextIfNeeded(resource, context);
                   if (hasDeleterDependents) {
                     dependents.stream()
                         .filter(d -> d instanceof Deleter)
@@ -147,7 +147,6 @@ public class Controller<P extends HasMetadata> implements Reconciler<P>, Cleaner
 
   @Override
   public UpdateControl<P> reconcile(P resource, Context<P> context) throws Exception {
-    initContextIfNeeded(resource, context);
     return metrics().timeControllerExecution(
         new ControllerExecution<>() {
           @Override
@@ -174,6 +173,7 @@ public class Controller<P extends HasMetadata> implements Reconciler<P>, Cleaner
 
           @Override
           public UpdateControl<P> execute() throws Exception {
+            initContextIfNeeded(resource, context);
             dependents.forEach(dependent -> dependent.reconcile(resource, context));
             return reconciler.reconcile(resource, context);
           }


### PR DESCRIPTION
- `initContextIfNeeded` should be part of total time execution.
- some optimization to avoid resolving metrics instance for each call. It should be a singleton, so I guess it is safe to keep a reference on it. the instance can be fetch from `configuration.getConfigurationService()` but a lot of unit tests are stubbing `ConfigurationServiceProvider.instance()` instead.