### PR TITLE
fix: resource cache after finalizer add

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/PostExecutionControl.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/PostExecutionControl.java
@@ -23,8 +23,9 @@ final class PostExecutionControl<R extends HasMetadata> {
     this.runtimeException = runtimeException;
   }
 
-  public static <R extends HasMetadata> PostExecutionControl<R> onlyFinalizerAdded() {
-    return new PostExecutionControl<>(true, null, false, null);
+  public static <R extends HasMetadata> PostExecutionControl<R> onlyFinalizerAdded(
+      R updatedCustomResource) {
+    return new PostExecutionControl<>(true, updatedCustomResource, false, null);
   }
 
   public static <R extends HasMetadata> PostExecutionControl<R> defaultDispatch() {
@@ -46,16 +47,8 @@ final class PostExecutionControl<R extends HasMetadata> {
     return new PostExecutionControl<>(false, null, false, exception);
   }
 
-  public boolean isOnlyFinalizerHandled() {
-    return onlyFinalizerHandled;
-  }
-
   public Optional<R> getUpdatedCustomResource() {
     return Optional.ofNullable(updatedCustomResource);
-  }
-
-  public boolean customResourceUpdatedDuringExecution() {
-    return updatedCustomResource != null;
   }
 
   public boolean exceptionDuringExecution() {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/ReconciliationDispatcher.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/ReconciliationDispatcher.java
@@ -98,8 +98,8 @@ class ReconciliationDispatcher<R extends HasMetadata> {
        * finalizer add. This will make sure that the resources are not created before there is a
        * finalizer.
        */
-      updateCustomResourceWithFinalizer(originalResource);
-      return PostExecutionControl.onlyFinalizerAdded();
+      var updatedResource = updateCustomResourceWithFinalizer(originalResource);
+      return PostExecutionControl.onlyFinalizerAdded(updatedResource);
     } else {
       var resourceForExecution =
           cloneResource(originalResource);
@@ -295,11 +295,11 @@ class ReconciliationDispatcher<R extends HasMetadata> {
     return postExecutionControl;
   }
 
-  private void updateCustomResourceWithFinalizer(R resource) {
+  private R updateCustomResourceWithFinalizer(R resource) {
     log.debug(
         "Adding finalizer for resource: {} version: {}", getUID(resource), getVersion(resource));
     resource.addFinalizer(configuration().getFinalizerName());
-    customResourceFacade.replaceResourceWithLock(resource);
+    return customResourceFacade.replaceResourceWithLock(resource);
   }
 
   private R updateCustomResource(R resource) {

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/ReconciliationDispatcherTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/ReconciliationDispatcherTest.java
@@ -261,13 +261,16 @@ class ReconciliationDispatcherTest {
   @Test
   void addsFinalizerIfNotMarkedForDeletionAndEmptyCustomResourceReturned() {
     removeFinalizers(testCustomResource);
-
     reconciler.reconcile = (r, c) -> UpdateControl.noUpdate();
+    when(customResourceFacade.replaceResourceWithLock(any())).thenReturn(testCustomResource);
 
-    reconciliationDispatcher.handleExecution(executionScopeWithCREvent(testCustomResource));
+    var postExecControl =
+        reconciliationDispatcher.handleExecution(executionScopeWithCREvent(testCustomResource));
 
     assertEquals(1, testCustomResource.getMetadata().getFinalizers().size());
     verify(customResourceFacade, times(1)).replaceResourceWithLock(any());
+    assertThat(postExecControl.updateIsStatusPatch()).isFalse();
+    assertThat(postExecControl.getUpdatedCustomResource()).isPresent();
   }
 
   @Test


### PR DESCRIPTION
Fix for the following error happens in some cases.
The cause was, that if there are event sources registered and a new resource is created, the finalizer was added, but is was not cached in tempCache, so if an event source produced an event just after, but before the update event from finalizer add arrived, the reconciliation used the resource from the cache without the finalizer (the first version), so controller tried to add the finalizer again.

The fix is actually trivial, just caching the resource to tempCache, as we do at any other update (not patch) operation.

```
job-example', namespace='default'}
2022-05-26 22:51:04,117 "48" i.j.o.p.e.EventProcessor       [DEBUG] [default.basic-session-cluster.36958] Skipping executing controller for resource id: ResourceID{name='basic-session-cluster', namespace='default'}. Controller in execution: true. Latest Resource present: true
2022-05-26 22:51:04,117 "64" i.j.o.p.e.ReconciliationDispatcher [DEBUG] [default.basic-session-job-example.36957] Adding finalizer for resource: 3ca8a128-d8b6-4d73-a975-270502dcc332 version: 36957
2022-05-26 22:51:04,117 "64" i.j.o.p.e.ReconciliationDispatcher [DEBUG] [default.basic-session-job-example.36957] Trying to replace resource basic-session-job-example, version: 36957
2022-05-26 22:51:04,117 "44" i.j.o.p.e.EventProcessor       [DEBUG] [default.basic-session-job-example.36959] Skipping executing controller for resource id: ResourceID{name='basic-session-job-example', namespace='default'}. Controller in execution: true. Latest Resource present: true
2022-05-26 22:51:04,123 "64" i.j.o.p.e.ReconciliationDispatcher [ERROR] [default.basic-session-job-example.36957] Error during event processing ExecutionScope{ resource id: ResourceID{name='basic-session-job-example', namespace='default'}, version: 36957} failed.
io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: PUT at: https://192.168.49.2:8443/apis/flink.apache.org/v1beta1/namespaces/default/flinksessionjobs/basic-session-job-example. Message: Operation cannot be fulfilled on flinksessionjobs.flink.apache.org "basic-session-job-example": the object has been modified; please apply your changes to the latest version and try again. Received status: Status(apiVersion=v1, code=409, details=StatusDetails(causes=[], group=flink.apache.org, kind=flinksessionjobs, name=basic-session-job-example, retryAfterSeconds=null, uid=null, additionalProperties={}), kind=Status, message=Operation cannot be fulfilled on flinksessionjobs.flink.apache.org "basic-session-job-example": the object has been modified; please apply your changes to the latest version and try again, metadata=ListMeta(_continue=null, remainingItemCount=null, resourceVersion=null, selfLink=null, additionalProperties={}), reason=Conflict, status=Failure, additionalProperties={}).
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.requestFailure(OperationSupport.java:682)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.requestFailure(OperationSupport.java:661)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.assertResponseCode(OperationSupport.java:612)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleResponse(OperationSupport.java:555)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleResponse(OperationSupport.java:518)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleUpdate(OperationSupport.java:342)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleUpdate(OperationSupport.java:322)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.handleUpdate(BaseOperation.java:649)
	at io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation.lambda$replace$1(HasMetadataOperation.java:195)
	at io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation.replace(HasMetadataOperation.java:200)
	at io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation.replace(HasMetadataOperation.java:141)
	at io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation.replace(HasMetadataOperation.java:43)
	at io.javaoperatorsdk.operator.processing.event.ReconciliationDispatcher$CustomResourceFacade.replaceResourceWithLock(ReconciliationDispatcher.java:346)
	at io.javaoperatorsdk.operator.processing.event.ReconciliationDispatcher.updateCustomResourceWithFinalizer(ReconciliationDispatcher.java:303)
	at io.javaoperatorsdk.operator.processing.event.ReconciliationDispatcher.handleReconcile(ReconciliationDispatcher.java:102)
	at io.javaoperatorsdk.operator.processing.event.ReconciliationDispatcher.handleDispatch(ReconciliationDispatcher.java:81)
	at io.javaoperatorsdk.operator.processing.event.ReconciliationDispatcher.handleExecution(ReconciliationDispatcher.java:56)
	at io.javaoperatorsdk.operator.processing.event.EventProcessor$ControllerExecution.run(EventProcessor.java:356)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)

```