### PR TITLE
feat: make default watched namespaces behavior explicit

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/AnnotationControllerConfiguration.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/AnnotationControllerConfiguration.java
@@ -66,7 +66,8 @@ public class AnnotationControllerConfiguration<R extends HasMetadata>
 
   @Override
   public Set<String> getNamespaces() {
-    return Set.of(valueOrDefault(annotation, ControllerConfiguration::namespaces, new String[] {}));
+    return Set.of(valueOrDefault(annotation, ControllerConfiguration::namespaces,
+        new String[] {Constants.WATCH_ALL_NAMESPACES}));
   }
 
   @Override

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ControllerConfigurationOverrider.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ControllerConfigurationOverrider.java
@@ -19,7 +19,7 @@ public class ControllerConfigurationOverrider<R extends HasMetadata> {
 
   private String finalizer;
   private boolean generationAware;
-  private final Set<String> namespaces;
+  private Set<String> namespaces;
   private RetryConfiguration retry;
   private String labelSelector;
   private ResourceEventFilter<R> customResourcePredicate;
@@ -52,8 +52,8 @@ public class ControllerConfigurationOverrider<R extends HasMetadata> {
     return this;
   }
 
-  public ControllerConfigurationOverrider<R> withCurrentNamespace() {
-    namespaces.clear();
+  public ControllerConfigurationOverrider<R> watchingOnlyCurrentNamespace() {
+    this.namespaces = ResourceConfiguration.DEPLOYED_NAMESPACE_ONLY;
     return this;
   }
 
@@ -64,12 +64,20 @@ public class ControllerConfigurationOverrider<R extends HasMetadata> {
 
   public ControllerConfigurationOverrider<R> removingNamespaces(String... namespaces) {
     List.of(namespaces).forEach(this.namespaces::remove);
+    if (this.namespaces.isEmpty()) {
+      this.namespaces = ResourceConfiguration.DEFAULT_NAMESPACES;
+    }
     return this;
   }
 
   public ControllerConfigurationOverrider<R> settingNamespace(String namespace) {
     this.namespaces.clear();
     this.namespaces.add(namespace);
+    return this;
+  }
+
+  public ControllerConfigurationOverrider<R> watchingAllNamespaces() {
+    this.namespaces = ResourceConfiguration.DEFAULT_NAMESPACES;
     return this;
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ControllerConfigurationOverrider.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ControllerConfigurationOverrider.java
@@ -53,7 +53,7 @@ public class ControllerConfigurationOverrider<R extends HasMetadata> {
   }
 
   public ControllerConfigurationOverrider<R> watchingOnlyCurrentNamespace() {
-    this.namespaces = ResourceConfiguration.DEPLOYED_NAMESPACE_ONLY;
+    this.namespaces = ResourceConfiguration.CURRENT_NAMESPACE_ONLY;
     return this;
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/DefaultResourceConfiguration.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/DefaultResourceConfiguration.java
@@ -1,6 +1,5 @@
 package io.javaoperatorsdk.operator.api.config;
 
-import java.util.Collections;
 import java.util.Set;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
@@ -10,21 +9,22 @@ public class DefaultResourceConfiguration<R extends HasMetadata>
 
   private final String labelSelector;
   private final Set<String> namespaces;
-  private final boolean watchAllNamespaces;
   private final Class<R> resourceClass;
 
   public DefaultResourceConfiguration(String labelSelector, Class<R> resourceClass,
       String... namespaces) {
     this(labelSelector, resourceClass,
-        namespaces != null ? Set.of(namespaces) : Collections.emptySet());
+        namespaces == null || namespaces.length == 0 ? ResourceConfiguration.DEFAULT_NAMESPACES
+            : Set.of(namespaces));
   }
 
   public DefaultResourceConfiguration(String labelSelector, Class<R> resourceClass,
       Set<String> namespaces) {
     this.labelSelector = labelSelector;
     this.resourceClass = resourceClass;
-    this.namespaces = namespaces != null ? namespaces : Collections.emptySet();
-    this.watchAllNamespaces = this.namespaces.isEmpty();
+    this.namespaces =
+        namespaces == null || namespaces.isEmpty() ? ResourceConfiguration.DEFAULT_NAMESPACES
+            : namespaces;
   }
 
   @Override
@@ -40,11 +40,6 @@ public class DefaultResourceConfiguration<R extends HasMetadata>
   @Override
   public Set<String> getNamespaces() {
     return namespaces;
-  }
-
-  @Override
-  public boolean watchAllNamespaces() {
-    return watchAllNamespaces;
   }
 
   @Override

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ResourceConfiguration.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ResourceConfiguration.java
@@ -11,7 +11,7 @@ import io.javaoperatorsdk.operator.api.reconciler.Constants;
 public interface ResourceConfiguration<R extends HasMetadata> {
 
   Set<String> DEFAULT_NAMESPACES = Set.of(Constants.WATCH_ALL_NAMESPACES);
-  Set<String> DEPLOYED_NAMESPACE_ONLY = Set.of(Constants.WATCH_CURRENT_NAMESPACE);
+  Set<String> CURRENT_NAMESPACE_ONLY = Set.of(Constants.WATCH_CURRENT_NAMESPACE);
 
   default String getResourceTypeName() {
     return ReconcilerUtils.getResourceTypeName(getResourceClass());
@@ -53,7 +53,7 @@ public interface ResourceConfiguration<R extends HasMetadata> {
 
   static boolean currentNamespaceWatched(Set<String> namespaces) {
     failIfNotValid(namespaces);
-    return DEPLOYED_NAMESPACE_ONLY.equals(namespaces);
+    return CURRENT_NAMESPACE_ONLY.equals(namespaces);
   }
 
   static void failIfNotValid(Set<String> namespaces) {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ResourceConfiguration.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ResourceConfiguration.java
@@ -10,15 +10,18 @@ import io.javaoperatorsdk.operator.api.reconciler.Constants;
 
 public interface ResourceConfiguration<R extends HasMetadata> {
 
+  Set<String> DEFAULT_NAMESPACES = Set.of(Constants.WATCH_ALL_NAMESPACES);
+  Set<String> DEPLOYED_NAMESPACE_ONLY = Set.of(Constants.WATCH_CURRENT_NAMESPACE);
+
   default String getResourceTypeName() {
     return ReconcilerUtils.getResourceTypeName(getResourceClass());
   }
 
   /**
    * Retrieves the label selector that is used to filter which resources are actually watched by the
-   * associated event source. See
-   * https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ for more details on
-   * syntax.
+   * associated event source. See the official documentation on the
+   * <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/">topic</a>
+   * for more details on syntax.
    *
    * @return the label selector filtering watched resources
    */
@@ -32,7 +35,7 @@ public interface ResourceConfiguration<R extends HasMetadata> {
   }
 
   default Set<String> getNamespaces() {
-    return Collections.emptySet();
+    return DEFAULT_NAMESPACES;
   }
 
   default boolean watchAllNamespaces() {
@@ -40,7 +43,8 @@ public interface ResourceConfiguration<R extends HasMetadata> {
   }
 
   static boolean allNamespacesWatched(Set<String> namespaces) {
-    return namespaces == null || namespaces.isEmpty();
+    failIfNotValid(namespaces);
+    return DEFAULT_NAMESPACES.equals(namespaces);
   }
 
   default boolean watchCurrentNamespace() {
@@ -48,9 +52,24 @@ public interface ResourceConfiguration<R extends HasMetadata> {
   }
 
   static boolean currentNamespaceWatched(Set<String> namespaces) {
-    return namespaces != null
-        && namespaces.size() == 1
-        && namespaces.contains(Constants.WATCH_CURRENT_NAMESPACE);
+    failIfNotValid(namespaces);
+    return DEPLOYED_NAMESPACE_ONLY.equals(namespaces);
+  }
+
+  static void failIfNotValid(Set<String> namespaces) {
+    if (namespaces != null && !namespaces.isEmpty()) {
+      final var present = namespaces.contains(Constants.WATCH_CURRENT_NAMESPACE)
+          || namespaces.contains(Constants.WATCH_ALL_NAMESPACES);
+      if (!present || namespaces.size() == 1) {
+        return;
+      }
+    }
+
+    throw new IllegalArgumentException(
+        "Must specify namespaces. To watch all namespaces, use only '"
+            + Constants.WATCH_ALL_NAMESPACES
+            + "'. To watch only the namespace in which the operator is deployed, use only '"
+            + Constants.WATCH_CURRENT_NAMESPACE + "'");
   }
 
   /**

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/Constants.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/Constants.java
@@ -4,6 +4,7 @@ public final class Constants {
 
   public static final String NO_VALUE_SET = "";
   public static final String WATCH_CURRENT_NAMESPACE = "JOSDK_WATCH_CURRENT";
+  public static final String WATCH_ALL_NAMESPACES = "JOSDK_ALL_NAMESPACES";
   public static final long NO_RECONCILIATION_MAX_INTERVAL = -1L;
 
   private Constants() {}

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/ControllerConfiguration.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/ControllerConfiguration.java
@@ -39,7 +39,7 @@ public @interface ControllerConfiguration {
    *
    * @return the list of namespaces this controller monitors
    */
-  String[] namespaces() default {};
+  String[] namespaces() default Constants.WATCH_ALL_NAMESPACES;
 
   /**
    * Optional label selector used to identify the set of custom resources the controller will acc

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependent.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependent.java
@@ -11,7 +11,6 @@ import static io.javaoperatorsdk.operator.api.reconciler.Constants.NO_VALUE_SET;
 @Target({ElementType.TYPE})
 public @interface KubernetesDependent {
   String SAME_AS_PARENT = "JOSDK_SAME_AS_PARENT";
-  String WATCH_ALL_NAMESPACES = "JOSDK_ALL_NAMESPACES";
 
   String[] DEFAULT_NAMESPACES = {SAME_AS_PARENT};
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResourceConfig.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResourceConfig.java
@@ -37,11 +37,7 @@ public class KubernetesDependentResourceConfig {
   }
 
   public Set<String> namespaces() {
-    if (!namespaces.contains(KubernetesDependent.WATCH_ALL_NAMESPACES)) {
-      return namespaces;
-    } else {
-      return Collections.emptySet();
-    }
+    return namespaces;
   }
 
   public String labelSelector() {

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/OperatorTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/OperatorTest.java
@@ -10,20 +10,17 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.config.AbstractConfigurationService;
 import io.javaoperatorsdk.operator.api.config.ConfigurationServiceProvider;
-import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
+import io.javaoperatorsdk.operator.api.config.MockControllerConfiguration;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @SuppressWarnings("rawtypes")
 class OperatorTest {
 
   private final KubernetesClient kubernetesClient = MockKubernetesClient.client(ConfigMap.class);
-  private final ControllerConfiguration configuration = mock(ControllerConfiguration.class);
   private final Operator operator = new Operator(kubernetesClient);
   private final FooReconciler fooReconciler = new FooReconciler();
 
@@ -35,10 +32,9 @@ class OperatorTest {
 
   @Test
   @DisplayName("should register `Reconciler` to Controller")
-  @SuppressWarnings("unchecked")
   public void shouldRegisterReconcilerToController() {
     // given
-    when(configuration.getResourceClass()).thenReturn(ConfigMap.class);
+    final var configuration = MockControllerConfiguration.forResource(ConfigMap.class);
 
     // when
     operator.register(fooReconciler, configuration);

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/config/MockControllerConfiguration.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/config/MockControllerConfiguration.java
@@ -1,0 +1,18 @@
+package io.javaoperatorsdk.operator.api.config;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MockControllerConfiguration {
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public static <R extends HasMetadata> ControllerConfiguration<R> forResource(
+      Class<R> resourceType) {
+    final ControllerConfiguration configuration = mock(ControllerConfiguration.class);
+    when(configuration.getResourceClass()).thenReturn(resourceType);
+    when(configuration.getNamespaces()).thenReturn(ResourceConfiguration.DEFAULT_NAMESPACES);
+    when(configuration.getEffectiveNamespaces()).thenCallRealMethod();
+    return configuration;
+  }
+}

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/config/ResourceConfigurationTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/config/ResourceConfigurationTest.java
@@ -1,0 +1,71 @@
+package io.javaoperatorsdk.operator.api.config;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import io.javaoperatorsdk.operator.api.reconciler.Constants;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ResourceConfigurationTest {
+
+  @Test
+  void allNamespacesWatched() {
+    assertThrows(IllegalArgumentException.class,
+        () -> ResourceConfiguration.allNamespacesWatched(null));
+    assertThrows(IllegalArgumentException.class, () -> ResourceConfiguration.allNamespacesWatched(
+        Set.of(Constants.WATCH_CURRENT_NAMESPACE, Constants.WATCH_ALL_NAMESPACES, "foo")));
+    assertThrows(IllegalArgumentException.class, () -> ResourceConfiguration.allNamespacesWatched(
+        Collections.emptySet()));
+    assertFalse(ResourceConfiguration.allNamespacesWatched(Set.of("foo", "bar")));
+    assertTrue(ResourceConfiguration.allNamespacesWatched(Set.of(Constants.WATCH_ALL_NAMESPACES)));
+    assertFalse(ResourceConfiguration.allNamespacesWatched(Set.of("foo")));
+    assertFalse(
+        ResourceConfiguration.allNamespacesWatched(Set.of(Constants.WATCH_CURRENT_NAMESPACE)));
+  }
+
+  @Test
+  void currentNamespaceWatched() {
+    assertThrows(IllegalArgumentException.class,
+        () -> ResourceConfiguration.currentNamespaceWatched(null));
+    assertThrows(IllegalArgumentException.class,
+        () -> ResourceConfiguration.currentNamespaceWatched(
+            Set.of(Constants.WATCH_CURRENT_NAMESPACE, Constants.WATCH_ALL_NAMESPACES, "foo")));
+    assertThrows(IllegalArgumentException.class,
+        () -> ResourceConfiguration.currentNamespaceWatched(Collections.emptySet()));
+    assertFalse(ResourceConfiguration.currentNamespaceWatched(Set.of("foo", "bar")));
+    assertFalse(
+        ResourceConfiguration.currentNamespaceWatched(Set.of(Constants.WATCH_ALL_NAMESPACES)));
+    assertFalse(ResourceConfiguration.currentNamespaceWatched(Set.of("foo")));
+    assertTrue(
+        ResourceConfiguration.currentNamespaceWatched(Set.of(Constants.WATCH_CURRENT_NAMESPACE)));
+  }
+
+  @Test
+  void nullLabelSelectorByDefault() {
+    assertNull(new ResourceConfiguration<>() {}.getLabelSelector());
+  }
+
+  @Test
+  void shouldWatchAllNamespacesByDefault() {
+    assertTrue(new ResourceConfiguration<>() {}.watchAllNamespaces());
+  }
+
+  @Test
+  void failIfNotValid() {
+    assertThrows(IllegalArgumentException.class, () -> ResourceConfiguration.failIfNotValid(null));
+    assertThrows(IllegalArgumentException.class,
+        () -> ResourceConfiguration.failIfNotValid(Collections.emptySet()));
+    assertThrows(IllegalArgumentException.class, () -> ResourceConfiguration.failIfNotValid(
+        Set.of(Constants.WATCH_CURRENT_NAMESPACE, Constants.WATCH_ALL_NAMESPACES, "foo")));
+    assertThrows(IllegalArgumentException.class, () -> ResourceConfiguration.failIfNotValid(
+        Set.of(Constants.WATCH_CURRENT_NAMESPACE, "foo")));
+    assertThrows(IllegalArgumentException.class, () -> ResourceConfiguration.failIfNotValid(
+        Set.of(Constants.WATCH_ALL_NAMESPACES, "foo")));
+
+    // should work
+    ResourceConfiguration.failIfNotValid(Set.of("foo", "bar"));
+  }
+}

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/EventSourceManagerTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/EventSourceManagerTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.javaoperatorsdk.operator.MockKubernetesClient;
 import io.javaoperatorsdk.operator.OperatorException;
-import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
+import io.javaoperatorsdk.operator.api.config.MockControllerConfiguration;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 import io.javaoperatorsdk.operator.processing.Controller;
 import io.javaoperatorsdk.operator.processing.event.source.CachingEventSource;
@@ -140,8 +140,7 @@ class EventSourceManagerTest {
   }
 
   private EventSourceManager initManager() {
-    final ControllerConfiguration configuration = mock(ControllerConfiguration.class);
-    when(configuration.getResourceClass()).thenReturn(HasMetadata.class);
+    final var configuration = MockControllerConfiguration.forResource(HasMetadata.class);
     final Controller controller = new Controller(mock(Reconciler.class), configuration,
         MockKubernetesClient.client(HasMetadata.class));
     return new EventSourceManager(controller);

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSourceTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSourceTest.java
@@ -14,6 +14,7 @@ import io.fabric8.kubernetes.client.dsl.FilterWatchListMultiDeletable;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
 import io.fabric8.kubernetes.client.informers.cache.Indexer;
+import io.javaoperatorsdk.operator.api.config.ResourceConfiguration;
 import io.javaoperatorsdk.operator.api.config.informer.InformerConfiguration;
 import io.javaoperatorsdk.operator.processing.event.EventHandler;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
@@ -23,6 +24,7 @@ import io.javaoperatorsdk.operator.sample.simple.TestCustomResource;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+@SuppressWarnings({"rawtypes", "unchecked"})
 class InformerEventSourceTest {
 
   private static final String PREV_RESOURCE_VERSION = "0";
@@ -30,16 +32,17 @@ class InformerEventSourceTest {
   private static final String NEXT_RESOURCE_VERSION = "2";
 
   private InformerEventSource<Deployment, TestCustomResource> informerEventSource;
-  private KubernetesClient clientMock = mock(KubernetesClient.class);
-  private TemporaryResourceCache<Deployment> temporaryResourceCacheMock =
+  private final KubernetesClient clientMock = mock(KubernetesClient.class);
+  private final TemporaryResourceCache<Deployment> temporaryResourceCacheMock =
       mock(TemporaryResourceCache.class);
-  private EventHandler eventHandlerMock = mock(EventHandler.class);
-  private MixedOperation crClientMock = mock(MixedOperation.class);
-  private FilterWatchListMultiDeletable specificResourceClientMock =
+  private final EventHandler eventHandlerMock = mock(EventHandler.class);
+  private final MixedOperation crClientMock = mock(MixedOperation.class);
+  private final FilterWatchListMultiDeletable specificResourceClientMock =
       mock(FilterWatchListMultiDeletable.class);
-  private FilterWatchListDeletable labeledResourceClientMock = mock(FilterWatchListDeletable.class);
-  private SharedIndexInformer informer = mock(SharedIndexInformer.class);
-  private InformerConfiguration<Deployment> informerConfiguration =
+  private final FilterWatchListDeletable labeledResourceClientMock =
+      mock(FilterWatchListDeletable.class);
+  private final SharedIndexInformer informer = mock(SharedIndexInformer.class);
+  private final InformerConfiguration<Deployment> informerConfiguration =
       mock(InformerConfiguration.class);
 
   @BeforeEach
@@ -51,6 +54,8 @@ class InformerEventSourceTest {
     when(labeledResourceClientMock.runnableInformer(0)).thenReturn(informer);
     when(informer.getIndexer()).thenReturn(mock(Indexer.class));
 
+    when(informerConfiguration.getEffectiveNamespaces())
+        .thenReturn(ResourceConfiguration.DEFAULT_NAMESPACES);
     when(informerConfiguration.getSecondaryToPrimaryMapper())
         .thenReturn(mock(SecondaryToPrimaryMapper.class));
 


### PR DESCRIPTION
This uses the constant that was initially introduced for the same reason
on KubernetesDependent, which is now moved to Constants. Uncovered
several issues with configuration overriding in the process and added
test coverage.

Fixes #1176
