### PR TITLE
feat: make RegisteredController a little more useful

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/RegisteredController.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/RegisteredController.java
@@ -1,6 +1,9 @@
 package io.javaoperatorsdk.operator;
 
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
 import io.javaoperatorsdk.operator.api.config.NamespaceChangeable;
 
-public interface RegisteredController extends NamespaceChangeable {
+public interface RegisteredController<P extends HasMetadata> extends NamespaceChangeable {
+  ControllerConfiguration<P> getConfiguration();
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/Controller.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/Controller.java
@@ -33,7 +33,7 @@ import static io.javaoperatorsdk.operator.api.reconciler.Constants.WATCH_CURRENT
 @SuppressWarnings({"unchecked", "rawtypes"})
 @Ignore
 public class Controller<P extends HasMetadata>
-    implements Reconciler<P>, Cleaner<P>, LifecycleAware, RegisteredController {
+    implements Reconciler<P>, Cleaner<P>, LifecycleAware, RegisteredController<P> {
 
   private static final Logger log = LoggerFactory.getLogger(Controller.class);
 


### PR DESCRIPTION
Allows to retrieve information from registered controllers from
Operator, in particular if there are any registered controllers, which
the Quarkus extension uses to determine whether or not to start the
Operator.
