### PR TITLE
fix: Ordered Managed Dependent IT and filtering

### DIFF
--- a/docs/documentation/dependent-resources.md
+++ b/docs/documentation/dependent-resources.md
@@ -293,4 +293,7 @@ makes sure that it or the related `InformerEventSource` always return the up-to-
 the reconciliation, the later received related event will not trigger the reconciliation again. This is a small
 optimization. For example if during a reconciliation a `ConfigMap` is updated using dependent resources, this won't
 trigger a new reconciliation. It' does not need to, since the change in the `ConfigMap` is made by the reconciler,
-and the fresh version is used further.
+and the fresh version is used further. To work properly, it is also required that all the changes are received only by
+one event source (this is a best practice in general) - so for example if there are two config map dependents either
+there should be a shared event source between them, or a label selector on the event sources just to selecting related
+events, see in [related integration test](https://github.com/java-operator-sdk/java-operator-sdk/blob/cd8d7e94f9d3f5d9f28dddbbb10f692546c22c9c/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/orderedmanageddependent/ConfigMapDependentResource1.java#L15-L15). 

--- a/docs/documentation/dependent-resources.md
+++ b/docs/documentation/dependent-resources.md
@@ -294,6 +294,6 @@ the reconciliation, the later received related event will not trigger the reconc
 optimization. For example if during a reconciliation a `ConfigMap` is updated using dependent resources, this won't
 trigger a new reconciliation. It' does not need to, since the change in the `ConfigMap` is made by the reconciler,
 and the fresh version is used further. To work properly, it is also required that all the changes are received only by
-one event source (this is a best practice in general) - so for example if there are two config map dependents either
+one event source (this is a best practice in general) - so for example if there are two config map dependents, either
 there should be a shared event source between them, or a label selector on the event sources just to selecting related
 events, see in [related integration test](https://github.com/java-operator-sdk/java-operator-sdk/blob/cd8d7e94f9d3f5d9f28dddbbb10f692546c22c9c/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/orderedmanageddependent/ConfigMapDependentResource1.java#L15-L15). 

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/OrderedManagedDependentIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/OrderedManagedDependentIT.java
@@ -26,7 +26,7 @@ class OrderedManagedDependentIT {
   void managedDependentsAreReconciledInOrder() {
     operator.create(OrderedManagedDependentCustomResource.class, createTestResource());
 
-    await().atMost(Duration.ofSeconds(5))
+    await().pollDelay(Duration.ofSeconds(1)).atMost(Duration.ofSeconds(5))
         .until(() -> ((OrderedManagedDependentTestReconciler) operator.getFirstReconciler())
             .getNumberOfExecutions() == 1);
 

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/orderedmanageddependent/ConfigMapDependentResource1.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/orderedmanageddependent/ConfigMapDependentResource1.java
@@ -1,15 +1,18 @@
 package io.javaoperatorsdk.operator.sample.orderedmanageddependent;
 
 import java.util.HashMap;
+import java.util.Map;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.ReconcileResult;
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUKubernetesDependentResource;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import io.javaoperatorsdk.operator.processing.event.source.PrimaryToSecondaryMapper;
 
+@KubernetesDependent(labelSelector = "dependent = cm1")
 public class ConfigMapDependentResource1 extends
     CRUKubernetesDependentResource<ConfigMap, OrderedManagedDependentCustomResource>
     implements PrimaryToSecondaryMapper<OrderedManagedDependentCustomResource> {
@@ -31,6 +34,9 @@ public class ConfigMapDependentResource1 extends
 
     ConfigMap configMap = new ConfigMap();
     configMap.setMetadata(new ObjectMeta());
+    Map<String,String> labels = new HashMap<>();
+    labels.put("dependent","cm1");
+    configMap.getMetadata().setLabels(labels);
     configMap.getMetadata().setName(primary.getMetadata().getName() + "1");
     configMap.getMetadata().setNamespace(primary.getMetadata().getNamespace());
     HashMap<String, String> data = new HashMap<>();

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/orderedmanageddependent/ConfigMapDependentResource1.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/orderedmanageddependent/ConfigMapDependentResource1.java
@@ -34,8 +34,8 @@ public class ConfigMapDependentResource1 extends
 
     ConfigMap configMap = new ConfigMap();
     configMap.setMetadata(new ObjectMeta());
-    Map<String,String> labels = new HashMap<>();
-    labels.put("dependent","cm1");
+    Map<String, String> labels = new HashMap<>();
+    labels.put("dependent", "cm1");
     configMap.getMetadata().setLabels(labels);
     configMap.getMetadata().setName(primary.getMetadata().getName() + "1");
     configMap.getMetadata().setNamespace(primary.getMetadata().getNamespace());

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/orderedmanageddependent/ConfigMapDependentResource2.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/orderedmanageddependent/ConfigMapDependentResource2.java
@@ -34,8 +34,8 @@ public class ConfigMapDependentResource2 extends
 
     ConfigMap configMap = new ConfigMap();
     configMap.setMetadata(new ObjectMeta());
-    Map<String,String> labels = new HashMap<>();
-    labels.put("dependent","cm2");
+    Map<String, String> labels = new HashMap<>();
+    labels.put("dependent", "cm2");
     configMap.getMetadata().setLabels(labels);
     configMap.getMetadata().setName(primary.getMetadata().getName() + "2");
     configMap.getMetadata().setNamespace(primary.getMetadata().getNamespace());

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/orderedmanageddependent/ConfigMapDependentResource2.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/orderedmanageddependent/ConfigMapDependentResource2.java
@@ -1,15 +1,18 @@
 package io.javaoperatorsdk.operator.sample.orderedmanageddependent;
 
 import java.util.HashMap;
+import java.util.Map;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.ReconcileResult;
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUKubernetesDependentResource;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import io.javaoperatorsdk.operator.processing.event.source.PrimaryToSecondaryMapper;
 
+@KubernetesDependent(labelSelector = "dependent = cm2")
 public class ConfigMapDependentResource2 extends
     CRUKubernetesDependentResource<ConfigMap, OrderedManagedDependentCustomResource>
     implements PrimaryToSecondaryMapper<OrderedManagedDependentCustomResource> {
@@ -31,6 +34,9 @@ public class ConfigMapDependentResource2 extends
 
     ConfigMap configMap = new ConfigMap();
     configMap.setMetadata(new ObjectMeta());
+    Map<String,String> labels = new HashMap<>();
+    labels.put("dependent","cm2");
+    configMap.getMetadata().setLabels(labels);
     configMap.getMetadata().setName(primary.getMetadata().getName() + "2");
     configMap.getMetadata().setNamespace(primary.getMetadata().getNamespace());
     HashMap<String, String> data = new HashMap<>();


### PR DESCRIPTION
The problem was that there were two informers without label selector for the 2 config maps, so event filtering was not working properly. There are 2 solutions in this case, share the event source between the dependents or use label selectors.