### PR TITLE
fix: abstract fetch resource

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/external/AbstractCachingDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/external/AbstractCachingDependentResource.java
@@ -15,9 +15,7 @@ public abstract class AbstractCachingDependentResource<R, P extends HasMetadata>
     this.resourceType = resourceType;
   }
 
-  public Optional<R> fetchResource(P primaryResource) {
-    return eventSource().getSecondaryResource(primaryResource);
-  }
+  public abstract Optional<R> fetchResource(P primaryResource);
 
   @Override
   public Class<R> resourceType() {


### PR DESCRIPTION
It does not make sense to get the resource from the cache, basically that is what we want to avoid.