### PR TITLE
Add bom module

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,8 +25,8 @@ jobs:
           cache: 'maven'
       - name: Check code format
         run: |
-          ./mvnw ${MAVEN_ARGS} formatter:validate -Dconfigfile=$PWD/contributing/eclipse-google-style.xml --file pom.xml
-          ./mvnw ${MAVEN_ARGS} impsort:check --file pom.xml
+          ./mvnw ${MAVEN_ARGS} formatter:validate -Dconfigfile=$PWD/contributing/eclipse-google-style.xml -pl '!operator-framework-bom' --file pom.xml
+          ./mvnw ${MAVEN_ARGS} impsort:check -pl '!operator-framework-bom' --file pom.xml
       - name: Run unit tests
         run: ./mvnw ${MAVEN_ARGS} -B test --file pom.xml
 

--- a/operator-framework-bom/pom.xml
+++ b/operator-framework-bom/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.javaoperatorsdk</groupId>
     <artifactId>operator-framework-bom</artifactId>
     <version>3.1.2-SNAPSHOT</version>
-    <name>Operator SDK for Java Bill of Materials</name>
+    <name>Operator SDK for Java - Bill of Materials</name>
     <packaging>pom</packaging>
 
     <dependencyManagement>

--- a/operator-framework-bom/pom.xml
+++ b/operator-framework-bom/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+  
+    <groupId>io.javaoperatorsdk</groupId>
+    <artifactId>operator-framework-bom</artifactId>
+    <version>3.1.2-SNAPSHOT</version>
+    <name>Operator SDK for Java Bill of Materials</name>
+    <packaging>pom</packaging>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.javaoperatorsdk</groupId>
+                <artifactId>operator-framework-core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.javaoperatorsdk</groupId>
+                <artifactId>operator-framework</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.javaoperatorsdk</groupId>
+                <artifactId>micrometer-support</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.javaoperatorsdk</groupId>
+                <artifactId>operator-framework-junit-5</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+    </distributionManagement>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
     </properties>
 
     <modules>
+        <module>operator-framework-bom</module>
         <module>operator-framework-core</module>
         <module>operator-framework-junit5</module>
         <module>operator-framework</module>


### PR DESCRIPTION
When a project has multiple modules, publishing a bom is considered to be a good practice for users to more easily manage dependencies. For example: https://search.maven.org/artifact/io.fabric8/kubernetes-client-bom and https://search.maven.org/artifact/io.micrometer/micrometer-bom.

I'm not sure of the actual artifact deployment process, so hopefully this makes sense.

I tested locally and it works.