### PR TITLE
fix: rename getAssiciatedResource to getSecondaryResource

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/DefaultContext.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/DefaultContext.java
@@ -32,7 +32,7 @@ public class DefaultContext<P extends HasMetadata> implements Context<P> {
   public <T> Optional<T> getSecondaryResource(Class<T> expectedType, String eventSourceName) {
     return controller.getEventSourceManager()
         .getResourceEventSourceFor(expectedType, eventSourceName)
-        .flatMap(es -> es.getResource(primaryResource));
+        .flatMap(es -> es.getSecondaryResource(primaryResource));
   }
 
   @Override

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/DefaultContext.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/DefaultContext.java
@@ -32,7 +32,7 @@ public class DefaultContext<P extends HasMetadata> implements Context<P> {
   public <T> Optional<T> getSecondaryResource(Class<T> expectedType, String eventSourceName) {
     return controller.getEventSourceManager()
         .getResourceEventSourceFor(expectedType, eventSourceName)
-        .flatMap(es -> es.getAssociatedResource(primaryResource));
+        .flatMap(es -> es.getResource(primaryResource));
   }
 
   @Override

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/ResourceOwner.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/ResourceOwner.java
@@ -22,5 +22,5 @@ public interface ResourceOwner<R, P extends HasMetadata> {
    * @return an {@link Optional} containing the secondary resource or {@link Optional#empty()} if it
    *         doesn't exist
    */
-  Optional<R> getAssociatedResource(P primary);
+  Optional<R> getResource(P primary);
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/ResourceOwner.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/ResourceOwner.java
@@ -22,5 +22,5 @@ public interface ResourceOwner<R, P extends HasMetadata> {
    * @return an {@link Optional} containing the secondary resource or {@link Optional#empty()} if it
    *         doesn't exist
    */
-  Optional<R> getResource(P primary);
+  Optional<R> getSecondaryResource(P primary);
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/AbstractDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/AbstractDependentResource.java
@@ -28,7 +28,7 @@ public abstract class AbstractDependentResource<R, P extends HasMetadata>
 
   @Override
   public ReconcileResult<R> reconcile(P primary, Context<P> context) {
-    var maybeActual = getResource(primary);
+    var maybeActual = getSecondaryResource(primary);
     if (creatable || updatable) {
       if (maybeActual.isEmpty()) {
         if (creatable) {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/AbstractDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/AbstractDependentResource.java
@@ -28,7 +28,7 @@ public abstract class AbstractDependentResource<R, P extends HasMetadata>
 
   @Override
   public ReconcileResult<R> reconcile(P primary, Context<P> context) {
-    var maybeActual = getAssociatedResource(primary);
+    var maybeActual = getResource(primary);
     if (creatable || updatable) {
       if (maybeActual.isEmpty()) {
         if (creatable) {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/external/AbstractCachingDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/external/AbstractCachingDependentResource.java
@@ -16,7 +16,7 @@ public abstract class AbstractCachingDependentResource<R, P extends HasMetadata>
   }
 
   public Optional<R> fetchResource(P primaryResource) {
-    return eventSource().getAssociatedResource(primaryResource);
+    return eventSource().getResource(primaryResource);
   }
 
   @Override
@@ -25,7 +25,7 @@ public abstract class AbstractCachingDependentResource<R, P extends HasMetadata>
   }
 
   @Override
-  public Optional<R> getAssociatedResource(P primaryResource) {
-    return eventSource().getAssociatedResource(primaryResource);
+  public Optional<R> getResource(P primaryResource) {
+    return eventSource().getResource(primaryResource);
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/external/AbstractCachingDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/external/AbstractCachingDependentResource.java
@@ -16,7 +16,7 @@ public abstract class AbstractCachingDependentResource<R, P extends HasMetadata>
   }
 
   public Optional<R> fetchResource(P primaryResource) {
-    return eventSource().getResource(primaryResource);
+    return eventSource().getSecondaryResource(primaryResource);
   }
 
   @Override
@@ -25,7 +25,7 @@ public abstract class AbstractCachingDependentResource<R, P extends HasMetadata>
   }
 
   @Override
-  public Optional<R> getResource(P primaryResource) {
-    return eventSource().getResource(primaryResource);
+  public Optional<R> getSecondaryResource(P primaryResource) {
+    return eventSource().getSecondaryResource(primaryResource);
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/external/AbstractSimpleDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/external/AbstractSimpleDependentResource.java
@@ -31,7 +31,7 @@ public abstract class AbstractSimpleDependentResource<R, P extends HasMetadata>
   }
 
   @Override
-  public Optional<R> getAssociatedResource(HasMetadata primaryResource) {
+  public Optional<R> getResource(HasMetadata primaryResource) {
     return cache.get(ResourceID.fromResource(primaryResource));
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/external/AbstractSimpleDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/external/AbstractSimpleDependentResource.java
@@ -31,7 +31,7 @@ public abstract class AbstractSimpleDependentResource<R, P extends HasMetadata>
   }
 
   @Override
-  public Optional<R> getResource(HasMetadata primaryResource) {
+  public Optional<R> getSecondaryResource(HasMetadata primaryResource) {
     return cache.get(ResourceID.fromResource(primaryResource));
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResource.java
@@ -97,7 +97,7 @@ public abstract class KubernetesDependentResource<R extends HasMetadata, P exten
 
   public void delete(P primary, Context<P> context) {
     if (!addOwnerReference()) {
-      var resource = getAssociatedResource(primary);
+      var resource = getResource(primary);
       resource.ifPresent(r -> client.resource(r).delete());
     }
   }
@@ -134,8 +134,8 @@ public abstract class KubernetesDependentResource<R extends HasMetadata, P exten
   }
 
   @Override
-  public Optional<R> getAssociatedResource(P primaryResource) {
-    return eventSource().getAssociatedResource(primaryResource);
+  public Optional<R> getResource(P primaryResource) {
+    return eventSource().getResource(primaryResource);
   }
 
   @Override

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResource.java
@@ -97,7 +97,7 @@ public abstract class KubernetesDependentResource<R extends HasMetadata, P exten
 
   public void delete(P primary, Context<P> context) {
     if (!addOwnerReference()) {
-      var resource = getResource(primary);
+      var resource = getSecondaryResource(primary);
       resource.ifPresent(r -> client.resource(r).delete());
     }
   }
@@ -134,8 +134,8 @@ public abstract class KubernetesDependentResource<R extends HasMetadata, P exten
   }
 
   @Override
-  public Optional<R> getResource(P primaryResource) {
-    return eventSource().getResource(primaryResource);
+  public Optional<R> getSecondaryResource(P primaryResource) {
+    return eventSource().getSecondaryResource(primaryResource);
   }
 
   @Override

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/CachingEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/CachingEventSource.java
@@ -54,7 +54,7 @@ public abstract class CachingEventSource<R, P extends HasMetadata>
   }
 
   @Override
-  public Optional<R> getResource(P primary) {
+  public Optional<R> getSecondaryResource(P primary) {
     return cache.get(ResourceID.fromResource(primary));
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/CachingEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/CachingEventSource.java
@@ -54,7 +54,7 @@ public abstract class CachingEventSource<R, P extends HasMetadata>
   }
 
   @Override
-  public Optional<R> getAssociatedResource(P primary) {
+  public Optional<R> getResource(P primary) {
     return cache.get(ResourceID.fromResource(primary));
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/controller/ControllerResourceEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/controller/ControllerResourceEventSource.java
@@ -102,7 +102,7 @@ public class ControllerResourceEventSource<T extends HasMetadata>
   }
 
   @Override
-  public Optional<T> getResource(T primary) {
+  public Optional<T> getSecondaryResource(T primary) {
     return get(ResourceID.fromResource(primary));
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/controller/ControllerResourceEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/controller/ControllerResourceEventSource.java
@@ -102,7 +102,7 @@ public class ControllerResourceEventSource<T extends HasMetadata>
   }
 
   @Override
-  public Optional<T> getAssociatedResource(T primary) {
+  public Optional<T> getResource(T primary) {
     return get(ResourceID.fromResource(primary));
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSource.java
@@ -152,7 +152,7 @@ public class InformerEventSource<R extends HasMetadata, P extends HasMetadata>
    * @return the informed resource associated with the specified primary resource
    */
   @Override
-  public Optional<R> getAssociatedResource(P resource) {
+  public Optional<R> getResource(P resource) {
     final var id = configuration.getAssociatedResourceIdentifier().associatedSecondaryID(resource);
     return get(id);
   }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSource.java
@@ -152,7 +152,7 @@ public class InformerEventSource<R extends HasMetadata, P extends HasMetadata>
    * @return the informed resource associated with the specified primary resource
    */
   @Override
-  public Optional<R> getResource(P resource) {
+  public Optional<R> getSecondaryResource(P resource) {
     final var id = configuration.getAssociatedResourceIdentifier().associatedSecondaryID(resource);
     return get(id);
   }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/ManagedInformerEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/ManagedInformerEventSource.java
@@ -93,7 +93,7 @@ public abstract class ManagedInformerEventSource<R extends HasMetadata, P extend
   }
 
   @Override
-  public Optional<R> getAssociatedResource(P primary) {
+  public Optional<R> getResource(P primary) {
     return get(ResourceID.fromResource(primary));
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/ManagedInformerEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/ManagedInformerEventSource.java
@@ -93,7 +93,7 @@ public abstract class ManagedInformerEventSource<R extends HasMetadata, P extend
   }
 
   @Override
-  public Optional<R> getResource(P primary) {
+  public Optional<R> getSecondaryResource(P primary) {
     return get(ResourceID.fromResource(primary));
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/polling/PerResourcePollingEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/polling/PerResourcePollingEventSource.java
@@ -132,7 +132,7 @@ public class PerResourcePollingEventSource<R, P extends HasMetadata>
    * @return the related resource for this event source
    */
   @Override
-  public Optional<R> getAssociatedResource(P primary) {
+  public Optional<R> getResource(P primary) {
     return getValueFromCacheOrSupplier(ResourceID.fromResource(primary));
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/polling/PerResourcePollingEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/polling/PerResourcePollingEventSource.java
@@ -132,7 +132,7 @@ public class PerResourcePollingEventSource<R, P extends HasMetadata>
    * @return the related resource for this event source
    */
   @Override
-  public Optional<R> getResource(P primary) {
+  public Optional<R> getSecondaryResource(P primary) {
     return getValueFromCacheOrSupplier(ResourceID.fromResource(primary));
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/polling/PollingEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/polling/PollingEventSource.java
@@ -98,7 +98,7 @@ public class PollingEventSource<R, P extends HasMetadata>
    * @return related resource
    */
   @Override
-  public Optional<R> getResource(P primary) {
+  public Optional<R> getSecondaryResource(P primary) {
     return getCachedValue(ResourceID.fromResource(primary));
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/polling/PollingEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/polling/PollingEventSource.java
@@ -98,7 +98,7 @@ public class PollingEventSource<R, P extends HasMetadata>
    * @return related resource
    */
   @Override
-  public Optional<R> getAssociatedResource(P primary) {
+  public Optional<R> getResource(P primary) {
     return getCachedValue(ResourceID.fromResource(primary));
   }
 }

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/config/UtilsTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/config/UtilsTest.java
@@ -98,7 +98,7 @@ class UtilsTest {
     }
 
     @Override
-    public Optional<Deployment> getResource(TestCustomResource primaryResource) {
+    public Optional<Deployment> getSecondaryResource(TestCustomResource primaryResource) {
       return Optional.empty();
     }
 

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/config/UtilsTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/config/UtilsTest.java
@@ -98,7 +98,7 @@ class UtilsTest {
     }
 
     @Override
-    public Optional<Deployment> getAssociatedResource(TestCustomResource primaryResource) {
+    public Optional<Deployment> getResource(TestCustomResource primaryResource) {
       return Optional.empty();
     }
 

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/external/AbstractSimpleDependentResourceTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/external/AbstractSimpleDependentResourceTest.java
@@ -45,14 +45,14 @@ class AbstractSimpleDependentResourceTest {
     simpleDependentResource.reconcile(TestUtils.testCustomResource1(), null);
 
     verify(supplierMock, times(1)).get();
-    assertThat(simpleDependentResource.getAssociatedResource(TestUtils.testCustomResource1()))
+    assertThat(simpleDependentResource.getResource(TestUtils.testCustomResource1()))
         .isPresent()
         .isEqualTo(Optional.of(SampleExternalResource.testResource1()));
   }
 
   @Test
   void getResourceReadsTheResourceFromCache() {
-    simpleDependentResource.getAssociatedResource(TestUtils.testCustomResource1());
+    simpleDependentResource.getResource(TestUtils.testCustomResource1());
 
     verify(supplierMock, times(0)).get();
     verify(updatableCacheMock, times(1)).get(any());

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/external/AbstractSimpleDependentResourceTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/external/AbstractSimpleDependentResourceTest.java
@@ -45,14 +45,14 @@ class AbstractSimpleDependentResourceTest {
     simpleDependentResource.reconcile(TestUtils.testCustomResource1(), null);
 
     verify(supplierMock, times(1)).get();
-    assertThat(simpleDependentResource.getResource(TestUtils.testCustomResource1()))
+    assertThat(simpleDependentResource.getSecondaryResource(TestUtils.testCustomResource1()))
         .isPresent()
         .isEqualTo(Optional.of(SampleExternalResource.testResource1()));
   }
 
   @Test
   void getResourceReadsTheResourceFromCache() {
-    simpleDependentResource.getResource(TestUtils.testCustomResource1());
+    simpleDependentResource.getSecondaryResource(TestUtils.testCustomResource1());
 
     verify(supplierMock, times(0)).get();
     verify(updatableCacheMock, times(1)).get(any());

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/standalonedependent/StandaloneDependentTestReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/standalonedependent/StandaloneDependentTestReconciler.java
@@ -48,7 +48,7 @@ public class StandaloneDependentTestReconciler
       StandaloneDependentTestCustomResource primary,
       Context<StandaloneDependentTestCustomResource> context) {
     deploymentDependent.reconcile(primary, context);
-    Optional<Deployment> deployment = deploymentDependent.getResource(primary);
+    Optional<Deployment> deployment = deploymentDependent.getSecondaryResource(primary);
     if (deployment.isEmpty()) {
       throw new IllegalStateException("Resource should not be empty after reconcile.");
     }

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/standalonedependent/StandaloneDependentTestReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/standalonedependent/StandaloneDependentTestReconciler.java
@@ -48,7 +48,7 @@ public class StandaloneDependentTestReconciler
       StandaloneDependentTestCustomResource primary,
       Context<StandaloneDependentTestCustomResource> context) {
     deploymentDependent.reconcile(primary, context);
-    Optional<Deployment> deployment = deploymentDependent.getAssociatedResource(primary);
+    Optional<Deployment> deployment = deploymentDependent.getResource(primary);
     if (deployment.isEmpty()) {
       throw new IllegalStateException("Resource should not be empty after reconcile.");
     }

--- a/sample-operators/webpage/src/main/java/io/javaoperatorsdk/operator/sample/WebPageStandaloneDependentsReconciler.java
+++ b/sample-operators/webpage/src/main/java/io/javaoperatorsdk/operator/sample/WebPageStandaloneDependentsReconciler.java
@@ -62,7 +62,7 @@ public class WebPageStandaloneDependentsReconciler
 
     webPage.setStatus(
         createStatus(
-            configMapDR.getResource(webPage).orElseThrow().getMetadata().getName()));
+            configMapDR.getSecondaryResource(webPage).orElseThrow().getMetadata().getName()));
     return UpdateControl.updateStatus(webPage);
   }
 

--- a/sample-operators/webpage/src/main/java/io/javaoperatorsdk/operator/sample/WebPageStandaloneDependentsReconciler.java
+++ b/sample-operators/webpage/src/main/java/io/javaoperatorsdk/operator/sample/WebPageStandaloneDependentsReconciler.java
@@ -62,7 +62,7 @@ public class WebPageStandaloneDependentsReconciler
 
     webPage.setStatus(
         createStatus(
-            configMapDR.getAssociatedResource(webPage).orElseThrow().getMetadata().getName()));
+            configMapDR.getResource(webPage).orElseThrow().getMetadata().getName()));
     return UpdateControl.updateStatus(webPage);
   }
 


### PR DESCRIPTION
`getResource` is either called on event source or dependent resource. In both context it should be obivius from `getResource` that it is about the resource dependent resource / or event source is managing / caching.