### PR TITLE
feat: allow loading resources as builders

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/BuilderUtils.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/BuilderUtils.java
@@ -1,0 +1,35 @@
+
+package io.javaoperatorsdk.operator;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public final class BuilderUtils {
+
+  // prevent instantiation of util class
+  private BuilderUtils() {}
+
+  public static final <T, B> B newBuilder(Class<B> builderType, T item) {
+    Class<T> builderTargetType = builderTargetType(builderType);
+    try {
+      Constructor<B> constructor = builderType.getDeclaredConstructor(builderTargetType);
+      return constructor.newInstance(item);
+    } catch (NoSuchMethodException | SecurityException | InstantiationException
+        | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+      throw new OperatorException(
+          "Failied to instantiate builder: " + builderType.getCanonicalName() + " using: " + item,
+          e);
+    }
+  }
+
+  public static final <T, B> Class<T> builderTargetType(Class<B> builderType) {
+    try {
+      Method method = builderType.getDeclaredMethod("build");
+      return (Class<T>) method.getReturnType();
+    } catch (NoSuchMethodException | SecurityException e) {
+      throw new OperatorException(
+          "Failied to determine target type for builder: " + builderType.getCanonicalName(), e);
+    }
+  }
+}

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/ReconcilerUtils.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/ReconcilerUtils.java
@@ -10,6 +10,7 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import io.fabric8.kubernetes.api.builder.Builder;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.utils.Serialization;
@@ -114,6 +115,10 @@ public class ReconcilerUtils {
 
   public static <T> T loadYaml(Class<T> clazz, Class loader, String yaml) {
     try (InputStream is = loader.getResourceAsStream(yaml)) {
+      if (Builder.class.isAssignableFrom(clazz)) {
+        return BuilderUtils.newBuilder(clazz,
+            Serialization.unmarshal(is, BuilderUtils.builderTargetType(clazz)));
+      }
       return Serialization.unmarshal(is, clazz);
     } catch (IOException ex) {
       throw new IllegalStateException("Cannot find yaml on classpath: " + yaml);

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/ReconcilerUtilsTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/ReconcilerUtilsTest.java
@@ -2,12 +2,14 @@ package io.javaoperatorsdk.operator;
 
 import org.junit.jupiter.api.Test;
 
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.api.model.apps.DeploymentSpec;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.KubernetesClientException;
@@ -86,6 +88,16 @@ class ReconcilerUtilsTest {
     ReconcilerUtils.setSpec(deployment, newSpec);
 
     assertThat(deployment.getSpec().getReplicas()).isEqualTo(1);
+  }
+
+  @Test
+  void loadYamlAsBuilder() {
+    DeploymentBuilder builder =
+        ReconcilerUtils.loadYaml(DeploymentBuilder.class, getClass(), "deployment.yaml");
+    builder.accept(ContainerBuilder.class, c -> c.withImage("my-image"));
+
+    Deployment deployment = builder.editMetadata().withName("my-deployment").and().build();
+    assertThat(deployment.getMetadata().getName()).isEqualTo("my-deployment");
   }
 
   private Deployment createTestDeployment() {

--- a/operator-framework-core/src/test/resources/io/javaoperatorsdk/operator/deployment.yaml
+++ b/operator-framework-core/src/test/resources/io/javaoperatorsdk/operator/deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+kind: Deployment
+metadata:
+  name: ""
+spec:
+  progressDeadlineSeconds: 600
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: "test"
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: "test"
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.17.0
+        ports:
+        - containerPort: 80


### PR DESCRIPTION
Resolves: #1334 

`loadYaml` checks if the target class is a builder and if so, it initalizes the builder using the deserialized yaml.