### PR TITLE
feat: use fabric8 client json mapper by default

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/AbstractConfigurationService.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/AbstractConfigurationService.java
@@ -13,9 +13,16 @@ import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 public class AbstractConfigurationService implements ConfigurationService {
   private final Map<String, ControllerConfiguration> configurations = new ConcurrentHashMap<>();
   private final Version version;
+  private final Cloner cloner;
 
   public AbstractConfigurationService(Version version) {
     this.version = version;
+    this.cloner = ConfigurationService.super.getResourceCloner();
+  }
+
+  public AbstractConfigurationService(Version version, Cloner cloner) {
+    this.version = version;
+    this.cloner = cloner;
   }
 
   protected <R extends HasMetadata> void register(ControllerConfiguration<R> config) {
@@ -77,10 +84,12 @@ public class AbstractConfigurationService implements ConfigurationService {
     return ReconcilerUtils.getNameFor(reconciler);
   }
 
+  @SuppressWarnings("unused")
   protected ControllerConfiguration getFor(String reconcilerName) {
     return configurations.get(reconcilerName);
   }
 
+  @SuppressWarnings("unused")
   protected Stream<ControllerConfiguration> controllerConfigurations() {
     return configurations.values().stream();
   }
@@ -93,5 +102,10 @@ public class AbstractConfigurationService implements ConfigurationService {
   @Override
   public Version getVersion() {
     return version;
+  }
+
+  @Override
+  public Cloner getResourceCloner() {
+    return cloner;
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/BaseConfigurationService.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/BaseConfigurationService.java
@@ -15,6 +15,10 @@ public class BaseConfigurationService extends AbstractConfigurationService {
     super(version);
   }
 
+  public BaseConfigurationService(Version version, Cloner cloner) {
+    super(version, cloner);
+  }
+
   public BaseConfigurationService() {
     this(Utils.loadFromProperties());
   }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationService.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationService.java
@@ -7,6 +7,7 @@ import java.util.concurrent.Executors;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.client.utils.Serialization;
 import io.javaoperatorsdk.operator.api.monitoring.Metrics;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResourceFactory;
@@ -126,7 +127,7 @@ public interface ConfigurationService {
   }
 
   default ObjectMapper getObjectMapper() {
-    return OBJECT_MAPPER;
+    return Serialization.jsonMapper();
   }
 
   default DependentResourceFactory dependentResourceFactory() {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationServiceOverrider.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationServiceOverrider.java
@@ -72,7 +72,7 @@ public class ConfigurationServiceOverrider {
   }
 
   public ConfigurationService build() {
-    return new BaseConfigurationService(original.getVersion()) {
+    return new BaseConfigurationService(original.getVersion(), cloner) {
       @Override
       public Set<String> getKnownReconcilerNames() {
         return original.getKnownReconcilerNames();
@@ -91,11 +91,6 @@ public class ConfigurationServiceOverrider {
       @Override
       public int concurrentReconciliationThreads() {
         return threadNumber;
-      }
-
-      @Override
-      public Cloner getResourceCloner() {
-        return cloner;
       }
 
       @Override

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/StandaloneDependentResourceIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/StandaloneDependentResourceIT.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.javaoperatorsdk.operator.api.config.ConfigurationService;
+import io.javaoperatorsdk.operator.api.config.ConfigurationServiceProvider;
 import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
 import io.javaoperatorsdk.operator.sample.standalonedependent.StandaloneDependentTestCustomResource;
 import io.javaoperatorsdk.operator.sample.standalonedependent.StandaloneDependentTestCustomResourceSpec;
@@ -52,7 +52,7 @@ public class StandaloneDependentResourceIT {
 
     awaitForDeploymentReadyReplicas(1);
 
-    var clonedCr = ConfigurationService.DEFAULT_CLONER.clone(createdCR);
+    var clonedCr = ConfigurationServiceProvider.instance().getResourceCloner().clone(createdCR);
     clonedCr.getSpec().setReplicaCount(2);
     operator.replace(clonedCr);
 


### PR DESCRIPTION
The json mapper might be fine tuned for application in some cases, probably in the default case we should use that everywhere if possible.

see also: https://github.com/fabric8io/kubernetes-client/issues/1308