### PR TITLE
feat: add resource fetcher to CachingInboundEventSource (#1424)

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/ExternalResourceCachingEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/ExternalResourceCachingEventSource.java
@@ -64,6 +64,11 @@ public abstract class ExternalResourceCachingEventSource<R, P extends HasMetadat
   }
 
   protected synchronized void handleDelete(ResourceID primaryID, Set<String> resourceIDs) {
+    handleDelete(primaryID, resourceIDs, true);
+  }
+
+  protected synchronized void handleDelete(ResourceID primaryID, Set<String> resourceIDs,
+      boolean propagateEvent) {
     if (!isRunning()) {
       return;
     }
@@ -75,7 +80,7 @@ public abstract class ExternalResourceCachingEventSource<R, P extends HasMetadat
     if (cachedValues != null && cachedValues.isEmpty()) {
       cache.remove(primaryID);
     }
-    if (!removedResources.isEmpty() && deleteAcceptedByFilter(removedResources)) {
+    if (propagateEvent && !removedResources.isEmpty() && deleteAcceptedByFilter(removedResources)) {
       getEventHandler().handleEvent(new Event(primaryID));
     }
   }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/inbound/CachingInboundEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/inbound/CachingInboundEventSource.java
@@ -1,29 +1,131 @@
 package io.javaoperatorsdk.operator.processing.event.source.inbound;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.ConcurrentHashMap;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.javaoperatorsdk.operator.OperatorException;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import io.javaoperatorsdk.operator.processing.event.source.CacheKeyMapper;
 import io.javaoperatorsdk.operator.processing.event.source.ExternalResourceCachingEventSource;
+import io.javaoperatorsdk.operator.processing.event.source.ResourceEventAware;
 
 public class CachingInboundEventSource<R, P extends HasMetadata>
-    extends ExternalResourceCachingEventSource<R, P> {
+    extends ExternalResourceCachingEventSource<R, P>
+    implements ResourceEventAware<P> {
 
-  public CachingInboundEventSource(Class<R> resourceClass, CacheKeyMapper<R> cacheKeyMapper) {
+  private final Timer timer;
+  private final Map<String, TimerTask> timerTasks = new ConcurrentHashMap<>();
+  private final ResourceFetcher<R, P> resourceFetcher;
+  private final long period;
+  private final Set<ResourceID> fetchedForPrimaries = ConcurrentHashMap.newKeySet();
+
+  public CachingInboundEventSource(
+      ResourceFetcher<R, P> resourceFetcher, Class<R> resourceClass,
+      CacheKeyMapper<R> cacheKeyMapper) {
+    this(resourceFetcher, resourceClass, cacheKeyMapper, 0);
+  }
+
+  public CachingInboundEventSource(
+      ResourceFetcher<R, P> resourceFetcher, Class<R> resourceClass,
+      CacheKeyMapper<R> cacheKeyMapper, long period) {
     super(resourceClass, cacheKeyMapper);
+    this.resourceFetcher = resourceFetcher;
+    this.period = period;
+    this.timer = period > 0 ? new Timer() : null;
   }
 
   public void handleResourceEvent(ResourceID primaryID, Set<R> resources) {
     super.handleResources(primaryID, resources);
+
+    resources.forEach(resource -> checkAndRegisterTask(primaryID, resource));
   }
 
   public void handleResourceEvent(ResourceID primaryID, R resource) {
     super.handleResources(primaryID, resource);
+
+    checkAndRegisterTask(primaryID, resource);
   }
 
   public void handleResourceDeleteEvent(ResourceID primaryID, String resourceID) {
     super.handleDelete(primaryID, Set.of(resourceID));
+
+    TimerTask task = timerTasks.remove(resourceID);
+    if (task != null) {
+      task.cancel();
+    }
+  }
+
+  @Override
+  public void onResourceDeleted(P resource) {
+    var resourceID = ResourceID.fromResource(resource);
+    fetchedForPrimaries.remove(resourceID);
+  }
+
+  private Set<R> getAndCacheResource(P primary) {
+    var primaryID = ResourceID.fromResource(primary);
+    var values = resourceFetcher.fetchResources(primary);
+    handleResources(primaryID, values, false);
+    fetchedForPrimaries.add(primaryID);
+    values.forEach(resource -> checkAndRegisterTask(primaryID, resource));
+    return values;
+  }
+
+  private void invalidCacheResource(ResourceID primaryID, String secondaryID) {
+    handleDelete(primaryID, Set.of(secondaryID), false);
+  }
+
+  private void checkAndRegisterTask(ResourceID primaryID, R resource) {
+    var secondaryID = cacheKeyMapper.keyFor(resource);
+    timerTasks.computeIfAbsent(secondaryID, key -> {
+      var task = new TimerTask() {
+        @Override
+        public void run() {
+          invalidCacheResource(primaryID, key);
+        }
+      };
+      timer.schedule(task, period, period);
+      return task;
+    });
+  }
+
+  /**
+   * When this event source is queried for the resource, it might not be fully "synced". Thus, the
+   * cache might not be propagated, therefore the supplier is checked for the resource too.
+   *
+   * @param primary resource of the controller
+   * @return the related resource for this event source
+   */
+  @Override
+  public Set<R> getSecondaryResources(P primary) {
+    var primaryID = ResourceID.fromResource(primary);
+    var cachedValue = cache.get(primaryID);
+    if (cachedValue != null && !cachedValue.isEmpty()) {
+      return new HashSet<>(cachedValue.values());
+    } else {
+      if (fetchedForPrimaries.contains(primaryID)) {
+        return Collections.emptySet();
+      } else {
+        return getAndCacheResource(primary);
+      }
+    }
+  }
+
+  public interface ResourceFetcher<R, P> {
+    Set<R> fetchResources(P primaryResource);
+  }
+
+  @Override
+  public void stop() throws OperatorException {
+    super.stop();
+    if (timer != null) {
+      timer.cancel();
+    }
   }
 
 }


### PR DESCRIPTION
I don't see real practical use case where we don't want a `ResourceFetcher`. There is a breaking change due to signature change but if  `ResourceFetcher` is left optional, then then current behavior is flawed and I doubt any one use it yet.
Otherwise, we can keep the current behavior but it means being able to handle that  `Set<R> getSecondaryResources(P primary);` may not return a valid set, i.e. return an Optional.empty to tell it doesn't know anything about the secondary ressource associated to primary yet but it is a bigger design change.

If ResourceFetcher is mandatory, then there is a lot of code shared with `PerResourcePollingEventSource`. The code is refactored so that the public interface of both EventSource remains clearly separated and do not leak the base implementation. Only the logger categoy would change.

Be aware that `PerResourcePollingEventSource` now throw an argument exception when period is invalid (instead of when calling timer.schedule).
