### PR TITLE
refactor!: rename JUnit extensions more appropriately

### DIFF
--- a/operator-framework-junit5/src/main/java/io/javaoperatorsdk/operator/junit/ClusterOperatorExtension.java
+++ b/operator-framework-junit5/src/main/java/io/javaoperatorsdk/operator/junit/ClusterOperatorExtension.java
@@ -20,14 +20,14 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
 import io.javaoperatorsdk.operator.api.config.ConfigurationService;
 
-public class E2EOperatorExtension extends AbstractOperatorExtension {
+public class ClusterOperatorExtension extends AbstractOperatorExtension {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(E2EOperatorExtension.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(ClusterOperatorExtension.class);
 
   private final List<HasMetadata> operatorDeployment;
   private final Duration operatorDeploymentTimeout;
 
-  private E2EOperatorExtension(
+  private ClusterOperatorExtension(
       ConfigurationService configurationService,
       List<HasMetadata> operatorDeployment,
       Duration operatorDeploymentTimeout,
@@ -44,7 +44,7 @@ public class E2EOperatorExtension extends AbstractOperatorExtension {
   }
 
   /**
-   * Creates a {@link Builder} to set up an {@link E2EOperatorExtension} instance.
+   * Creates a {@link Builder} to set up an {@link ClusterOperatorExtension} instance.
    *
    * @return the builder.
    */
@@ -132,8 +132,8 @@ public class E2EOperatorExtension extends AbstractOperatorExtension {
       return this;
     }
 
-    public E2EOperatorExtension build() {
-      return new E2EOperatorExtension(
+    public ClusterOperatorExtension build() {
+      return new ClusterOperatorExtension(
           configurationService,
           operatorDeployment,
           deploymentTimeout,

--- a/operator-framework-junit5/src/main/java/io/javaoperatorsdk/operator/junit/LocalOperatorExtension.java
+++ b/operator-framework-junit5/src/main/java/io/javaoperatorsdk/operator/junit/LocalOperatorExtension.java
@@ -26,17 +26,17 @@ import io.javaoperatorsdk.operator.processing.retry.Retry;
 import static io.javaoperatorsdk.operator.api.config.ControllerConfigurationOverrider.override;
 
 @SuppressWarnings("rawtypes")
-public class OperatorExtension extends AbstractOperatorExtension {
+public class LocalOperatorExtension extends AbstractOperatorExtension {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(OperatorExtension.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(LocalOperatorExtension.class);
 
   private final Operator operator;
   private final List<ReconcilerSpec> reconcilers;
-  private List<PortFowardSpec> portForwards;
-  private List<LocalPortForward> localPortForwards;
-  private Map<Reconciler, RegisteredController> registeredControllers;
+  private final List<PortFowardSpec> portForwards;
+  private final List<LocalPortForward> localPortForwards;
+  private final Map<Reconciler, RegisteredController> registeredControllers;
 
-  private OperatorExtension(
+  private LocalOperatorExtension(
       ConfigurationService configurationService,
       List<ReconcilerSpec> reconcilers,
       List<HasMetadata> infrastructure,
@@ -60,7 +60,7 @@ public class OperatorExtension extends AbstractOperatorExtension {
   }
 
   /**
-   * Creates a {@link Builder} to set up an {@link OperatorExtension} instance.
+   * Creates a {@link Builder} to set up an {@link LocalOperatorExtension} instance.
    *
    * @return the builder.
    */
@@ -221,8 +221,8 @@ public class OperatorExtension extends AbstractOperatorExtension {
       return this;
     }
 
-    public OperatorExtension build() {
-      return new OperatorExtension(
+    public LocalOperatorExtension build() {
+      return new LocalOperatorExtension(
           configurationService,
           reconcilers,
           infrastructure,

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/ChangeNamespaceIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/ChangeNamespaceIT.java
@@ -12,7 +12,7 @@ import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.javaoperatorsdk.operator.junit.OperatorExtension;
+import io.javaoperatorsdk.operator.junit.LocalOperatorExtension;
 import io.javaoperatorsdk.operator.sample.changenamespace.ChangeNamespaceTestCustomResource;
 import io.javaoperatorsdk.operator.sample.changenamespace.ChangeNamespaceTestReconciler;
 
@@ -26,8 +26,8 @@ class ChangeNamespaceIT {
   public static final String TEST_RESOURCE_NAME_3 = "test3";
   public static final String ADDITIONAL_TEST_NAMESPACE = "additional-test-namespace";
   @RegisterExtension
-  OperatorExtension operator =
-      OperatorExtension.builder().withReconciler(new ChangeNamespaceTestReconciler()).build();
+  LocalOperatorExtension operator =
+      LocalOperatorExtension.builder().withReconciler(new ChangeNamespaceTestReconciler()).build();
 
   @Test
   void addNewAndRemoveOldNamespaceTest() {

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/CleanerForReconcilerIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/CleanerForReconcilerIT.java
@@ -17,7 +17,8 @@ class CleanerForReconcilerIT {
 
   @RegisterExtension
   LocalOperatorExtension operator =
-      LocalOperatorExtension.builder().withReconciler(new CleanerForReconcilerTestReconciler()).build();
+      LocalOperatorExtension.builder().withReconciler(new CleanerForReconcilerTestReconciler())
+          .build();
 
 
   @Test

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/CleanerForReconcilerIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/CleanerForReconcilerIT.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.javaoperatorsdk.operator.junit.OperatorExtension;
+import io.javaoperatorsdk.operator.junit.LocalOperatorExtension;
 import io.javaoperatorsdk.operator.sample.cleanerforreconciler.CleanerForReconcilerCustomResource;
 import io.javaoperatorsdk.operator.sample.cleanerforreconciler.CleanerForReconcilerTestReconciler;
 
@@ -16,8 +16,8 @@ class CleanerForReconcilerIT {
   public static final String TEST_RESOURCE_NAME = "cleaner-for-reconciler-test1";
 
   @RegisterExtension
-  OperatorExtension operator =
-      OperatorExtension.builder().withReconciler(new CleanerForReconcilerTestReconciler()).build();
+  LocalOperatorExtension operator =
+      LocalOperatorExtension.builder().withReconciler(new CleanerForReconcilerTestReconciler()).build();
 
 
   @Test

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/ConcurrencyIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/ConcurrencyIT.java
@@ -10,7 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
-import io.javaoperatorsdk.operator.junit.OperatorExtension;
+import io.javaoperatorsdk.operator.junit.LocalOperatorExtension;
 import io.javaoperatorsdk.operator.sample.simple.TestCustomResource;
 import io.javaoperatorsdk.operator.sample.simple.TestReconciler;
 import io.javaoperatorsdk.operator.support.TestUtils;
@@ -26,8 +26,8 @@ class ConcurrencyIT {
   private static final Logger log = LoggerFactory.getLogger(ConcurrencyIT.class);
 
   @RegisterExtension
-  OperatorExtension operator =
-      OperatorExtension.builder().withReconciler(new TestReconciler(true)).build();
+  LocalOperatorExtension operator =
+      LocalOperatorExtension.builder().withReconciler(new TestReconciler(true)).build();
 
   @Test
   void manyResourcesGetCreatedUpdatedAndDeleted() throws InterruptedException {

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/ControllerExecutionIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/ControllerExecutionIT.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
-import io.javaoperatorsdk.operator.junit.OperatorExtension;
+import io.javaoperatorsdk.operator.junit.LocalOperatorExtension;
 import io.javaoperatorsdk.operator.sample.simple.TestCustomResource;
 import io.javaoperatorsdk.operator.sample.simple.TestReconciler;
 import io.javaoperatorsdk.operator.support.TestUtils;
@@ -18,8 +18,8 @@ import static org.awaitility.Awaitility.await;
 class ControllerExecutionIT {
 
   @RegisterExtension
-  OperatorExtension operator =
-      OperatorExtension.builder().withReconciler(new TestReconciler(true)).build();
+  LocalOperatorExtension operator =
+      LocalOperatorExtension.builder().withReconciler(new TestReconciler(true)).build();
 
   @Test
   void configMapGetsCreatedForTestCustomResource() {

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/CreateUpdateInformerEventSourceEventFilterIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/CreateUpdateInformerEventSourceEventFilterIT.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.javaoperatorsdk.operator.junit.OperatorExtension;
+import io.javaoperatorsdk.operator.junit.LocalOperatorExtension;
 import io.javaoperatorsdk.operator.sample.createupdateeventfilter.CreateUpdateEventFilterTestCustomResource;
 import io.javaoperatorsdk.operator.sample.createupdateeventfilter.CreateUpdateEventFilterTestCustomResourceSpec;
 import io.javaoperatorsdk.operator.sample.createupdateeventfilter.CreateUpdateEventFilterTestReconciler;
@@ -19,8 +19,8 @@ import static org.awaitility.Awaitility.await;
 class CreateUpdateInformerEventSourceEventFilterIT {
 
   @RegisterExtension
-  OperatorExtension operator =
-      OperatorExtension.builder()
+  LocalOperatorExtension operator =
+      LocalOperatorExtension.builder()
           .withReconciler(new CreateUpdateEventFilterTestReconciler())
           .build();
 

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/CustomResourceFilterIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/CustomResourceFilterIT.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.javaoperatorsdk.operator.junit.OperatorExtension;
+import io.javaoperatorsdk.operator.junit.LocalOperatorExtension;
 import io.javaoperatorsdk.operator.sample.customfilter.CustomFilteringTestReconciler;
 import io.javaoperatorsdk.operator.sample.customfilter.CustomFilteringTestResource;
 import io.javaoperatorsdk.operator.sample.customfilter.CustomFilteringTestResourceSpec;
@@ -14,8 +14,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 class CustomResourceFilterIT {
 
   @RegisterExtension
-  OperatorExtension operator =
-      OperatorExtension.builder().withReconciler(new CustomFilteringTestReconciler()).build();
+  LocalOperatorExtension operator =
+      LocalOperatorExtension.builder().withReconciler(new CustomFilteringTestReconciler()).build();
 
   @Test
   void doesCustomFiltering() throws InterruptedException {

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/DeleterForManagedDependentResourcesOnlyIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/DeleterForManagedDependentResourcesOnlyIT.java
@@ -18,7 +18,8 @@ class DeleterForManagedDependentResourcesOnlyIT {
 
   @RegisterExtension
   LocalOperatorExtension operator =
-      LocalOperatorExtension.builder().withReconciler(new CleanerForManagedDependentTestReconciler())
+      LocalOperatorExtension.builder()
+          .withReconciler(new CleanerForManagedDependentTestReconciler())
           .build();
 
 

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/DeleterForManagedDependentResourcesOnlyIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/DeleterForManagedDependentResourcesOnlyIT.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.javaoperatorsdk.operator.junit.OperatorExtension;
+import io.javaoperatorsdk.operator.junit.LocalOperatorExtension;
 import io.javaoperatorsdk.operator.sample.cleanermanageddependent.CleanerForManagedDependentCustomResource;
 import io.javaoperatorsdk.operator.sample.cleanermanageddependent.CleanerForManagedDependentTestReconciler;
 import io.javaoperatorsdk.operator.sample.cleanermanageddependent.ConfigMapDependentResource;
@@ -17,8 +17,8 @@ class DeleterForManagedDependentResourcesOnlyIT {
   public static final String TEST_RESOURCE_NAME = "cleaner-for-reconciler-test1";
 
   @RegisterExtension
-  OperatorExtension operator =
-      OperatorExtension.builder().withReconciler(new CleanerForManagedDependentTestReconciler())
+  LocalOperatorExtension operator =
+      LocalOperatorExtension.builder().withReconciler(new CleanerForManagedDependentTestReconciler())
           .build();
 
 

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/DependentOperationEventFilterIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/DependentOperationEventFilterIT.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.javaoperatorsdk.operator.junit.OperatorExtension;
+import io.javaoperatorsdk.operator.junit.LocalOperatorExtension;
 import io.javaoperatorsdk.operator.sample.dependentoperationeventfiltering.ConfigMapDependentResource;
 import io.javaoperatorsdk.operator.sample.dependentoperationeventfiltering.DependentOperationEventFilterCustomResource;
 import io.javaoperatorsdk.operator.sample.dependentoperationeventfiltering.DependentOperationEventFilterCustomResourceSpec;
@@ -23,8 +23,8 @@ class DependentOperationEventFilterIT {
   public static final String SPEC_VAL_2 = "val2";
 
   @RegisterExtension
-  OperatorExtension operator =
-      OperatorExtension.builder()
+  LocalOperatorExtension operator =
+      LocalOperatorExtension.builder()
           .withReconciler(new DependentOperationEventFilterCustomResourceTestReconciler())
           .build();
 

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/DependentPrimaryIndexerIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/DependentPrimaryIndexerIT.java
@@ -1,12 +1,12 @@
 package io.javaoperatorsdk.operator;
 
-import io.javaoperatorsdk.operator.junit.OperatorExtension;
+import io.javaoperatorsdk.operator.junit.LocalOperatorExtension;
 import io.javaoperatorsdk.operator.sample.primaryindexer.DependentPrimaryIndexerTestReconciler;
 
 public class DependentPrimaryIndexerIT extends PrimaryIndexerIT {
 
-  protected OperatorExtension buildOperator() {
-    return OperatorExtension.builder().withReconciler(new DependentPrimaryIndexerTestReconciler())
+  protected LocalOperatorExtension buildOperator() {
+    return LocalOperatorExtension.builder().withReconciler(new DependentPrimaryIndexerTestReconciler())
         .build();
   }
 }

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/DependentPrimaryIndexerIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/DependentPrimaryIndexerIT.java
@@ -6,7 +6,8 @@ import io.javaoperatorsdk.operator.sample.primaryindexer.DependentPrimaryIndexer
 public class DependentPrimaryIndexerIT extends PrimaryIndexerIT {
 
   protected LocalOperatorExtension buildOperator() {
-    return LocalOperatorExtension.builder().withReconciler(new DependentPrimaryIndexerTestReconciler())
+    return LocalOperatorExtension.builder()
+        .withReconciler(new DependentPrimaryIndexerTestReconciler())
         .build();
   }
 }

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/ErrorStatusHandlerIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/ErrorStatusHandlerIT.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
-import io.javaoperatorsdk.operator.junit.OperatorExtension;
+import io.javaoperatorsdk.operator.junit.LocalOperatorExtension;
 import io.javaoperatorsdk.operator.processing.retry.GenericRetry;
 import io.javaoperatorsdk.operator.sample.errorstatushandler.ErrorStatusHandlerTestCustomResource;
 import io.javaoperatorsdk.operator.sample.errorstatushandler.ErrorStatusHandlerTestReconciler;
@@ -20,8 +20,8 @@ class ErrorStatusHandlerIT {
   ErrorStatusHandlerTestReconciler reconciler = new ErrorStatusHandlerTestReconciler();
 
   @RegisterExtension
-  OperatorExtension operator =
-      OperatorExtension.builder()
+  LocalOperatorExtension operator =
+      LocalOperatorExtension.builder()
           .withReconciler(reconciler,
               new GenericRetry().setMaxAttempts(MAX_RETRY_ATTEMPTS).withLinearRetry())
           .build();

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/EventSourceIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/EventSourceIT.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
-import io.javaoperatorsdk.operator.junit.OperatorExtension;
+import io.javaoperatorsdk.operator.junit.LocalOperatorExtension;
 import io.javaoperatorsdk.operator.sample.event.EventSourceTestCustomReconciler;
 import io.javaoperatorsdk.operator.sample.event.EventSourceTestCustomResource;
 import io.javaoperatorsdk.operator.sample.event.EventSourceTestCustomResourceSpec;
@@ -17,8 +17,8 @@ import static org.awaitility.Awaitility.await;
 
 class EventSourceIT {
   @RegisterExtension
-  OperatorExtension operator =
-      OperatorExtension.builder().withReconciler(EventSourceTestCustomReconciler.class).build();
+  LocalOperatorExtension operator =
+      LocalOperatorExtension.builder().withReconciler(EventSourceTestCustomReconciler.class).build();
 
   @Test
   void receivingPeriodicEvents() {

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/EventSourceIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/EventSourceIT.java
@@ -18,7 +18,8 @@ import static org.awaitility.Awaitility.await;
 class EventSourceIT {
   @RegisterExtension
   LocalOperatorExtension operator =
-      LocalOperatorExtension.builder().withReconciler(EventSourceTestCustomReconciler.class).build();
+      LocalOperatorExtension.builder().withReconciler(EventSourceTestCustomReconciler.class)
+          .build();
 
   @Test
   void receivingPeriodicEvents() {

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/InformerEventSourceIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/InformerEventSourceIT.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.javaoperatorsdk.operator.junit.OperatorExtension;
+import io.javaoperatorsdk.operator.junit.LocalOperatorExtension;
 import io.javaoperatorsdk.operator.sample.informereventsource.InformerEventSourceTestCustomReconciler;
 import io.javaoperatorsdk.operator.sample.informereventsource.InformerEventSourceTestCustomResource;
 
@@ -24,8 +24,8 @@ class InformerEventSourceIT {
   public static final String UPDATE_STATUS_MESSAGE = "Updated Status";
 
   @RegisterExtension
-  OperatorExtension operator =
-      OperatorExtension.builder()
+  LocalOperatorExtension operator =
+      LocalOperatorExtension.builder()
           .withReconciler(new InformerEventSourceTestCustomReconciler())
           .build();
 
@@ -38,7 +38,7 @@ class InformerEventSourceIT {
     waitForCRStatusValue(INITIAL_STATUS_MESSAGE);
 
     configMap.getData().put(TARGET_CONFIG_MAP_KEY, UPDATE_STATUS_MESSAGE);
-    configMap = operator.replace(ConfigMap.class, configMap);
+    operator.replace(ConfigMap.class, configMap);
 
     waitForCRStatusValue(UPDATE_STATUS_MESSAGE);
   }

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/KubernetesResourceStatusUpdateIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/KubernetesResourceStatusUpdateIT.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentSpec;
-import io.javaoperatorsdk.operator.junit.OperatorExtension;
+import io.javaoperatorsdk.operator.junit.LocalOperatorExtension;
 import io.javaoperatorsdk.operator.sample.deployment.DeploymentReconciler;
 
 import static io.javaoperatorsdk.operator.sample.deployment.DeploymentReconciler.STATUS_MESSAGE;
@@ -21,8 +21,8 @@ import static org.awaitility.Awaitility.await;
 class KubernetesResourceStatusUpdateIT {
 
   @RegisterExtension
-  OperatorExtension operator =
-      OperatorExtension.builder().withReconciler(new DeploymentReconciler()).build();
+  LocalOperatorExtension operator =
+      LocalOperatorExtension.builder().withReconciler(new DeploymentReconciler()).build();
 
   @Test
   void testReconciliationOfNonCustomResourceAndStatusUpdate() {

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/MaxIntervalIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/MaxIntervalIT.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.javaoperatorsdk.operator.junit.OperatorExtension;
+import io.javaoperatorsdk.operator.junit.LocalOperatorExtension;
 import io.javaoperatorsdk.operator.sample.maxinterval.MaxIntervalTestCustomResource;
 import io.javaoperatorsdk.operator.sample.maxinterval.MaxIntervalTestReconciler;
 
@@ -15,8 +15,8 @@ import static org.awaitility.Awaitility.await;
 class MaxIntervalIT {
 
   @RegisterExtension
-  OperatorExtension operator =
-      OperatorExtension.builder().withReconciler(new MaxIntervalTestReconciler()).build();
+  LocalOperatorExtension operator =
+      LocalOperatorExtension.builder().withReconciler(new MaxIntervalTestReconciler()).build();
 
   @Test
   void reconciliationTriggeredBasedOnMaxInterval() {

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/MultiVersionCRDIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/MultiVersionCRDIT.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.javaoperatorsdk.operator.junit.OperatorExtension;
+import io.javaoperatorsdk.operator.junit.LocalOperatorExtension;
 import io.javaoperatorsdk.operator.sample.multiversioncrd.*;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -19,8 +19,8 @@ class MultiVersionCRDIT {
   public static final String CR_V2_NAME = "crv2";
 
   @RegisterExtension
-  OperatorExtension operator =
-      OperatorExtension.builder()
+  LocalOperatorExtension operator =
+      LocalOperatorExtension.builder()
           .withReconciler(MultiVersionCRDTestReconciler1.class)
           .withReconciler(MultiVersionCRDTestReconciler2.class)
           .build();

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/MultipleSecondaryEventSourceIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/MultipleSecondaryEventSourceIT.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
-import io.javaoperatorsdk.operator.junit.OperatorExtension;
+import io.javaoperatorsdk.operator.junit.LocalOperatorExtension;
 import io.javaoperatorsdk.operator.sample.multiplesecondaryeventsource.MultipleSecondaryEventSourceCustomResource;
 import io.javaoperatorsdk.operator.sample.multiplesecondaryeventsource.MultipleSecondaryEventSourceReconciler;
 
@@ -17,8 +17,8 @@ class MultipleSecondaryEventSourceIT {
 
   public static final String TEST_RESOURCE_NAME = "testresource";
   @RegisterExtension
-  OperatorExtension operator =
-      OperatorExtension.builder().withReconciler(MultipleSecondaryEventSourceReconciler.class)
+  LocalOperatorExtension operator =
+      LocalOperatorExtension.builder().withReconciler(MultipleSecondaryEventSourceReconciler.class)
           .build();
 
   @Test

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/ObservedGenerationHandlingIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/ObservedGenerationHandlingIT.java
@@ -16,7 +16,8 @@ import static org.awaitility.Awaitility.await;
 class ObservedGenerationHandlingIT {
   @RegisterExtension
   LocalOperatorExtension operator =
-      LocalOperatorExtension.builder().withReconciler(new ObservedGenerationTestReconciler()).build();
+      LocalOperatorExtension.builder().withReconciler(new ObservedGenerationTestReconciler())
+          .build();
 
   @Test
   void testReconciliationOfNonCustomResourceAndStatusUpdate() {

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/ObservedGenerationHandlingIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/ObservedGenerationHandlingIT.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.javaoperatorsdk.operator.junit.OperatorExtension;
+import io.javaoperatorsdk.operator.junit.LocalOperatorExtension;
 import io.javaoperatorsdk.operator.sample.observedgeneration.ObservedGenerationTestCustomResource;
 import io.javaoperatorsdk.operator.sample.observedgeneration.ObservedGenerationTestReconciler;
 
@@ -15,8 +15,8 @@ import static org.awaitility.Awaitility.await;
 
 class ObservedGenerationHandlingIT {
   @RegisterExtension
-  OperatorExtension operator =
-      OperatorExtension.builder().withReconciler(new ObservedGenerationTestReconciler()).build();
+  LocalOperatorExtension operator =
+      LocalOperatorExtension.builder().withReconciler(new ObservedGenerationTestReconciler()).build();
 
   @Test
   void testReconciliationOfNonCustomResourceAndStatusUpdate() {

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/OrderedManagedDependentIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/OrderedManagedDependentIT.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.javaoperatorsdk.operator.junit.OperatorExtension;
+import io.javaoperatorsdk.operator.junit.LocalOperatorExtension;
 import io.javaoperatorsdk.operator.sample.orderedmanageddependent.ConfigMapDependentResource1;
 import io.javaoperatorsdk.operator.sample.orderedmanageddependent.ConfigMapDependentResource2;
 import io.javaoperatorsdk.operator.sample.orderedmanageddependent.OrderedManagedDependentCustomResource;
@@ -18,8 +18,8 @@ import static org.awaitility.Awaitility.await;
 class OrderedManagedDependentIT {
 
   @RegisterExtension
-  OperatorExtension operator =
-      OperatorExtension.builder().withReconciler(new OrderedManagedDependentTestReconciler())
+  LocalOperatorExtension operator =
+      LocalOperatorExtension.builder().withReconciler(new OrderedManagedDependentTestReconciler())
           .build();
 
   @Test

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/PrimaryIndexerIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/PrimaryIndexerIT.java
@@ -26,7 +26,8 @@ class PrimaryIndexerIT {
   LocalOperatorExtension operator = buildOperator();
 
   protected LocalOperatorExtension buildOperator() {
-    return LocalOperatorExtension.builder().withReconciler(new PrimaryIndexerTestReconciler()).build();
+    return LocalOperatorExtension.builder().withReconciler(new PrimaryIndexerTestReconciler())
+        .build();
   }
 
   @Test

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/PrimaryIndexerIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/PrimaryIndexerIT.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.javaoperatorsdk.operator.junit.OperatorExtension;
+import io.javaoperatorsdk.operator.junit.LocalOperatorExtension;
 import io.javaoperatorsdk.operator.sample.primaryindexer.AbstractPrimaryIndexerTestReconciler;
 import io.javaoperatorsdk.operator.sample.primaryindexer.PrimaryIndexerTestCustomResource;
 import io.javaoperatorsdk.operator.sample.primaryindexer.PrimaryIndexerTestCustomResourceSpec;
@@ -23,10 +23,10 @@ class PrimaryIndexerIT {
   public static final String RESOURCE_NAME2 = "test2";
 
   @RegisterExtension
-  OperatorExtension operator = buildOperator();
+  LocalOperatorExtension operator = buildOperator();
 
-  protected OperatorExtension buildOperator() {
-    return OperatorExtension.builder().withReconciler(new PrimaryIndexerTestReconciler()).build();
+  protected LocalOperatorExtension buildOperator() {
+    return LocalOperatorExtension.builder().withReconciler(new PrimaryIndexerTestReconciler()).build();
   }
 
   @Test

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/RetryIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/RetryIT.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
-import io.javaoperatorsdk.operator.junit.OperatorExtension;
+import io.javaoperatorsdk.operator.junit.LocalOperatorExtension;
 import io.javaoperatorsdk.operator.processing.retry.GenericRetry;
 import io.javaoperatorsdk.operator.sample.retry.RetryTestCustomReconciler;
 import io.javaoperatorsdk.operator.sample.retry.RetryTestCustomResource;
@@ -24,8 +24,8 @@ class RetryIT {
   public static final int NUMBER_FAILED_EXECUTIONS = 3;
 
   @RegisterExtension
-  OperatorExtension operator =
-      OperatorExtension.builder()
+  LocalOperatorExtension operator =
+      LocalOperatorExtension.builder()
           .withReconciler(
               new RetryTestCustomReconciler(NUMBER_FAILED_EXECUTIONS),
               new GenericRetry().setInitialInterval(RETRY_INTERVAL).withLinearRetry()

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/RetryMaxAttemptIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/RetryMaxAttemptIT.java
@@ -3,7 +3,7 @@ package io.javaoperatorsdk.operator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.javaoperatorsdk.operator.junit.OperatorExtension;
+import io.javaoperatorsdk.operator.junit.LocalOperatorExtension;
 import io.javaoperatorsdk.operator.processing.retry.GenericRetry;
 import io.javaoperatorsdk.operator.sample.retry.RetryTestCustomReconciler;
 import io.javaoperatorsdk.operator.sample.retry.RetryTestCustomResource;
@@ -20,8 +20,8 @@ class RetryMaxAttemptIT {
   RetryTestCustomReconciler reconciler = new RetryTestCustomReconciler(ALL_EXECUTION_TO_FAIL);
 
   @RegisterExtension
-  OperatorExtension operator =
-      OperatorExtension.builder()
+  LocalOperatorExtension operator =
+      LocalOperatorExtension.builder()
           .withReconciler(reconciler,
               new GenericRetry().setInitialInterval(RETRY_INTERVAL).withLinearRetry()
                   .setMaxAttempts(MAX_RETRY_ATTEMPTS))

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/StandaloneDependentResourceIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/StandaloneDependentResourceIT.java
@@ -22,7 +22,8 @@ class StandaloneDependentResourceIT {
 
   @RegisterExtension
   LocalOperatorExtension operator =
-      LocalOperatorExtension.builder().withReconciler(new StandaloneDependentTestReconciler()).build();
+      LocalOperatorExtension.builder().withReconciler(new StandaloneDependentTestReconciler())
+          .build();
 
   @Test
   void dependentResourceManagesDeployment() {

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/StandaloneDependentResourceIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/StandaloneDependentResourceIT.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.javaoperatorsdk.operator.api.config.ConfigurationService;
-import io.javaoperatorsdk.operator.junit.OperatorExtension;
+import io.javaoperatorsdk.operator.junit.LocalOperatorExtension;
 import io.javaoperatorsdk.operator.sample.standalonedependent.StandaloneDependentTestCustomResource;
 import io.javaoperatorsdk.operator.sample.standalonedependent.StandaloneDependentTestCustomResourceSpec;
 import io.javaoperatorsdk.operator.sample.standalonedependent.StandaloneDependentTestReconciler;
@@ -21,8 +21,8 @@ class StandaloneDependentResourceIT {
   public static final String DEPENDENT_TEST_NAME = "dependent-test1";
 
   @RegisterExtension
-  OperatorExtension operator =
-      OperatorExtension.builder().withReconciler(new StandaloneDependentTestReconciler()).build();
+  LocalOperatorExtension operator =
+      LocalOperatorExtension.builder().withReconciler(new StandaloneDependentTestReconciler()).build();
 
   @Test
   void dependentResourceManagesDeployment() {

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/SubResourceUpdateIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/SubResourceUpdateIT.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
-import io.javaoperatorsdk.operator.junit.OperatorExtension;
+import io.javaoperatorsdk.operator.junit.LocalOperatorExtension;
 import io.javaoperatorsdk.operator.sample.subresource.SubResourceTestCustomReconciler;
 import io.javaoperatorsdk.operator.sample.subresource.SubResourceTestCustomResource;
 import io.javaoperatorsdk.operator.sample.subresource.SubResourceTestCustomResourceSpec;
@@ -23,8 +23,8 @@ class SubResourceUpdateIT {
   public static final int EVENT_RECEIVE_WAIT = 200;
 
   @RegisterExtension
-  OperatorExtension operator =
-      OperatorExtension.builder().withReconciler(SubResourceTestCustomReconciler.class).build();
+  LocalOperatorExtension operator =
+      LocalOperatorExtension.builder().withReconciler(SubResourceTestCustomReconciler.class).build();
 
   @Test
   void updatesSubResourceStatus() {

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/SubResourceUpdateIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/SubResourceUpdateIT.java
@@ -24,7 +24,8 @@ class SubResourceUpdateIT {
 
   @RegisterExtension
   LocalOperatorExtension operator =
-      LocalOperatorExtension.builder().withReconciler(SubResourceTestCustomReconciler.class).build();
+      LocalOperatorExtension.builder().withReconciler(SubResourceTestCustomReconciler.class)
+          .build();
 
   @Test
   void updatesSubResourceStatus() {

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/UpdatingResAndSubResIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/UpdatingResAndSubResIT.java
@@ -19,7 +19,8 @@ import static org.awaitility.Awaitility.await;
 class UpdatingResAndSubResIT {
   @RegisterExtension
   LocalOperatorExtension operator =
-      LocalOperatorExtension.builder().withReconciler(DoubleUpdateTestCustomReconciler.class).build();
+      LocalOperatorExtension.builder().withReconciler(DoubleUpdateTestCustomReconciler.class)
+          .build();
 
   @Test
   void updatesSubResourceStatus() {

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/UpdatingResAndSubResIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/UpdatingResAndSubResIT.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
-import io.javaoperatorsdk.operator.junit.OperatorExtension;
+import io.javaoperatorsdk.operator.junit.LocalOperatorExtension;
 import io.javaoperatorsdk.operator.sample.doubleupdate.DoubleUpdateTestCustomReconciler;
 import io.javaoperatorsdk.operator.sample.doubleupdate.DoubleUpdateTestCustomResource;
 import io.javaoperatorsdk.operator.sample.doubleupdate.DoubleUpdateTestCustomResourceSpec;
@@ -18,8 +18,8 @@ import static org.awaitility.Awaitility.await;
 
 class UpdatingResAndSubResIT {
   @RegisterExtension
-  OperatorExtension operator =
-      OperatorExtension.builder().withReconciler(DoubleUpdateTestCustomReconciler.class).build();
+  LocalOperatorExtension operator =
+      LocalOperatorExtension.builder().withReconciler(DoubleUpdateTestCustomReconciler.class).build();
 
   @Test
   void updatesSubResourceStatus() {

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/support/TestUtils.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/support/TestUtils.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 import java.util.UUID;
 
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
-import io.javaoperatorsdk.operator.junit.OperatorExtension;
+import io.javaoperatorsdk.operator.junit.LocalOperatorExtension;
 import io.javaoperatorsdk.operator.sample.simple.TestCustomResource;
 import io.javaoperatorsdk.operator.sample.simple.TestCustomResourceSpec;
 
@@ -56,7 +56,7 @@ public class TestUtils {
     }
   }
 
-  public static int getNumberOfExecutions(OperatorExtension extension) {
+  public static int getNumberOfExecutions(LocalOperatorExtension extension) {
     return ((TestExecutionInfoProvider) extension.getReconcilers().get(0)).getNumberOfExecutions();
   }
 }

--- a/sample-operators/mysql-schema/src/test/java/io/javaoperatorsdk/operator/sample/MySQLSchemaOperatorE2E.java
+++ b/sample-operators/mysql-schema/src/test/java/io/javaoperatorsdk/operator/sample/MySQLSchemaOperatorE2E.java
@@ -18,7 +18,7 @@ import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.junit.AbstractOperatorExtension;
 import io.javaoperatorsdk.operator.junit.E2EOperatorExtension;
-import io.javaoperatorsdk.operator.junit.OperatorExtension;
+import io.javaoperatorsdk.operator.junit.LocalOperatorExtension;
 import io.javaoperatorsdk.operator.sample.dependent.ResourcePollerConfig;
 import io.javaoperatorsdk.operator.sample.dependent.SchemaDependentResource;
 
@@ -63,7 +63,7 @@ class MySQLSchemaOperatorE2E {
   @RegisterExtension
   AbstractOperatorExtension operator =
       isLocal()
-          ? OperatorExtension.builder()
+          ? LocalOperatorExtension.builder()
               .withReconciler(
                   new MySQLSchemaReconciler(),
                   c -> c.replacingNamedDependentResourceConfig(
@@ -82,7 +82,7 @@ class MySQLSchemaOperatorE2E {
   public MySQLSchemaOperatorE2E() throws FileNotFoundException {}
 
   @Test
-  void test() throws IOException {
+  void test() {
 
     MySQLSchema testSchema = new MySQLSchema();
     testSchema.setMetadata(

--- a/sample-operators/mysql-schema/src/test/java/io/javaoperatorsdk/operator/sample/MySQLSchemaOperatorE2E.java
+++ b/sample-operators/mysql-schema/src/test/java/io/javaoperatorsdk/operator/sample/MySQLSchemaOperatorE2E.java
@@ -2,7 +2,6 @@ package io.javaoperatorsdk.operator.sample;
 
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -17,7 +16,7 @@ import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.junit.AbstractOperatorExtension;
-import io.javaoperatorsdk.operator.junit.E2EOperatorExtension;
+import io.javaoperatorsdk.operator.junit.ClusterOperatorExtension;
 import io.javaoperatorsdk.operator.junit.LocalOperatorExtension;
 import io.javaoperatorsdk.operator.sample.dependent.ResourcePollerConfig;
 import io.javaoperatorsdk.operator.sample.dependent.SchemaDependentResource;
@@ -74,7 +73,7 @@ class MySQLSchemaOperatorE2E {
               .withInfrastructure(infrastructure)
               .withPortForward(MY_SQL_NS, "app", "mysql", 3306, LOCAL_PORT)
               .build()
-          : E2EOperatorExtension.builder()
+          : ClusterOperatorExtension.builder()
               .withOperatorDeployment(client.load(new FileInputStream("k8s/operator.yaml")).get())
               .withInfrastructure(infrastructure)
               .build();

--- a/sample-operators/tomcat-operator/src/test/java/io/javaoperatorsdk/operator/sample/TomcatOperatorE2E.java
+++ b/sample-operators/tomcat-operator/src/test/java/io/javaoperatorsdk/operator/sample/TomcatOperatorE2E.java
@@ -11,7 +11,7 @@ import org.slf4j.LoggerFactory;
 import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.kubernetes.client.*;
 import io.javaoperatorsdk.operator.junit.AbstractOperatorExtension;
-import io.javaoperatorsdk.operator.junit.E2EOperatorExtension;
+import io.javaoperatorsdk.operator.junit.ClusterOperatorExtension;
 import io.javaoperatorsdk.operator.junit.InClusterCurl;
 import io.javaoperatorsdk.operator.junit.LocalOperatorExtension;
 
@@ -45,7 +45,7 @@ class TomcatOperatorE2E {
       .withReconciler(new TomcatReconciler())
       .withReconciler(new WebappReconciler(client))
       .build()
-      : E2EOperatorExtension.builder()
+      : ClusterOperatorExtension.builder()
           .waitForNamespaceDeletion(false)
           .withOperatorDeployment(
               client.load(new FileInputStream("k8s/operator.yaml")).get())

--- a/sample-operators/tomcat-operator/src/test/java/io/javaoperatorsdk/operator/sample/TomcatOperatorE2E.java
+++ b/sample-operators/tomcat-operator/src/test/java/io/javaoperatorsdk/operator/sample/TomcatOperatorE2E.java
@@ -13,7 +13,7 @@ import io.fabric8.kubernetes.client.*;
 import io.javaoperatorsdk.operator.junit.AbstractOperatorExtension;
 import io.javaoperatorsdk.operator.junit.E2EOperatorExtension;
 import io.javaoperatorsdk.operator.junit.InClusterCurl;
-import io.javaoperatorsdk.operator.junit.OperatorExtension;
+import io.javaoperatorsdk.operator.junit.LocalOperatorExtension;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.awaitility.Awaitility.await;
@@ -40,7 +40,7 @@ class TomcatOperatorE2E {
   }
 
   @RegisterExtension
-  AbstractOperatorExtension operator = isLocal() ? OperatorExtension.builder()
+  AbstractOperatorExtension operator = isLocal() ? LocalOperatorExtension.builder()
       .waitForNamespaceDeletion(false)
       .withReconciler(new TomcatReconciler())
       .withReconciler(new WebappReconciler(client))

--- a/sample-operators/webpage/src/test/java/io/javaoperatorsdk/operator/sample/WebPageOperatorDependentResourcesE2E.java
+++ b/sample-operators/webpage/src/test/java/io/javaoperatorsdk/operator/sample/WebPageOperatorDependentResourcesE2E.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.javaoperatorsdk.operator.junit.AbstractOperatorExtension;
 import io.javaoperatorsdk.operator.junit.E2EOperatorExtension;
-import io.javaoperatorsdk.operator.junit.OperatorExtension;
+import io.javaoperatorsdk.operator.junit.LocalOperatorExtension;
 
 class WebPageOperatorDependentResourcesE2E extends WebPageOperatorAbstractTest {
 
@@ -16,7 +16,7 @@ class WebPageOperatorDependentResourcesE2E extends WebPageOperatorAbstractTest {
   @RegisterExtension
   AbstractOperatorExtension operator =
       isLocal()
-          ? OperatorExtension.builder()
+          ? LocalOperatorExtension.builder()
               .waitForNamespaceDeletion(false)
               .withReconciler(new WebPageStandaloneDependentsReconciler(client))
               .build()

--- a/sample-operators/webpage/src/test/java/io/javaoperatorsdk/operator/sample/WebPageOperatorDependentResourcesE2E.java
+++ b/sample-operators/webpage/src/test/java/io/javaoperatorsdk/operator/sample/WebPageOperatorDependentResourcesE2E.java
@@ -6,7 +6,7 @@ import java.io.FileNotFoundException;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.javaoperatorsdk.operator.junit.AbstractOperatorExtension;
-import io.javaoperatorsdk.operator.junit.E2EOperatorExtension;
+import io.javaoperatorsdk.operator.junit.ClusterOperatorExtension;
 import io.javaoperatorsdk.operator.junit.LocalOperatorExtension;
 
 class WebPageOperatorDependentResourcesE2E extends WebPageOperatorAbstractTest {
@@ -20,7 +20,7 @@ class WebPageOperatorDependentResourcesE2E extends WebPageOperatorAbstractTest {
               .waitForNamespaceDeletion(false)
               .withReconciler(new WebPageStandaloneDependentsReconciler(client))
               .build()
-          : E2EOperatorExtension.builder()
+          : ClusterOperatorExtension.builder()
               .waitForNamespaceDeletion(false)
               .withOperatorDeployment(client.load(new FileInputStream("k8s/operator.yaml")).get())
               .build();

--- a/sample-operators/webpage/src/test/java/io/javaoperatorsdk/operator/sample/WebPageOperatorE2E.java
+++ b/sample-operators/webpage/src/test/java/io/javaoperatorsdk/operator/sample/WebPageOperatorE2E.java
@@ -10,7 +10,7 @@ import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.javaoperatorsdk.operator.junit.AbstractOperatorExtension;
-import io.javaoperatorsdk.operator.junit.E2EOperatorExtension;
+import io.javaoperatorsdk.operator.junit.ClusterOperatorExtension;
 import io.javaoperatorsdk.operator.junit.LocalOperatorExtension;
 
 import static io.javaoperatorsdk.operator.sample.WebPageOperator.WEBPAGE_RECONCILER_ENV;
@@ -28,7 +28,7 @@ class WebPageOperatorE2E extends WebPageOperatorAbstractTest {
               .waitForNamespaceDeletion(false)
               .withReconciler(new WebPageReconciler(client))
               .build()
-          : E2EOperatorExtension.builder()
+          : ClusterOperatorExtension.builder()
               .waitForNamespaceDeletion(false)
               .withOperatorDeployment(client.load(new FileInputStream("k8s/operator.yaml")).get(),
                   resources -> {

--- a/sample-operators/webpage/src/test/java/io/javaoperatorsdk/operator/sample/WebPageOperatorE2E.java
+++ b/sample-operators/webpage/src/test/java/io/javaoperatorsdk/operator/sample/WebPageOperatorE2E.java
@@ -11,7 +11,7 @@ import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.javaoperatorsdk.operator.junit.AbstractOperatorExtension;
 import io.javaoperatorsdk.operator.junit.E2EOperatorExtension;
-import io.javaoperatorsdk.operator.junit.OperatorExtension;
+import io.javaoperatorsdk.operator.junit.LocalOperatorExtension;
 
 import static io.javaoperatorsdk.operator.sample.WebPageOperator.WEBPAGE_RECONCILER_ENV;
 import static io.javaoperatorsdk.operator.sample.WebPageOperator.WEBPAGE_RECONCILER_ENV_VALUE;
@@ -24,7 +24,7 @@ class WebPageOperatorE2E extends WebPageOperatorAbstractTest {
   @RegisterExtension
   AbstractOperatorExtension operator =
       isLocal()
-          ? OperatorExtension.builder()
+          ? LocalOperatorExtension.builder()
               .waitForNamespaceDeletion(false)
               .withReconciler(new WebPageReconciler(client))
               .build()


### PR DESCRIPTION
- refactor: rename OperatorExtension -> LocalOperatorExtension
- refactor: rename E2EOperatorExtension -> ClusterOperatorExtension
