### PR TITLE
test

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ControllerConfiguration.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ControllerConfiguration.java
@@ -2,7 +2,7 @@ package io.javaoperatorsdk.operator.api.config;
 
 import java.time.Duration;
 import java.util.Collections;
-import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
@@ -46,8 +46,8 @@ public interface ControllerConfiguration<R extends HasMetadata> extends Resource
     return ResourceEventFilters.passthrough();
   }
 
-  default List<DependentResourceSpec<?, ?>> getDependentResources() {
-    return Collections.emptyList();
+  default Map<String, DependentResourceSpec<?, ?>> getDependentResources() {
+    return Collections.emptyMap();
   }
 
   default Optional<Duration> reconciliationMaxInterval() {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ControllerConfigurationOverrider.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ControllerConfigurationOverrider.java
@@ -90,7 +90,7 @@ public class ControllerConfigurationOverrider<R extends HasMetadata> {
     return this;
   }
 
-  public ControllerConfigurationOverrider<R> replaceNamedDependentResourceConfig(String name,
+  public ControllerConfigurationOverrider<R> replacingNamedDependentResourceConfig(String name,
       Object dependentResourceConfig) {
     final var currentConfig = dependentResourceSpecs.get(name);
     if (currentConfig == null) {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ControllerConfigurationOverrider.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ControllerConfigurationOverrider.java
@@ -1,6 +1,7 @@
 package io.javaoperatorsdk.operator.api.config;
 
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -31,7 +32,8 @@ public class ControllerConfigurationOverrider<R extends HasMetadata> {
     labelSelector = original.getLabelSelector();
     customResourcePredicate = original.getEventFilter();
     reconciliationMaxInterval = original.reconciliationMaxInterval().orElse(null);
-    dependentResourceSpecs = original.getDependentResources();
+    // make the original specs modifiable
+    dependentResourceSpecs = new HashMap<>(original.getDependentResources());
     this.original = original;
   }
 
@@ -88,7 +90,8 @@ public class ControllerConfigurationOverrider<R extends HasMetadata> {
     return this;
   }
 
-  public void replaceNamedDependentResourceConfig(String name, Object dependentResourceConfig) {
+  public ControllerConfigurationOverrider<R> replaceNamedDependentResourceConfig(String name,
+      Object dependentResourceConfig) {
     final var currentConfig = dependentResourceSpecs.get(name);
     if (currentConfig == null) {
       throw new IllegalArgumentException("Cannot find a DependentResource named: " + name);
@@ -97,6 +100,7 @@ public class ControllerConfigurationOverrider<R extends HasMetadata> {
     dependentResourceSpecs.put(name,
         new DependentResourceSpec(currentConfig.getDependentResourceClass(),
             dependentResourceConfig, name));
+    return this;
   }
 
   public ControllerConfiguration<R> build() {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/DefaultControllerConfiguration.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/DefaultControllerConfiguration.java
@@ -2,7 +2,7 @@ package io.javaoperatorsdk.operator.api.config;
 
 import java.time.Duration;
 import java.util.Collections;
-import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -10,7 +10,6 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.javaoperatorsdk.operator.api.config.dependent.DependentResourceSpec;
 import io.javaoperatorsdk.operator.processing.event.source.controller.ResourceEventFilter;
 
-@SuppressWarnings("rawtypes")
 public class DefaultControllerConfiguration<R extends HasMetadata>
     extends DefaultResourceConfiguration<R>
     implements ControllerConfiguration<R> {
@@ -22,7 +21,7 @@ public class DefaultControllerConfiguration<R extends HasMetadata>
   private final boolean generationAware;
   private final RetryConfiguration retryConfiguration;
   private final ResourceEventFilter<R> resourceEventFilter;
-  private final List<DependentResourceSpec<?, ?>> dependents;
+  private final Map<String, DependentResourceSpec<?, ?>> dependents;
   private final Duration reconciliationMaxInterval;
 
   // NOSONAR constructor is meant to provide all information
@@ -38,7 +37,7 @@ public class DefaultControllerConfiguration<R extends HasMetadata>
       ResourceEventFilter<R> resourceEventFilter,
       Class<R> resourceClass,
       Duration reconciliationMaxInterval,
-      List<DependentResourceSpec<?, ?>> dependents) {
+      Map<String, DependentResourceSpec<?, ?>> dependents) {
     super(labelSelector, resourceClass, namespaces);
     this.associatedControllerClassName = associatedControllerClassName;
     this.name = name;
@@ -52,7 +51,7 @@ public class DefaultControllerConfiguration<R extends HasMetadata>
             : retryConfiguration;
     this.resourceEventFilter = resourceEventFilter;
 
-    this.dependents = dependents != null ? dependents : Collections.emptyList();
+    this.dependents = dependents != null ? dependents : Collections.emptyMap();
   }
 
   @Override
@@ -91,7 +90,7 @@ public class DefaultControllerConfiguration<R extends HasMetadata>
   }
 
   @Override
-  public List<DependentResourceSpec<?, ?>> getDependentResources() {
+  public Map<String, DependentResourceSpec<?, ?>> getDependentResources() {
     return dependents;
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/dependent/DependentResourceSpec.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/dependent/DependentResourceSpec.java
@@ -1,5 +1,6 @@
 package io.javaoperatorsdk.operator.api.config.dependent;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
@@ -10,9 +11,13 @@ public class DependentResourceSpec<T extends DependentResource<?, ?>, C> {
 
   private final C dependentResourceConfig;
 
-  public DependentResourceSpec(Class<T> dependentResourceClass, C dependentResourceConfig) {
+  private final String name;
+
+  public DependentResourceSpec(Class<T> dependentResourceClass, C dependentResourceConfig,
+      String name) {
     this.dependentResourceClass = dependentResourceClass;
     this.dependentResourceConfig = dependentResourceConfig;
+    this.name = name;
   }
 
   public Class<T> getDependentResourceClass() {
@@ -21,5 +26,33 @@ public class DependentResourceSpec<T extends DependentResource<?, ?>, C> {
 
   public Optional<C> getDependentResourceConfiguration() {
     return Optional.ofNullable(dependentResourceConfig);
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String toString() {
+    return "DependentResourceSpec{ name='" + name +
+        "', type=" + dependentResourceClass.getCanonicalName() +
+        ", config=" + dependentResourceConfig + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DependentResourceSpec<?, ?> that = (DependentResourceSpec<?, ?>) o;
+    return name.equals(that.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name);
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/Dependent.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/Dependent.java
@@ -1,6 +1,11 @@
 package io.javaoperatorsdk.operator.api.reconciler.dependent;
 
+import static io.javaoperatorsdk.operator.api.reconciler.Constants.EMPTY_STRING;
+
 public @interface Dependent {
 
+  @SuppressWarnings("rawtypes")
   Class<? extends DependentResource> type();
+
+  String name() default EMPTY_STRING;
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/DependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/DependentResource.java
@@ -12,7 +12,8 @@ public interface DependentResource<R, P extends HasMetadata> {
 
   Class<R> resourceType();
 
-  default String name() {
-    return getClass().getCanonicalName();
+  @SuppressWarnings("rawtypes")
+  static String defaultNameFor(Class<? extends DependentResource> dependentResourceClass) {
+    return dependentResourceClass.getCanonicalName();
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/DependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/DependentResource.java
@@ -9,4 +9,10 @@ public interface DependentResource<R, P extends HasMetadata> {
   ReconcileResult<R> reconcile(P primary, Context<P> context);
 
   Optional<R> getResource(P primaryResource);
+
+  Class<R> resourceType();
+
+  default String name() {
+    return getClass().getCanonicalName();
+  }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/DependentResourceFactory.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/DependentResourceFactory.java
@@ -7,12 +7,16 @@ import io.javaoperatorsdk.operator.api.config.dependent.DependentResourceSpec;
 public interface DependentResourceFactory {
 
   default <T extends DependentResource<?, ?>> T createFrom(DependentResourceSpec<T, ?> spec) {
+    return createFrom(spec.getDependentResourceClass());
+  }
+
+  default <T extends DependentResource<?, ?>> T createFrom(Class<T> dependentResourceClass) {
     try {
-      return spec.getDependentResourceClass().getConstructor().newInstance();
+      return dependentResourceClass.getConstructor().newInstance();
     } catch (InstantiationException | NoSuchMethodException | IllegalAccessException
         | InvocationTargetException e) {
       throw new IllegalArgumentException("Cannot instantiate DependentResource "
-          + spec.getDependentResourceClass().getCanonicalName(), e);
+          + dependentResourceClass.getCanonicalName(), e);
     }
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/managed/ManagedDependentResourceContext.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/managed/ManagedDependentResourceContext.java
@@ -94,10 +94,7 @@ public class ManagedDependentResourceContext {
    */
   @SuppressWarnings({"unchecked"})
   public <T> DependentResource<T, ?> getDependentResource(String name, Class<T> resourceClass) {
-    var dependentResource = dependentResources.get(name);
-    if (dependentResource == null) {
-      throw new OperatorException("No dependent resource found with name: " + name);
-    }
+    DependentResource dependentResource = getDependentResource(name);
     final var actual = dependentResource.resourceType();
     if (!actual.equals(resourceClass)) {
       throw new OperatorException(
@@ -105,5 +102,25 @@ public class ManagedDependentResourceContext {
               + actual.getName() + " instead of: " + resourceClass.getName());
     }
     return dependentResource;
+  }
+
+  private DependentResource getDependentResource(String name) {
+    var dependentResource = dependentResources.get(name);
+    if (dependentResource == null) {
+      throw new OperatorException("No dependent resource found with name: " + name);
+    }
+    return dependentResource;
+  }
+
+  @SuppressWarnings("unchecked")
+  public <T extends DependentResource> T getAdaptedDependentResource(String name,
+      Class<T> dependentResourceClass) {
+    DependentResource dependentResource = getDependentResource(name);
+    if (dependentResourceClass.isInstance(dependentResource)) {
+      return (T) dependentResource;
+    } else {
+      throw new IllegalArgumentException("Dependent resource associated with name: " + name
+          + " is not adaptable to type: " + dependentResourceClass.getCanonicalName());
+    }
   }
 }

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/config/ControllerConfigurationOverriderTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/config/ControllerConfigurationOverriderTest.java
@@ -42,7 +42,7 @@ class ControllerConfigurationOverriderTest {
     final var overriddenNS = "newNS";
     final var labelSelector = "foo=bar";
     final var overridden = ControllerConfigurationOverrider.override(configuration)
-        .replaceNamedDependentResourceConfig(
+        .replacingNamedDependentResourceConfig(
             DependentResource.defaultNameFor(ReadOnlyDependent.class),
             new KubernetesDependentResourceConfig(true, new String[] {overriddenNS}, labelSelector))
         .build();

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/config/ControllerConfigurationOverriderTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/config/ControllerConfigurationOverriderTest.java
@@ -1,0 +1,77 @@
+package io.javaoperatorsdk.operator.api.config;
+
+import org.junit.jupiter.api.Test;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
+import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.Dependent;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependentResource;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependentResourceConfig;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ControllerConfigurationOverriderTest {
+
+  @Test
+  void replaceNamedDependentResourceConfigShouldWork() {
+    var configuration = new AnnotationControllerConfiguration<>(new OneDepReconciler());
+    var dependents = configuration.getDependentResources();
+    assertFalse(dependents.isEmpty());
+    assertEquals(1, dependents.size());
+    final var dependentResourceName = DependentResource.defaultNameFor(ReadOnlyDependent.class);
+    assertTrue(dependents.containsKey(dependentResourceName));
+    var dependentSpec = dependents.get(dependentResourceName);
+    assertEquals(ReadOnlyDependent.class, dependentSpec.getDependentResourceClass());
+    var maybeConfig = dependentSpec.getDependentResourceConfiguration();
+    assertTrue(maybeConfig.isPresent());
+    assertTrue(maybeConfig.get() instanceof KubernetesDependentResourceConfig);
+    var config = (KubernetesDependentResourceConfig) maybeConfig.orElseThrow();
+    // check that the DependentResource inherits the controller's configuration if applicable
+    assertEquals(1, config.namespaces().length);
+    assertNull(config.labelSelector());
+    assertEquals(OneDepReconciler.CONFIGURED_NS, config.namespaces()[0]);
+
+    // override the namespaces for the dependent resource
+    final var overriddenNS = "newNS";
+    final var labelSelector = "foo=bar";
+    final var overridden = ControllerConfigurationOverrider.override(configuration)
+        .replaceNamedDependentResourceConfig(
+            DependentResource.defaultNameFor(ReadOnlyDependent.class),
+            new KubernetesDependentResourceConfig(true, new String[] {overriddenNS}, labelSelector))
+        .build();
+    dependents = overridden.getDependentResources();
+    dependentSpec = dependents.get(dependentResourceName);
+    config = (KubernetesDependentResourceConfig) dependentSpec.getDependentResourceConfiguration()
+        .orElseThrow();
+    assertEquals(1, config.namespaces().length);
+    assertEquals(labelSelector, config.labelSelector());
+    assertEquals(overriddenNS, config.namespaces()[0]);
+  }
+
+  @ControllerConfiguration(namespaces = OneDepReconciler.CONFIGURED_NS,
+      dependents = @Dependent(type = ReadOnlyDependent.class))
+  private static class OneDepReconciler implements Reconciler<ConfigMap> {
+
+    private static final String CONFIGURED_NS = "foo";
+
+    @Override
+    public UpdateControl<ConfigMap> reconcile(ConfigMap resource, Context<ConfigMap> context) {
+      return null;
+    }
+  }
+
+  private static class ReadOnlyDependent extends KubernetesDependentResource<ConfigMap, ConfigMap> {
+
+    public ReadOnlyDependent() {
+      super(ConfigMap.class);
+    }
+  }
+
+}

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/config/UtilsTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/config/UtilsTest.java
@@ -101,6 +101,12 @@ class UtilsTest {
     public Optional<Deployment> getResource(TestCustomResource primaryResource) {
       return Optional.empty();
     }
+
+    @Override
+    public Class<Deployment> resourceType() {
+      return Deployment.class;
+    }
+
   }
 
   public static class TestKubernetesDependentResource

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/external/AbstractSimpleDependentResourceTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/external/AbstractSimpleDependentResourceTest.java
@@ -18,7 +18,11 @@ import io.javaoperatorsdk.operator.processing.event.source.UpdatableCache;
 import io.javaoperatorsdk.operator.sample.simple.TestCustomResource;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @SuppressWarnings("unchecked")
 class AbstractSimpleDependentResourceTest {
@@ -135,6 +139,11 @@ class AbstractSimpleDependentResourceTest {
     protected SampleExternalResource desired(TestCustomResource primary,
         Context<TestCustomResource> context) {
       return SampleExternalResource.testResource1();
+    }
+
+    @Override
+    public Class<SampleExternalResource> resourceType() {
+      return SampleExternalResource.class;
     }
   }
 }

--- a/sample-operators/mysql-schema/src/main/java/io/javaoperatorsdk/operator/sample/MySQLSchemaOperator.java
+++ b/sample-operators/mysql-schema/src/main/java/io/javaoperatorsdk/operator/sample/MySQLSchemaOperator.java
@@ -35,8 +35,8 @@ public class MySQLSchemaOperator {
 
     // override the default configuration
     operator.register(schemaReconciler,
-        configOverrider -> configOverrider.replaceDependentResourceConfig(
-            SchemaDependentResource.class,
+        configOverrider -> configOverrider.replaceNamedDependentResourceConfig(
+            SchemaDependentResource.NAME,
             new ResourcePollerConfig(300, MySQLDbConfig.loadFromEnvironmentVars())));
     operator.installShutdownHook();
     operator.start();

--- a/sample-operators/mysql-schema/src/main/java/io/javaoperatorsdk/operator/sample/MySQLSchemaOperator.java
+++ b/sample-operators/mysql-schema/src/main/java/io/javaoperatorsdk/operator/sample/MySQLSchemaOperator.java
@@ -35,7 +35,7 @@ public class MySQLSchemaOperator {
 
     // override the default configuration
     operator.register(schemaReconciler,
-        configOverrider -> configOverrider.replaceNamedDependentResourceConfig(
+        configOverrider -> configOverrider.replacingNamedDependentResourceConfig(
             SchemaDependentResource.NAME,
             new ResourcePollerConfig(300, MySQLDbConfig.loadFromEnvironmentVars())));
     operator.installShutdownHook();

--- a/sample-operators/mysql-schema/src/main/java/io/javaoperatorsdk/operator/sample/MySQLSchemaReconciler.java
+++ b/sample-operators/mysql-schema/src/main/java/io/javaoperatorsdk/operator/sample/MySQLSchemaReconciler.java
@@ -11,6 +11,7 @@ import io.javaoperatorsdk.operator.api.reconciler.ErrorStatusUpdateControl;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.Dependent;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
 import io.javaoperatorsdk.operator.sample.dependent.SchemaDependentResource;
 import io.javaoperatorsdk.operator.sample.dependent.SecretDependentResource;
 
@@ -35,7 +36,12 @@ public class MySQLSchemaReconciler
     // we only need to update the status if we just built the schema, i.e. when it's present in the
     // context
     Secret secret = context.getSecondaryResource(Secret.class).orElseThrow();
-    return context.getSecondaryResource(MySQLSchema.class).map(s -> {
+
+    SchemaDependentResource schemaDependentResource =
+        context.managedDependentResourceContext().getAdaptedDependentResource(
+            DependentResource.defaultNameFor(SchemaDependentResource.class),
+            SchemaDependentResource.class);
+    return schemaDependentResource.fetchResource(schema).map(s -> {
       updateStatusPojo(schema, secret.getMetadata().getName(),
           secret.getData().get(MYSQL_SECRET_USERNAME));
       log.info("Schema {} created - updating CR status", schema.getMetadata().getName());

--- a/sample-operators/mysql-schema/src/main/java/io/javaoperatorsdk/operator/sample/MySQLSchemaReconciler.java
+++ b/sample-operators/mysql-schema/src/main/java/io/javaoperatorsdk/operator/sample/MySQLSchemaReconciler.java
@@ -4,7 +4,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.fabric8.kubernetes.api.model.Secret;
-import io.javaoperatorsdk.operator.api.reconciler.*;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
+import io.javaoperatorsdk.operator.api.reconciler.ErrorStatusHandler;
+import io.javaoperatorsdk.operator.api.reconciler.ErrorStatusUpdateControl;
+import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.Dependent;
 import io.javaoperatorsdk.operator.sample.dependent.SchemaDependentResource;
 import io.javaoperatorsdk.operator.sample.dependent.SecretDependentResource;
@@ -30,9 +35,7 @@ public class MySQLSchemaReconciler
     // we only need to update the status if we just built the schema, i.e. when it's present in the
     // context
     Secret secret = context.getSecondaryResource(Secret.class).orElseThrow();
-    SchemaDependentResource schemaDependentResource = context.managedDependentResourceContext()
-        .getDependentResource(SchemaDependentResource.class);
-    return schemaDependentResource.fetchResource(schema).map(s -> {
+    return context.getSecondaryResource(MySQLSchema.class).map(s -> {
       updateStatusPojo(schema, secret.getMetadata().getName(),
           secret.getData().get(MYSQL_SECRET_USERNAME));
       log.info("Schema {} created - updating CR status", schema.getMetadata().getName());

--- a/sample-operators/mysql-schema/src/main/java/io/javaoperatorsdk/operator/sample/MySQLSchemaReconciler.java
+++ b/sample-operators/mysql-schema/src/main/java/io/javaoperatorsdk/operator/sample/MySQLSchemaReconciler.java
@@ -20,7 +20,7 @@ import static java.lang.String.format;
 @ControllerConfiguration(
     dependents = {
         @Dependent(type = SecretDependentResource.class),
-        @Dependent(type = SchemaDependentResource.class)
+        @Dependent(type = SchemaDependentResource.class, name = SchemaDependentResource.NAME)
     })
 public class MySQLSchemaReconciler
     implements Reconciler<MySQLSchema>, ErrorStatusHandler<MySQLSchema> {

--- a/sample-operators/mysql-schema/src/main/java/io/javaoperatorsdk/operator/sample/dependent/SchemaDependentResource.java
+++ b/sample-operators/mysql-schema/src/main/java/io/javaoperatorsdk/operator/sample/dependent/SchemaDependentResource.java
@@ -32,7 +32,7 @@ public class SchemaDependentResource
 // todo fix
 // , Deleter<MySQLSchema>
 {
-
+  public static final String NAME = "schema";
   private static final Logger log = LoggerFactory.getLogger(SchemaDependentResource.class);
 
   private MySQLDbConfig dbConfig;

--- a/sample-operators/mysql-schema/src/test/java/io/javaoperatorsdk/operator/sample/MySQLSchemaOperatorE2E.java
+++ b/sample-operators/mysql-schema/src/test/java/io/javaoperatorsdk/operator/sample/MySQLSchemaOperatorE2E.java
@@ -65,7 +65,7 @@ class MySQLSchemaOperatorE2E {
           ? OperatorExtension.builder()
               .withReconciler(
                   new MySQLSchemaReconciler(),
-                  c -> c.replaceNamedDependentResourceConfig(
+                  c -> c.replacingNamedDependentResourceConfig(
                       SchemaDependentResource.NAME,
                       new ResourcePollerConfig(
                           700, new MySQLDbConfig("127.0.0.1", "3306", "root", "password"))))

--- a/sample-operators/mysql-schema/src/test/java/io/javaoperatorsdk/operator/sample/MySQLSchemaOperatorE2E.java
+++ b/sample-operators/mysql-schema/src/test/java/io/javaoperatorsdk/operator/sample/MySQLSchemaOperatorE2E.java
@@ -60,18 +60,15 @@ class MySQLSchemaOperatorE2E {
   }
 
   @RegisterExtension
-  @SuppressWarnings("unchecked")
   AbstractOperatorExtension operator =
       isLocal()
           ? OperatorExtension.builder()
               .withReconciler(
                   new MySQLSchemaReconciler(),
-                  c -> {
-                    c.replaceDependentResourceConfig(
-                        SchemaDependentResource.class,
-                        new ResourcePollerConfig(
-                            700, new MySQLDbConfig("127.0.0.1", "3306", "root", "password")));
-                  })
+                  c -> c.replaceNamedDependentResourceConfig(
+                      SchemaDependentResource.NAME,
+                      new ResourcePollerConfig(
+                          700, new MySQLDbConfig("127.0.0.1", "3306", "root", "password"))))
               .withInfrastructure(infrastructure)
               .build()
           : E2EOperatorExtension.builder()


### PR DESCRIPTION
- fix: retrieve DependentResource based on name instead of class
- feat: record association of name and DependentResource in configuration
- fix: make it possible to override dependent specs
- chore: add more tests
- refactor: rename replaceNamedDependentResourceConfig to fit other method names
- feat: make it possible to retrieve actual dependent resource type
