### PR TITLE
fix: make webpage sample work OOTB

### DIFF
--- a/sample-operators/webpage/README.md
+++ b/sample-operators/webpage/README.md
@@ -46,6 +46,9 @@ page. Otherwise you can change the service to a LoadBalancer (e.g on a public cl
 You can also try to change the HTML code in `k8s/webpage.yaml` and do another `kubectl apply -f k8s/webpage.yaml`.
 This should update the actual NGINX deployment with the new configuration.  
 
+Note that there are multiple reconciler implementations that watch `WebPage` resources differentiated by a label.
+When you create a new `WebPage` resource, make sure its label matches the active reconciler's label selector.
+
 If you want the Operator to be running as a deployment in your cluster, follow the below steps.
 
 ### Build

--- a/sample-operators/webpage/k8s/webpage.yaml
+++ b/sample-operators/webpage/k8s/webpage.yaml
@@ -1,8 +1,9 @@
 apiVersion: "sample.javaoperatorsdk/v1"
 kind: WebPage
 metadata:
-  labels:
-    low-level: "true"
+# Use labels to match the resource with different reconciler implementations:
+# labels:
+#    low-level: "true"
   name: hellows
 spec:
   exposed: false


### PR DESCRIPTION
The webpage sample does not work OOTB with the `k8s/webpage.yaml`, as the default reconciler watches for webpage resources without labels.