### PR TITLE
aggregate exception improvement

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/AggregatedOperatorException.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/AggregatedOperatorException.java
@@ -1,6 +1,7 @@
 package io.javaoperatorsdk.operator;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -9,13 +10,13 @@ public class AggregatedOperatorException extends OperatorException {
   private final List<Exception> causes;
 
   public AggregatedOperatorException(String message, Exception... exceptions) {
-    super(message, Objects.requireNonNull(exceptions)[0]);
-    this.causes = Arrays.asList(exceptions);
+    super(message, exceptions != null && exceptions.length > 0 ? exceptions[0] : null);
+    this.causes = exceptions != null ? Arrays.asList(exceptions) : Collections.emptyList();
   }
 
   public AggregatedOperatorException(String message, List<Exception> exceptions) {
-    super(message, Objects.requireNonNull(exceptions).get(0));
-    this.causes = exceptions;
+    super(message, exceptions != null && !exceptions.isEmpty() ? exceptions.get(0) : null);
+    this.causes = exceptions != null ? exceptions : Collections.emptyList();
   }
 
   public List<Exception> getAggregatedExceptions() {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/AggregatedOperatorException.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/AggregatedOperatorException.java
@@ -3,7 +3,6 @@ package io.javaoperatorsdk.operator;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 public class AggregatedOperatorException extends OperatorException {
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/AggregatedOperatorException.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/AggregatedOperatorException.java
@@ -1,23 +1,30 @@
 package io.javaoperatorsdk.operator;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 public class AggregatedOperatorException extends OperatorException {
+
   private final List<Exception> causes;
 
   public AggregatedOperatorException(String message, Exception... exceptions) {
-    super(message);
-    this.causes = exceptions != null ? Arrays.asList(exceptions) : Collections.emptyList();
+    super(message, exceptions[0]);
+    this.causes = Arrays.asList(exceptions);
   }
 
   public AggregatedOperatorException(String message, List<Exception> exceptions) {
-    super(message);
-    this.causes = exceptions != null ? exceptions : Collections.emptyList();
+    super(message, exceptions.get(0));
+    this.causes = exceptions;
   }
 
   public List<Exception> getAggregatedExceptions() {
     return causes;
+  }
+
+  @Override
+  public String toString() {
+    return "AggregatedOperatorException{" +
+        "causes=" + causes +
+        '}';
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/AggregatedOperatorException.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/AggregatedOperatorException.java
@@ -2,18 +2,19 @@ package io.javaoperatorsdk.operator;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 public class AggregatedOperatorException extends OperatorException {
 
   private final List<Exception> causes;
 
   public AggregatedOperatorException(String message, Exception... exceptions) {
-    super(message, exceptions[0]);
+    super(message, Objects.requireNonNull(exceptions)[0]);
     this.causes = Arrays.asList(exceptions);
   }
 
   public AggregatedOperatorException(String message, List<Exception> exceptions) {
-    super(message, exceptions.get(0));
+    super(message, Objects.requireNonNull(exceptions).get(0));
     this.causes = exceptions;
   }
 


### PR DESCRIPTION
Overriding `toString`. Adding the first exception as cause - maybe would be better to override `printStackTrace` to handle the causes? Respectively `getOurStackTrace` in `Throwable` to have it nicer?