### PR TITLE
fix: remove get controllers from operator

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Operator.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Operator.java
@@ -1,8 +1,6 @@
 package io.javaoperatorsdk.operator;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -73,10 +71,6 @@ public class Operator implements LifecycleAware {
 
   public KubernetesClient getKubernetesClient() {
     return kubernetesClient;
-  }
-
-  public List<Controller> getControllers() {
-    return new ArrayList<>(controllers.controllers.values());
   }
 
   /**

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/OperatorTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/OperatorTest.java
@@ -10,12 +10,9 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.config.AbstractConfigurationService;
 import io.javaoperatorsdk.operator.api.config.ConfigurationServiceProvider;
-import io.javaoperatorsdk.operator.api.config.MockControllerConfiguration;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
-
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @SuppressWarnings("rawtypes")
 class OperatorTest {
@@ -28,20 +25,6 @@ class OperatorTest {
   @AfterAll
   static void setUpConfigurationServiceProvider() {
     ConfigurationServiceProvider.reset();
-  }
-
-  @Test
-  @DisplayName("should register `Reconciler` to Controller")
-  public void shouldRegisterReconcilerToController() {
-    // given
-    final var configuration = MockControllerConfiguration.forResource(ConfigMap.class);
-
-    // when
-    operator.register(fooReconciler, configuration);
-
-    // then
-    assertThat(operator.getControllers().size()).isEqualTo(1);
-    assertThat(operator.getControllers().get(0).getReconciler()).isEqualTo(fooReconciler);
   }
 
   @Test

--- a/operator-framework-junit5/src/main/java/io/javaoperatorsdk/operator/junit/OperatorExtension.java
+++ b/operator-framework-junit5/src/main/java/io/javaoperatorsdk/operator/junit/OperatorExtension.java
@@ -18,7 +18,6 @@ import io.javaoperatorsdk.operator.Operator;
 import io.javaoperatorsdk.operator.api.config.ConfigurationService;
 import io.javaoperatorsdk.operator.api.config.ControllerConfigurationOverrider;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
-import io.javaoperatorsdk.operator.processing.Controller;
 import io.javaoperatorsdk.operator.processing.retry.Retry;
 
 import static io.javaoperatorsdk.operator.api.config.ControllerConfigurationOverrider.override;
@@ -65,7 +64,7 @@ public class OperatorExtension extends AbstractOperatorExtension {
   }
 
   private Stream<Reconciler> reconcilers() {
-    return operator.getControllers().stream().map(Controller::getReconciler);
+    return reconcilers.stream().map(reconcilerSpec -> reconcilerSpec.reconciler);
   }
 
   public List<Reconciler> getReconcilers() {


### PR DESCRIPTION
Controllers should not be exposed, those are internal structures for now. Without a clear purpose this can be confusing.