### PR TITLE
feat: add a DependentResource implementation that's also an EventSource

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/DefaultContext.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/DefaultContext.java
@@ -32,7 +32,7 @@ public class DefaultContext<P extends HasMetadata> implements Context<P> {
   public <T> Optional<T> getSecondaryResource(Class<T> expectedType, String eventSourceName) {
     return controller.getEventSourceManager()
         .getResourceEventSourceFor(expectedType, eventSourceName)
-        .flatMap(es -> es.getAssociated(primaryResource));
+        .flatMap(es -> es.getAssociatedResource(primaryResource));
   }
 
   @Override

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/EventSourceInitializer.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/EventSourceInitializer.java
@@ -14,11 +14,12 @@ import io.javaoperatorsdk.operator.processing.event.source.EventSource;
 public interface EventSourceInitializer<P extends HasMetadata> {
 
   /**
-   * Prepares a list of {@link EventSource} implementations to be registered by the SDK.
+   * Prepares a map of {@link EventSource} implementations keyed by the name with which they need to
+   * be registered by the SDK.
    *
    * @param context a {@link EventSourceContext} providing access to information useful to event
    *        sources
-   * @return list of event sources to register
+   * @return a map of event sources to register
    */
   Map<String, EventSource> prepareEventSources(EventSourceContext<P> context);
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/UpdateControl.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/UpdateControl.java
@@ -2,7 +2,6 @@ package io.javaoperatorsdk.operator.api.reconciler;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 
-@SuppressWarnings("rawtypes")
 public class UpdateControl<T extends HasMetadata> extends BaseControl<UpdateControl<T>> {
 
   private final T resource;
@@ -32,8 +31,7 @@ public class UpdateControl<T extends HasMetadata> extends BaseControl<UpdateCont
     return new UpdateControl<>(customResource, false, true);
   }
 
-  public static <T extends HasMetadata> UpdateControl<T> updateStatus(
-      T customResource) {
+  public static <T extends HasMetadata> UpdateControl<T> updateStatus(T customResource) {
     return new UpdateControl<>(customResource, true, false);
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/DependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/DependentResource.java
@@ -1,9 +1,8 @@
 package io.javaoperatorsdk.operator.api.reconciler.dependent;
 
-import java.util.Optional;
-
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.processing.ResourceOwner;
 
 /**
  * An interface to implement and provide dependent resource support.
@@ -11,7 +10,7 @@ import io.javaoperatorsdk.operator.api.reconciler.Context;
  * @param <R> the dependent resource type
  * @param <P> the associated primary resource type
  */
-public interface DependentResource<R, P extends HasMetadata> {
+public interface DependentResource<R, P extends HasMetadata> extends ResourceOwner<R, P> {
 
   /**
    * Reconciles the dependent resource given the desired primary state
@@ -21,25 +20,6 @@ public interface DependentResource<R, P extends HasMetadata> {
    * @return a {@link ReconcileResult} providing information about the reconciliation result
    */
   ReconcileResult<R> reconcile(P primary, Context<P> context);
-
-  /**
-   * The intention with get resource is to return the actual state of the resource. Usually from a
-   * local cache, what was updated after the reconciliation, or typically from the event source that
-   * caches the resources.
-   *
-   * @param primaryResource the primary resource for which we want to retrieve the secondary
-   *        resource
-   * @return an {@link Optional} containing the secondary resource or {@link Optional#empty()} if it
-   *         doesn't exist
-   */
-  Optional<R> getResource(P primaryResource);
-
-  /**
-   * Retrieves the resource type associated with this DependentResource
-   *
-   * @return the resource type associated with this DependentResource
-   */
-  Class<R> resourceType();
 
   /**
    * Computes a default name for the specified DependentResource class

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/EventSourceProvider.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/EventSourceProvider.java
@@ -10,6 +10,4 @@ public interface EventSourceProvider<P extends HasMetadata> {
    * @return the initiated event source.
    */
   EventSource initEventSource(EventSourceContext<P> context);
-
-  EventSource getEventSource();
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/ResourceOwner.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/ResourceOwner.java
@@ -14,7 +14,9 @@ public interface ResourceOwner<R, P extends HasMetadata> {
   Class<R> resourceType();
 
   /**
-   * Retrieves the resource associated with the specified primary one
+   * Retrieves the resource associated with the specified primary one, returning the actual state of
+   * the resource. Typically, this state might come from a local cache, updated after
+   * reconciliation.
    *
    * @param primary the primary resource for which we want to retrieve the secondary resource
    * @return an {@link Optional} containing the secondary resource or {@link Optional#empty()} if it

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/ResourceOwner.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/ResourceOwner.java
@@ -1,0 +1,24 @@
+package io.javaoperatorsdk.operator.processing;
+
+import java.util.Optional;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+
+public interface ResourceOwner<R, P extends HasMetadata> {
+
+  /**
+   * Retrieves the resource type associated with this ResourceOwner
+   *
+   * @return the resource type associated with this ResourceOwner
+   */
+  Class<R> resourceType();
+
+  /**
+   * Retrieves the resource associated with the specified primary one
+   *
+   * @param primary the primary resource for which we want to retrieve the secondary resource
+   * @return an {@link Optional} containing the secondary resource or {@link Optional#empty()} if it
+   *         doesn't exist
+   */
+  Optional<R> getAssociatedResource(P primary);
+}

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/AbstractDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/AbstractDependentResource.java
@@ -71,18 +71,34 @@ public abstract class AbstractDependentResource<R, P extends HasMetadata>
   protected R handleCreate(R desired, P primary, Context<P> context) {
     ResourceID resourceID = ResourceID.fromResource(primary);
     R created = creator.create(desired, primary, context);
-    cacheAfterCreate(resourceID, created);
+    processPostCreate(resourceID, created);
     return created;
   }
 
-  protected abstract void cacheAfterCreate(ResourceID resourceID, R created);
+  /**
+   * Allows sub-classes to perform additional processing (e.g. caching) on the created resource if
+   * needed.
+   *
+   * @param primaryResourceId the {@link ResourceID} of the primary resource associated with the
+   *        newly created resource
+   * @param created the newly created resource
+   */
+  protected abstract void processPostCreate(ResourceID primaryResourceId, R created);
 
-  protected abstract void cacheAfterUpdate(R actual, ResourceID resourceID, R updated);
+  /**
+   * Allows sub-classes to perform additional processing on the updated resource if needed.
+   *
+   * @param primaryResourceId the {@link ResourceID} of the primary resource associated with the
+   *        newly updated resource
+   * @param updated the updated resource
+   * @param actual the resource as it was before the update
+   */
+  protected abstract void processPostUpdate(ResourceID primaryResourceId, R updated, R actual);
 
   protected R handleUpdate(R actual, R desired, P primary, Context<P> context) {
     ResourceID resourceID = ResourceID.fromResource(primary);
     R updated = updater.update(actual, desired, primary, context);
-    cacheAfterUpdate(actual, resourceID, updated);
+    processPostUpdate(resourceID, updated, actual);
     return updated;
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/AbstractDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/AbstractDependentResource.java
@@ -28,7 +28,7 @@ public abstract class AbstractDependentResource<R, P extends HasMetadata>
 
   @Override
   public ReconcileResult<R> reconcile(P primary, Context<P> context) {
-    var maybeActual = getResource(primary);
+    var maybeActual = getAssociatedResource(primary);
     if (creatable || updatable) {
       if (maybeActual.isEmpty()) {
         if (creatable) {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/AbstractDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/AbstractDependentResource.java
@@ -71,7 +71,7 @@ public abstract class AbstractDependentResource<R, P extends HasMetadata>
   protected R handleCreate(R desired, P primary, Context<P> context) {
     ResourceID resourceID = ResourceID.fromResource(primary);
     R created = creator.create(desired, primary, context);
-    processPostCreate(resourceID, created);
+    onCreated(resourceID, created);
     return created;
   }
 
@@ -83,7 +83,7 @@ public abstract class AbstractDependentResource<R, P extends HasMetadata>
    *        newly created resource
    * @param created the newly created resource
    */
-  protected abstract void processPostCreate(ResourceID primaryResourceId, R created);
+  protected abstract void onCreated(ResourceID primaryResourceId, R created);
 
   /**
    * Allows sub-classes to perform additional processing on the updated resource if needed.
@@ -93,12 +93,12 @@ public abstract class AbstractDependentResource<R, P extends HasMetadata>
    * @param updated the updated resource
    * @param actual the resource as it was before the update
    */
-  protected abstract void processPostUpdate(ResourceID primaryResourceId, R updated, R actual);
+  protected abstract void onUpdated(ResourceID primaryResourceId, R updated, R actual);
 
   protected R handleUpdate(R actual, R desired, P primary, Context<P> context) {
     ResourceID resourceID = ResourceID.fromResource(primary);
     R updated = updater.update(actual, desired, primary, context);
-    processPostUpdate(resourceID, updated, actual);
+    onUpdated(resourceID, updated, actual);
     return updated;
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/AbstractDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/AbstractDependentResource.java
@@ -7,9 +7,6 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.Deleter;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
-import io.javaoperatorsdk.operator.api.reconciler.dependent.EventSourceProvider;
-import io.javaoperatorsdk.operator.api.reconciler.dependent.RecentOperationCacheFiller;
-import io.javaoperatorsdk.operator.api.reconciler.dependent.RecentOperationEventFilter;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.ReconcileResult;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 
@@ -68,89 +65,20 @@ public abstract class AbstractDependentResource<R, P extends HasMetadata>
 
   protected R handleCreate(R desired, P primary, Context<P> context) {
     ResourceID resourceID = ResourceID.fromResource(primary);
-    R created = null;
-    try {
-      prepareEventFiltering(desired, resourceID);
-      created = creator.create(desired, primary, context);
-      cacheAfterCreate(resourceID, created);
-      return created;
-    } catch (RuntimeException e) {
-      cleanupAfterEventFiltering(desired, resourceID, created);
-      throw e;
-    }
+    R created = creator.create(desired, primary, context);
+    cacheAfterCreate(resourceID, created);
+    return created;
   }
 
-  private void cleanupAfterEventFiltering(R desired, ResourceID resourceID, R created) {
-    if (isFilteringEventSource()) {
-      eventSourceAsRecentOperationEventFilter()
-          .cleanupOnCreateOrUpdateEventFiltering(resourceID, created);
-    }
-  }
+  protected abstract void cacheAfterCreate(ResourceID resourceID, R created);
 
-  private void cacheAfterCreate(ResourceID resourceID, R created) {
-    if (isRecentOperationCacheFiller()) {
-      eventSourceAsRecentOperationCacheFiller().handleRecentResourceCreate(resourceID, created);
-    }
-  }
-
-  private void cacheAfterUpdate(R actual, ResourceID resourceID, R updated) {
-    if (isRecentOperationCacheFiller()) {
-      eventSourceAsRecentOperationCacheFiller().handleRecentResourceUpdate(resourceID, updated,
-          actual);
-    }
-  }
-
-  private void prepareEventFiltering(R desired, ResourceID resourceID) {
-    if (isFilteringEventSource()) {
-      eventSourceAsRecentOperationEventFilter().prepareForCreateOrUpdateEventFiltering(resourceID,
-          desired);
-    }
-  }
+  protected abstract void cacheAfterUpdate(R actual, ResourceID resourceID, R updated);
 
   protected R handleUpdate(R actual, R desired, P primary, Context<P> context) {
     ResourceID resourceID = ResourceID.fromResource(primary);
-    R updated = null;
-    try {
-      prepareEventFiltering(desired, resourceID);
-      updated = updater.update(actual, desired, primary, context);
-      cacheAfterUpdate(actual, resourceID, updated);
-      return updated;
-    } catch (RuntimeException e) {
-      cleanupAfterEventFiltering(desired, resourceID, updated);
-      throw e;
-    }
-  }
-
-  @SuppressWarnings("unchecked")
-  private RecentOperationEventFilter<R> eventSourceAsRecentOperationEventFilter() {
-    return (RecentOperationEventFilter<R>) ((EventSourceProvider<P>) this).getEventSource();
-  }
-
-  @SuppressWarnings("unchecked")
-  private RecentOperationCacheFiller<R> eventSourceAsRecentOperationCacheFiller() {
-    return (RecentOperationCacheFiller<R>) ((EventSourceProvider<P>) this).getEventSource();
-  }
-
-  @SuppressWarnings("unchecked")
-  // this cannot be done in constructor since event source might be initialized later
-  protected boolean isFilteringEventSource() {
-    if (this instanceof EventSourceProvider) {
-      final var eventSource = ((EventSourceProvider<P>) this).getEventSource();
-      return eventSource instanceof RecentOperationEventFilter;
-    } else {
-      return false;
-    }
-  }
-
-  @SuppressWarnings("unchecked")
-  // this cannot be done in constructor since event source might be initialized later
-  protected boolean isRecentOperationCacheFiller() {
-    if (this instanceof EventSourceProvider) {
-      final var eventSource = ((EventSourceProvider<P>) this).getEventSource();
-      return eventSource instanceof RecentOperationCacheFiller;
-    } else {
-      return false;
-    }
+    R updated = updater.update(actual, desired, primary, context);
+    cacheAfterUpdate(actual, resourceID, updated);
+    return updated;
   }
 
   protected R desired(P primary, Context<P> context) {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/AbstractEventSourceHolderDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/AbstractEventSourceHolderDependentResource.java
@@ -86,13 +86,13 @@ public abstract class AbstractEventSourceHolderDependentResource<R, P extends Ha
   }
 
 
-  protected void processPostCreate(ResourceID primaryResourceId, R created) {
+  protected void onCreated(ResourceID primaryResourceId, R created) {
     if (isCacheFillerEventSource) {
       recentOperationCacheFiller().handleRecentResourceCreate(primaryResourceId, created);
     }
   }
 
-  protected void processPostUpdate(ResourceID primaryResourceId, R updated, R actual) {
+  protected void onUpdated(ResourceID primaryResourceId, R updated, R actual) {
     if (isCacheFillerEventSource) {
       recentOperationCacheFiller().handleRecentResourceUpdate(primaryResourceId, updated, actual);
     }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/AbstractEventSourceHolderDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/AbstractEventSourceHolderDependentResource.java
@@ -1,0 +1,120 @@
+package io.javaoperatorsdk.operator.processing.dependent;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.javaoperatorsdk.operator.OperatorException;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.EventSourceProvider;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.RecentOperationCacheFiller;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.RecentOperationEventFilter;
+import io.javaoperatorsdk.operator.processing.event.EventHandler;
+import io.javaoperatorsdk.operator.processing.event.ResourceID;
+import io.javaoperatorsdk.operator.processing.event.source.EventSource;
+
+public abstract class AbstractEventSourceHolderDependentResource<R, P extends HasMetadata, T extends EventSource>
+    extends AbstractDependentResource<R, P> implements EventSource, EventSourceProvider<P> {
+  private T eventSource;
+  private boolean isFilteringEventSource;
+  private boolean isCacheFillerEventSource;
+
+  @Override
+  public void start() throws OperatorException {
+    eventSource.start();
+  }
+
+  @Override
+  public void stop() throws OperatorException {
+    eventSource.stop();
+  }
+
+  public EventSource initEventSource(EventSourceContext<P> context) {
+    // some sub-classes (e.g. KubernetesDependentResource) can have their event source created
+    // before this method is called in the managed case, so only create the event source if it
+    // hasn't already been set
+    if (eventSource == null) {
+      eventSource = createEventSource(context);
+    }
+
+    // but we still need to record which interfaces the event source implements even if it has
+    // already been set before this method is called
+    isFilteringEventSource = eventSource instanceof RecentOperationEventFilter;
+    isCacheFillerEventSource = eventSource instanceof RecentOperationCacheFiller;
+    return this;
+  }
+
+  protected abstract T createEventSource(EventSourceContext<P> context);
+
+  protected void setEventSource(T eventSource) {
+    this.eventSource = eventSource;
+  }
+
+  @Override
+  public void setEventHandler(EventHandler handler) {
+    eventSource.setEventHandler(handler);
+  }
+
+  protected T eventSource() {
+    return eventSource;
+  }
+
+  protected R handleCreate(R desired, P primary, Context<P> context) {
+    ResourceID resourceID = ResourceID.fromResource(primary);
+    R created = null;
+    try {
+      prepareEventFiltering(desired, resourceID);
+      created = super.handleCreate(desired, primary, context);
+      return created;
+    } catch (RuntimeException e) {
+      cleanupAfterEventFiltering(desired, resourceID, created);
+      throw e;
+    }
+  }
+
+  protected R handleUpdate(R actual, R desired, P primary, Context<P> context) {
+    ResourceID resourceID = ResourceID.fromResource(primary);
+    R updated = null;
+    try {
+      prepareEventFiltering(desired, resourceID);
+      updated = super.handleUpdate(actual, desired, primary, context);
+      return updated;
+    } catch (RuntimeException e) {
+      cleanupAfterEventFiltering(desired, resourceID, updated);
+      throw e;
+    }
+  }
+
+
+  protected void cacheAfterCreate(ResourceID resourceID, R created) {
+    if (isCacheFillerEventSource) {
+      recentOperationCacheFiller().handleRecentResourceCreate(resourceID, created);
+    }
+  }
+
+  protected void cacheAfterUpdate(R actual, ResourceID resourceID, R updated) {
+    if (isCacheFillerEventSource) {
+      recentOperationCacheFiller().handleRecentResourceUpdate(resourceID, updated, actual);
+    }
+  }
+
+  private void prepareEventFiltering(R desired, ResourceID resourceID) {
+    if (isFilteringEventSource) {
+      recentOperationEventFilter().prepareForCreateOrUpdateEventFiltering(resourceID, desired);
+    }
+  }
+
+  private void cleanupAfterEventFiltering(R desired, ResourceID resourceID, R created) {
+    if (isFilteringEventSource) {
+      recentOperationEventFilter().cleanupOnCreateOrUpdateEventFiltering(resourceID, created);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private RecentOperationEventFilter<R> recentOperationEventFilter() {
+    return (RecentOperationEventFilter<R>) eventSource;
+  }
+
+  @SuppressWarnings("unchecked")
+  private RecentOperationCacheFiller<R> recentOperationCacheFiller() {
+    return (RecentOperationCacheFiller<R>) eventSource;
+  }
+}

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/AbstractEventSourceHolderDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/AbstractEventSourceHolderDependentResource.java
@@ -86,15 +86,15 @@ public abstract class AbstractEventSourceHolderDependentResource<R, P extends Ha
   }
 
 
-  protected void cacheAfterCreate(ResourceID resourceID, R created) {
+  protected void processPostCreate(ResourceID primaryResourceId, R created) {
     if (isCacheFillerEventSource) {
-      recentOperationCacheFiller().handleRecentResourceCreate(resourceID, created);
+      recentOperationCacheFiller().handleRecentResourceCreate(primaryResourceId, created);
     }
   }
 
-  protected void cacheAfterUpdate(R actual, ResourceID resourceID, R updated) {
+  protected void processPostUpdate(ResourceID primaryResourceId, R updated, R actual) {
     if (isCacheFillerEventSource) {
-      recentOperationCacheFiller().handleRecentResourceUpdate(resourceID, updated, actual);
+      recentOperationCacheFiller().handleRecentResourceUpdate(primaryResourceId, updated, actual);
     }
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/AbstractEventSourceHolderDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/AbstractEventSourceHolderDependentResource.java
@@ -10,9 +10,11 @@ import io.javaoperatorsdk.operator.api.reconciler.dependent.RecentOperationEvent
 import io.javaoperatorsdk.operator.processing.event.EventHandler;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import io.javaoperatorsdk.operator.processing.event.source.EventSource;
+import io.javaoperatorsdk.operator.processing.event.source.ResourceEventSource;
 
-public abstract class AbstractEventSourceHolderDependentResource<R, P extends HasMetadata, T extends EventSource>
-    extends AbstractDependentResource<R, P> implements EventSource, EventSourceProvider<P> {
+public abstract class AbstractEventSourceHolderDependentResource<R, P extends HasMetadata, T extends ResourceEventSource<R, P>>
+    extends AbstractDependentResource<R, P>
+    implements ResourceEventSource<R, P>, EventSourceProvider<P> {
   private T eventSource;
   private boolean isFilteringEventSource;
   private boolean isCacheFillerEventSource;

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/external/AbstractCachingDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/external/AbstractCachingDependentResource.java
@@ -16,7 +16,7 @@ public abstract class AbstractCachingDependentResource<R, P extends HasMetadata>
   }
 
   public Optional<R> fetchResource(P primaryResource) {
-    return eventSource().getAssociated(primaryResource);
+    return eventSource().getAssociatedResource(primaryResource);
   }
 
   @Override
@@ -25,7 +25,7 @@ public abstract class AbstractCachingDependentResource<R, P extends HasMetadata>
   }
 
   @Override
-  public Optional<R> getResource(P primaryResource) {
-    return eventSource().getAssociated(primaryResource);
+  public Optional<R> getAssociatedResource(P primaryResource) {
+    return eventSource().getAssociatedResource(primaryResource);
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/external/AbstractCachingDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/external/AbstractCachingDependentResource.java
@@ -3,16 +3,12 @@ package io.javaoperatorsdk.operator.processing.dependent.external;
 import java.util.Optional;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.javaoperatorsdk.operator.api.reconciler.dependent.EventSourceProvider;
-import io.javaoperatorsdk.operator.processing.dependent.AbstractDependentResource;
+import io.javaoperatorsdk.operator.processing.dependent.AbstractEventSourceHolderDependentResource;
 import io.javaoperatorsdk.operator.processing.event.ExternalResourceCachingEventSource;
-import io.javaoperatorsdk.operator.processing.event.source.EventSource;
 
 public abstract class AbstractCachingDependentResource<R, P extends HasMetadata>
-    extends AbstractDependentResource<R, P>
-    implements EventSourceProvider<P> {
-
-  protected ExternalResourceCachingEventSource<R, P> eventSource;
+    extends
+    AbstractEventSourceHolderDependentResource<R, P, ExternalResourceCachingEventSource<R, P>> {
   private final Class<R> resourceType;
 
   protected AbstractCachingDependentResource(Class<R> resourceType) {
@@ -20,12 +16,7 @@ public abstract class AbstractCachingDependentResource<R, P extends HasMetadata>
   }
 
   public Optional<R> fetchResource(P primaryResource) {
-    return eventSource.getAssociated(primaryResource);
-  }
-
-  @Override
-  public EventSource getEventSource() {
-    return eventSource;
+    return eventSource().getAssociated(primaryResource);
   }
 
   @Override
@@ -35,6 +26,6 @@ public abstract class AbstractCachingDependentResource<R, P extends HasMetadata>
 
   @Override
   public Optional<R> getResource(P primaryResource) {
-    return eventSource.getAssociated(primaryResource);
+    return eventSource().getAssociated(primaryResource);
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/external/AbstractSimpleDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/external/AbstractSimpleDependentResource.java
@@ -59,17 +59,13 @@ public abstract class AbstractSimpleDependentResource<R, P extends HasMetadata>
   protected abstract void deleteResource(P primary, Context<P> context);
 
   @Override
-  protected R handleCreate(R desired, P primary, Context<P> context) {
-    var res = this.creator.create(desired, primary, context);
-    cache.put(ResourceID.fromResource(primary), res);
-    return res;
+  protected void cacheAfterCreate(ResourceID resourceID, R created) {
+    cache.put(resourceID, created);
   }
 
   @Override
-  protected R handleUpdate(R actual, R desired, P primary, Context<P> context) {
-    var res = updater.update(actual, desired, primary, context);
-    cache.put(ResourceID.fromResource(primary), res);
-    return res;
+  protected void cacheAfterUpdate(R actual, ResourceID resourceID, R updated) {
+    cache.put(resourceID, updated);
   }
 
   public Matcher.Result<R> match(R actualResource, P primary, Context<P> context) {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/external/AbstractSimpleDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/external/AbstractSimpleDependentResource.java
@@ -59,12 +59,12 @@ public abstract class AbstractSimpleDependentResource<R, P extends HasMetadata>
   protected abstract void deleteResource(P primary, Context<P> context);
 
   @Override
-  protected void processPostCreate(ResourceID primaryResourceId, R created) {
+  protected void onCreated(ResourceID primaryResourceId, R created) {
     cache.put(primaryResourceId, created);
   }
 
   @Override
-  protected void processPostUpdate(ResourceID primaryResourceId, R updated, R actual) {
+  protected void onUpdated(ResourceID primaryResourceId, R updated, R actual) {
     cache.put(primaryResourceId, updated);
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/external/AbstractSimpleDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/external/AbstractSimpleDependentResource.java
@@ -31,7 +31,7 @@ public abstract class AbstractSimpleDependentResource<R, P extends HasMetadata>
   }
 
   @Override
-  public Optional<R> getResource(HasMetadata primaryResource) {
+  public Optional<R> getAssociatedResource(HasMetadata primaryResource) {
     return cache.get(ResourceID.fromResource(primaryResource));
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/external/AbstractSimpleDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/external/AbstractSimpleDependentResource.java
@@ -59,13 +59,13 @@ public abstract class AbstractSimpleDependentResource<R, P extends HasMetadata>
   protected abstract void deleteResource(P primary, Context<P> context);
 
   @Override
-  protected void cacheAfterCreate(ResourceID resourceID, R created) {
-    cache.put(resourceID, created);
+  protected void processPostCreate(ResourceID primaryResourceId, R created) {
+    cache.put(primaryResourceId, created);
   }
 
   @Override
-  protected void cacheAfterUpdate(R actual, ResourceID resourceID, R updated) {
-    cache.put(resourceID, updated);
+  protected void processPostUpdate(ResourceID primaryResourceId, R updated, R actual) {
+    cache.put(primaryResourceId, updated);
   }
 
   public Matcher.Result<R> match(R actualResource, P primary, Context<P> context) {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/external/PerResourcePollingDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/external/PerResourcePollingDependentResource.java
@@ -2,7 +2,7 @@ package io.javaoperatorsdk.operator.processing.dependent.external;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
-import io.javaoperatorsdk.operator.processing.event.source.EventSource;
+import io.javaoperatorsdk.operator.processing.event.ExternalResourceCachingEventSource;
 import io.javaoperatorsdk.operator.processing.event.source.polling.PerResourcePollingEventSource;
 
 public abstract class PerResourcePollingDependentResource<R, P extends HasMetadata>
@@ -17,9 +17,9 @@ public abstract class PerResourcePollingDependentResource<R, P extends HasMetada
   }
 
   @Override
-  public EventSource initEventSource(EventSourceContext<P> context) {
-    eventSource = new PerResourcePollingEventSource<>(this, context.getPrimaryCache(),
+  protected ExternalResourceCachingEventSource<R, P> createEventSource(
+      EventSourceContext<P> context) {
+    return new PerResourcePollingEventSource<>(this, context.getPrimaryCache(),
         getPollingPeriod(), resourceType());
-    return eventSource;
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/external/PollingDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/external/PollingDependentResource.java
@@ -5,8 +5,8 @@ import java.util.function.Supplier;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
+import io.javaoperatorsdk.operator.processing.event.ExternalResourceCachingEventSource;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
-import io.javaoperatorsdk.operator.processing.event.source.EventSource;
 import io.javaoperatorsdk.operator.processing.event.source.polling.PollingEventSource;
 
 public abstract class PollingDependentResource<R, P extends HasMetadata>
@@ -21,8 +21,8 @@ public abstract class PollingDependentResource<R, P extends HasMetadata>
   }
 
   @Override
-  public EventSource initEventSource(EventSourceContext<P> context) {
-    eventSource = new PollingEventSource<>(this, getPollingPeriod(), resourceType());
-    return eventSource;
+  protected ExternalResourceCachingEventSource<R, P> createEventSource(
+      EventSourceContext<P> context) {
+    return new PollingEventSource<>(this, getPollingPeriod(), resourceType());
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResource.java
@@ -97,7 +97,7 @@ public abstract class KubernetesDependentResource<R extends HasMetadata, P exten
 
   public void delete(P primary, Context<P> context) {
     if (!addOwnerReference()) {
-      var resource = getResource(primary);
+      var resource = getAssociatedResource(primary);
       resource.ifPresent(r -> client.resource(r).delete());
     }
   }
@@ -134,8 +134,8 @@ public abstract class KubernetesDependentResource<R extends HasMetadata, P exten
   }
 
   @Override
-  public Optional<R> getResource(P primaryResource) {
-    return eventSource().getAssociated(primaryResource);
+  public Optional<R> getAssociatedResource(P primaryResource) {
+    return eventSource().getAssociatedResource(primaryResource);
   }
 
   @Override

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventSourceManager.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventSourceManager.java
@@ -86,7 +86,7 @@ public class EventSourceManager<R extends HasMetadata> implements LifecycleAware
       if (eventSource instanceof ResourceEventSource) {
         ResourceEventSource source = (ResourceEventSource) eventSource;
         log.debug("{} event source {} for {}", event, eventSource.name(),
-            source.getResourceClass());
+            source.resourceType());
       } else {
         log.debug("{} event source {}", event, eventSource.name());
       }
@@ -171,12 +171,12 @@ public class EventSourceManager<R extends HasMetadata> implements LifecycleAware
     return eventSources.controllerResourceEventSource();
   }
 
-  public <S> Optional<ResourceEventSource<R, S>> getResourceEventSourceFor(
+  public <S> Optional<ResourceEventSource<S, R>> getResourceEventSourceFor(
       Class<S> dependentType) {
     return getResourceEventSourceFor(dependentType, null);
   }
 
-  public <S> Optional<ResourceEventSource<R, S>> getResourceEventSourceFor(
+  public <S> Optional<ResourceEventSource<S, R>> getResourceEventSourceFor(
       Class<S> dependentType, String qualifier) {
     if (dependentType == null) {
       return Optional.empty();

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/AbstractResourceEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/AbstractResourceEventSource.java
@@ -4,7 +4,7 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 
 public abstract class AbstractResourceEventSource<P extends HasMetadata, R>
     extends AbstractEventSource
-    implements ResourceEventSource<P, R> {
+    implements ResourceEventSource<R, P> {
   private final Class<R> resourceClass;
 
   protected AbstractResourceEventSource(Class<R> resourceClass) {
@@ -12,7 +12,7 @@ public abstract class AbstractResourceEventSource<P extends HasMetadata, R>
   }
 
   @Override
-  public Class<R> getResourceClass() {
+  public Class<R> resourceType() {
     return resourceClass;
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/CachingEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/CachingEventSource.java
@@ -54,7 +54,7 @@ public abstract class CachingEventSource<R, P extends HasMetadata>
   }
 
   @Override
-  public Optional<R> getAssociated(P primary) {
+  public Optional<R> getAssociatedResource(P primary) {
     return cache.get(ResourceID.fromResource(primary));
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/ResourceEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/ResourceEventSource.java
@@ -1,12 +1,9 @@
 package io.javaoperatorsdk.operator.processing.event.source;
 
-import java.util.Optional;
-
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.javaoperatorsdk.operator.processing.ResourceOwner;
 
-public interface ResourceEventSource<P extends HasMetadata, R> extends EventSource {
+public interface ResourceEventSource<R, P extends HasMetadata> extends EventSource,
+    ResourceOwner<R, P> {
 
-  Class<R> getResourceClass();
-
-  Optional<R> getAssociated(P primary);
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/controller/ControllerResourceEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/controller/ControllerResourceEventSource.java
@@ -29,6 +29,7 @@ public class ControllerResourceEventSource<T extends HasMetadata>
   private final Controller<T> controller;
   private final ResourceEventFilter<T> filter;
 
+  @SuppressWarnings("unchecked")
   public ControllerResourceEventSource(Controller<T> controller) {
     super(controller.getCRClient(), controller.getConfiguration());
     this.controller = controller;
@@ -101,7 +102,7 @@ public class ControllerResourceEventSource<T extends HasMetadata>
   }
 
   @Override
-  public Optional<T> getAssociated(T primary) {
+  public Optional<T> getAssociatedResource(T primary) {
     return get(ResourceID.fromResource(primary));
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSource.java
@@ -152,7 +152,7 @@ public class InformerEventSource<R extends HasMetadata, P extends HasMetadata>
    * @return the informed resource associated with the specified primary resource
    */
   @Override
-  public Optional<R> getAssociated(P resource) {
+  public Optional<R> getAssociatedResource(P resource) {
     final var id = configuration.getAssociatedResourceIdentifier().associatedSecondaryID(resource);
     return get(id);
   }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSource.java
@@ -165,8 +165,7 @@ public class InformerEventSource<R extends HasMetadata, P extends HasMetadata>
   public synchronized void handleRecentResourceUpdate(ResourceID resourceID, R resource,
       R previousResourceVersion) {
     handleRecentCreateOrUpdate(resource,
-        () -> super.handleRecentResourceUpdate(resourceID, resource,
-            previousResourceVersion));
+        () -> super.handleRecentResourceUpdate(resourceID, resource, previousResourceVersion));
   }
 
   @Override

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/ManagedInformerEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/ManagedInformerEventSource.java
@@ -93,7 +93,7 @@ public abstract class ManagedInformerEventSource<R extends HasMetadata, P extend
   }
 
   @Override
-  public Optional<R> getAssociated(P primary) {
+  public Optional<R> getAssociatedResource(P primary) {
     return get(ResourceID.fromResource(primary));
   }
 
@@ -119,9 +119,7 @@ public abstract class ManagedInformerEventSource<R extends HasMetadata, P extend
     return manager().list(namespace, predicate);
   }
 
-  ManagedInformerEventSource<R, P, C> setTemporalResourceCache(
-      TemporaryResourceCache<R> temporaryResourceCache) {
+  void setTemporalResourceCache(TemporaryResourceCache<R> temporaryResourceCache) {
     this.temporaryResourceCache = temporaryResourceCache;
-    return this;
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/polling/PerResourcePollingEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/polling/PerResourcePollingEventSource.java
@@ -132,7 +132,7 @@ public class PerResourcePollingEventSource<R, P extends HasMetadata>
    * @return the related resource for this event source
    */
   @Override
-  public Optional<R> getAssociated(P primary) {
+  public Optional<R> getAssociatedResource(P primary) {
     return getValueFromCacheOrSupplier(ResourceID.fromResource(primary));
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/polling/PollingEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/polling/PollingEventSource.java
@@ -1,6 +1,9 @@
 package io.javaoperatorsdk.operator.processing.event.source.polling;
 
-import java.util.*;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Timer;
+import java.util.TimerTask;
 import java.util.function.Supplier;
 
 import org.slf4j.Logger;
@@ -95,7 +98,7 @@ public class PollingEventSource<R, P extends HasMetadata>
    * @return related resource
    */
   @Override
-  public Optional<R> getAssociated(P primary) {
+  public Optional<R> getAssociatedResource(P primary) {
     return getCachedValue(ResourceID.fromResource(primary));
   }
 }

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/config/UtilsTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/config/UtilsTest.java
@@ -98,7 +98,7 @@ class UtilsTest {
     }
 
     @Override
-    public Optional<Deployment> getResource(TestCustomResource primaryResource) {
+    public Optional<Deployment> getAssociatedResource(TestCustomResource primaryResource) {
       return Optional.empty();
     }
 

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/external/AbstractSimpleDependentResourceTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/external/AbstractSimpleDependentResourceTest.java
@@ -45,14 +45,14 @@ class AbstractSimpleDependentResourceTest {
     simpleDependentResource.reconcile(TestUtils.testCustomResource1(), null);
 
     verify(supplierMock, times(1)).get();
-    assertThat(simpleDependentResource.getResource(TestUtils.testCustomResource1()))
+    assertThat(simpleDependentResource.getAssociatedResource(TestUtils.testCustomResource1()))
         .isPresent()
         .isEqualTo(Optional.of(SampleExternalResource.testResource1()));
   }
 
   @Test
   void getResourceReadsTheResourceFromCache() {
-    simpleDependentResource.getResource(TestUtils.testCustomResource1());
+    simpleDependentResource.getAssociatedResource(TestUtils.testCustomResource1());
 
     verify(supplierMock, times(0)).get();
     verify(updatableCacheMock, times(1)).get(any());

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/EventSourceManagerTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/EventSourceManagerTest.java
@@ -86,7 +86,7 @@ class EventSourceManagerTest {
     assertTrue(source.get() instanceof ControllerResourceEventSource);
 
     CachingEventSource eventSource = mock(CachingEventSource.class);
-    when(eventSource.getResourceClass()).thenReturn(String.class);
+    when(eventSource.resourceType()).thenReturn(String.class);
     manager.registerEventSource(eventSource);
 
     source = manager.getResourceEventSourceFor(String.class);
@@ -100,11 +100,11 @@ class EventSourceManagerTest {
     final var name = "name1";
 
     CachingEventSource eventSource = mock(CachingEventSource.class);
-    when(eventSource.getResourceClass()).thenReturn(TestCustomResource.class);
+    when(eventSource.resourceType()).thenReturn(TestCustomResource.class);
     manager.registerEventSource(name, eventSource);
 
     eventSource = mock(CachingEventSource.class);
-    when(eventSource.getResourceClass()).thenReturn(TestCustomResource.class);
+    when(eventSource.resourceType()).thenReturn(TestCustomResource.class);
     final var source = eventSource;
 
     final var exception = assertThrows(OperatorException.class,
@@ -121,11 +121,11 @@ class EventSourceManagerTest {
     EventSourceManager manager = initManager();
 
     CachingEventSource eventSource = mock(CachingEventSource.class);
-    when(eventSource.getResourceClass()).thenReturn(TestCustomResource.class);
+    when(eventSource.resourceType()).thenReturn(TestCustomResource.class);
     manager.registerEventSource("name1", eventSource);
 
     CachingEventSource eventSource2 = mock(CachingEventSource.class);
-    when(eventSource2.getResourceClass()).thenReturn(TestCustomResource.class);
+    when(eventSource2.resourceType()).thenReturn(TestCustomResource.class);
     manager.registerEventSource("name2", eventSource2);
 
     final var exception = assertThrows(IllegalArgumentException.class,
@@ -144,7 +144,7 @@ class EventSourceManagerTest {
     EventSourceManager manager = initManager();
 
     CachingEventSource eventSource = mock(CachingEventSource.class);
-    when(eventSource.getResourceClass()).thenReturn(String.class);
+    when(eventSource.resourceType()).thenReturn(String.class);
     manager.registerEventSource(eventSource);
 
     final Set<EventSource> sources = manager.getRegisteredEventSources();

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/standalonedependent/StandaloneDependentTestReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/standalonedependent/StandaloneDependentTestReconciler.java
@@ -47,7 +47,7 @@ public class StandaloneDependentTestReconciler
       StandaloneDependentTestCustomResource primary,
       Context<StandaloneDependentTestCustomResource> context) {
     deploymentDependent.reconcile(primary, context);
-    Optional<Deployment> deployment = deploymentDependent.getResource(primary);
+    Optional<Deployment> deployment = deploymentDependent.getAssociatedResource(primary);
     if (deployment.isEmpty()) {
       throw new IllegalStateException("Resource should not be empty after reconcile.");
     }

--- a/sample-operators/mysql-schema/src/main/java/io/javaoperatorsdk/operator/sample/dependent/SecretDependentResource.java
+++ b/sample-operators/mysql-schema/src/main/java/io/javaoperatorsdk/operator/sample/dependent/SecretDependentResource.java
@@ -48,8 +48,8 @@ public class SecretDependentResource extends KubernetesDependentResource<Secret,
         .build();
   }
 
-  private String getSecretName(String name) {
-    return String.format(SECRET_FORMAT, name);
+  private String getSecretName(String schemaName) {
+    return String.format(SECRET_FORMAT, schemaName);
   }
 
   @Override
@@ -61,7 +61,6 @@ public class SecretDependentResource extends KubernetesDependentResource<Secret,
   @Override
   public ResourceID associatedSecondaryID(MySQLSchema primary) {
     return new ResourceID(
-        String.format(SECRET_FORMAT, primary.getMetadata().getName()),
-        primary.getMetadata().getNamespace());
+        getSecretName(primary.getMetadata().getName()), primary.getMetadata().getNamespace());
   }
 }

--- a/sample-operators/webpage/src/main/java/io/javaoperatorsdk/operator/sample/WebPageStandaloneDependentsReconciler.java
+++ b/sample-operators/webpage/src/main/java/io/javaoperatorsdk/operator/sample/WebPageStandaloneDependentsReconciler.java
@@ -70,7 +70,8 @@ public class WebPageStandaloneDependentsReconciler
   }
 
   private String getConfigMapName(WebPage webPage) {
-    return dependent("configmap").getResource(webPage).orElseThrow().getMetadata().getName();
+    return dependent("configmap").getAssociatedResource(webPage).orElseThrow().getMetadata()
+        .getName();
   }
 
   @Override


### PR DESCRIPTION
The benefit of this change is multi-fold:
- simplifies AbstractDependentResource which doesn't have to handle
  cases it should not be concerned about
- allows to share more code with AbstractSimpleDependentResource
- enforces that the same name is used for the DependentResource and
  EventSource even in the standalone mode when using one of the provided
  implementations
