### PR TITLE
Try to get lease namespace if unspecified

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/LeaderElectionManager.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/LeaderElectionManager.java
@@ -39,7 +39,7 @@ public class LeaderElectionManager {
   public void init(LeaderElectionConfiguration config, KubernetesClient client) {
     this.identity = identity(config);
     final var leaseNamespace =
-        config.getLeaseNamespace().or(LeaderElectionManager::tryGetInClusterNamespace);
+        config.getLeaseNamespace().or(LeaderElectionManager::tryNamespaceFromPath);
     if (leaseNamespace.isEmpty()) {
       final var message =
           "Lease namespace is not set and cannot be inferred. Leader election cannot continue.";
@@ -96,7 +96,7 @@ public class LeaderElectionManager {
     return id;
   }
 
-  private static Optional<String> tryGetInClusterNamespace() {
+  private static Optional<String> tryNamespaceFromPath() {
     log.info("Trying to get namespace from Kubernetes service account namespace path...");
 
     final var serviceAccountNamespace =

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/LeaderElectionManager.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/LeaderElectionManager.java
@@ -107,16 +107,17 @@ public class LeaderElectionManager {
     if (serviceAccountNamespaceExists) {
       log.info("Found service account namespace at: [{}].", serviceAccountNamespace);
       try {
-        return Optional.of(Files.readString(serviceAccountNamespacePath));
+        return Optional
+            .of(Files.readString(serviceAccountNamespacePath).strip());
       } catch (IOException e) {
         log.error(
             "Error reading service account namespace from: [" + serviceAccountNamespace + "].", e);
         return Optional.empty();
       }
-    } else {
-      log.warn("Did not find service account namespace at: [{}].", serviceAccountNamespace);
-      return Optional.empty();
     }
+
+    log.warn("Did not find service account namespace at: [{}].", serviceAccountNamespace);
+    return Optional.empty();
   }
 
   public void start() {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/LeaderElectionManager.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/LeaderElectionManager.java
@@ -1,9 +1,5 @@
 package io.javaoperatorsdk.operator;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
@@ -16,12 +12,8 @@ import io.fabric8.kubernetes.client.extended.leaderelection.LeaderElectionConfig
 import io.fabric8.kubernetes.client.extended.leaderelection.LeaderElector;
 import io.fabric8.kubernetes.client.extended.leaderelection.LeaderElectorBuilder;
 import io.fabric8.kubernetes.client.extended.leaderelection.resourcelock.LeaseLock;
-import io.fabric8.kubernetes.client.utils.Utils;
 import io.javaoperatorsdk.operator.api.config.ConfigurationServiceProvider;
 import io.javaoperatorsdk.operator.api.config.LeaderElectionConfiguration;
-
-import static io.fabric8.kubernetes.client.Config.KUBERNETES_NAMESPACE_FILE;
-import static io.fabric8.kubernetes.client.Config.KUBERNETES_NAMESPACE_PATH;
 
 public class LeaderElectionManager {
 
@@ -95,30 +87,6 @@ public class LeaderElectionManager {
       id = UUID.randomUUID().toString();
     }
     return id;
-  }
-
-  private static Optional<String> tryNamespaceFromPath() {
-    log.info("Trying to get namespace from Kubernetes service account namespace path...");
-
-    final var serviceAccountNamespace =
-        Utils.getSystemPropertyOrEnvVar(KUBERNETES_NAMESPACE_FILE, KUBERNETES_NAMESPACE_PATH);
-    final var serviceAccountNamespacePath = Path.of(serviceAccountNamespace);
-
-    final var serviceAccountNamespaceExists = Files.isRegularFile(serviceAccountNamespacePath);
-    if (serviceAccountNamespaceExists) {
-      log.info("Found service account namespace at: [{}].", serviceAccountNamespace);
-      try {
-        return Optional
-            .of(Files.readString(serviceAccountNamespacePath).strip());
-      } catch (IOException e) {
-        log.error(
-            "Error reading service account namespace from: [" + serviceAccountNamespace + "].", e);
-        return Optional.empty();
-      }
-    }
-
-    log.warn("Did not find service account namespace at: [{}].", serviceAccountNamespace);
-    return Optional.empty();
   }
 
   public void start() {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/LeaderElectionManager.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/LeaderElectionManager.java
@@ -1,5 +1,9 @@
 package io.javaoperatorsdk.operator;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
@@ -12,9 +16,12 @@ import io.fabric8.kubernetes.client.extended.leaderelection.LeaderElectionConfig
 import io.fabric8.kubernetes.client.extended.leaderelection.LeaderElector;
 import io.fabric8.kubernetes.client.extended.leaderelection.LeaderElectorBuilder;
 import io.fabric8.kubernetes.client.extended.leaderelection.resourcelock.LeaseLock;
-import io.fabric8.kubernetes.client.extended.leaderelection.resourcelock.Lock;
+import io.fabric8.kubernetes.client.utils.Utils;
 import io.javaoperatorsdk.operator.api.config.ConfigurationServiceProvider;
 import io.javaoperatorsdk.operator.api.config.LeaderElectionConfiguration;
+
+import static io.fabric8.kubernetes.client.Config.KUBERNETES_NAMESPACE_FILE;
+import static io.fabric8.kubernetes.client.Config.KUBERNETES_NAMESPACE_PATH;
 
 public class LeaderElectionManager {
 
@@ -31,14 +38,29 @@ public class LeaderElectionManager {
 
   public void init(LeaderElectionConfiguration config, KubernetesClient client) {
     this.identity = identity(config);
-    Lock lock = new LeaseLock(config.getLeaseNamespace(), config.getLeaseName(), identity);
+    final var leaseNamespace =
+        config.getLeaseNamespace().or(LeaderElectionManager::tryGetInClusterNamespace);
+    if (leaseNamespace.isEmpty()) {
+      final var message =
+          "Lease namespace is not set and cannot be inferred. Leader election cannot continue.";
+      log.error(message);
+      throw new IllegalArgumentException(message);
+    }
+    final var lock = new LeaseLock(leaseNamespace.orElseThrow(), config.getLeaseName(), identity);
     // releaseOnCancel is not used in the underlying implementation
-    leaderElector = new LeaderElectorBuilder(client,
-        ConfigurationServiceProvider.instance().getExecutorService())
-        .withConfig(
-            new LeaderElectionConfig(lock, config.getLeaseDuration(), config.getRenewDeadline(),
-                config.getRetryPeriod(), leaderCallbacks(), true, config.getLeaseName()))
-        .build();
+    leaderElector =
+        new LeaderElectorBuilder(
+            client, ConfigurationServiceProvider.instance().getExecutorService())
+            .withConfig(
+                new LeaderElectionConfig(
+                    lock,
+                    config.getLeaseDuration(),
+                    config.getRenewDeadline(),
+                    config.getRetryPeriod(),
+                    leaderCallbacks(),
+                    true,
+                    config.getLeaseName()))
+            .build();
   }
 
   public boolean isLeaderElectionEnabled() {
@@ -46,9 +68,12 @@ public class LeaderElectionManager {
   }
 
   private LeaderCallbacks leaderCallbacks() {
-    return new LeaderCallbacks(this::startLeading, this::stopLeading, leader -> {
-      log.info("New leader with identity: {}", leader);
-    });
+    return new LeaderCallbacks(
+        this::startLeading,
+        this::stopLeading,
+        leader -> {
+          log.info("New leader with identity: {}", leader);
+        });
   }
 
   private void startLeading() {
@@ -64,11 +89,34 @@ public class LeaderElectionManager {
   }
 
   private String identity(LeaderElectionConfiguration config) {
-    String id = config.getIdentity().orElse(System.getenv("HOSTNAME"));
+    var id = config.getIdentity().orElse(System.getenv("HOSTNAME"));
     if (id == null || id.isBlank()) {
       id = UUID.randomUUID().toString();
     }
     return id;
+  }
+
+  private static Optional<String> tryGetInClusterNamespace() {
+    log.info("Trying to get namespace from Kubernetes service account namespace path...");
+
+    final var serviceAccountNamespace =
+        Utils.getSystemPropertyOrEnvVar(KUBERNETES_NAMESPACE_FILE, KUBERNETES_NAMESPACE_PATH);
+    final var serviceAccountNamespacePath = Path.of(serviceAccountNamespace);
+
+    final var serviceAccountNamespaceExists = Files.isRegularFile(serviceAccountNamespacePath);
+    if (serviceAccountNamespaceExists) {
+      log.info("Found service account namespace at: [{}].", serviceAccountNamespace);
+      try {
+        return Optional.of(Files.readString(serviceAccountNamespacePath));
+      } catch (IOException e) {
+        log.error(
+            "Error reading service account namespace from: [" + serviceAccountNamespace + "].", e);
+        return Optional.empty();
+      }
+    } else {
+      log.warn("Did not find service account namespace at: [{}].", serviceAccountNamespace);
+      return Optional.empty();
+    }
   }
 
   public void start() {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/LeaderElectionConfiguration.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/LeaderElectionConfiguration.java
@@ -35,6 +35,15 @@ public class LeaderElectionConfiguration {
         RETRY_PERIOD_DEFAULT_VALUE, null);
   }
 
+  public LeaderElectionConfiguration(String leaseName) {
+    this(
+        leaseName,
+        null,
+        LEASE_DURATION_DEFAULT_VALUE,
+        RENEW_DEADLINE_DEFAULT_VALUE,
+        RETRY_PERIOD_DEFAULT_VALUE, null);
+  }
+
   public LeaderElectionConfiguration(
       String leaseName,
       String leaseNamespace,
@@ -59,8 +68,8 @@ public class LeaderElectionConfiguration {
     this.identity = identity;
   }
 
-  public String getLeaseNamespace() {
-    return leaseNamespace;
+  public Optional<String> getLeaseNamespace() {
+    return Optional.ofNullable(leaseNamespace);
   }
 
   public String getLeaseName() {

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/LeaderElectionManagerTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/LeaderElectionManagerTest.java
@@ -1,0 +1,63 @@
+package io.javaoperatorsdk.operator;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.javaoperatorsdk.operator.api.config.LeaderElectionConfiguration;
+
+import static io.fabric8.kubernetes.client.Config.KUBERNETES_NAMESPACE_FILE;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+class LeaderElectionManagerTest {
+
+  private ControllerManager controllerManager;
+  private KubernetesClient kubernetesClient;
+  private LeaderElectionManager leaderElectionManager;
+
+  @BeforeEach
+  void setUp() {
+    controllerManager = mock(ControllerManager.class);
+    kubernetesClient = mock(KubernetesClient.class);
+    leaderElectionManager = new LeaderElectionManager(controllerManager);
+  }
+
+  @AfterEach
+  void tearDown() {
+    System.getProperties().remove(KUBERNETES_NAMESPACE_FILE);
+  }
+
+  @Test
+  void testInit() {
+    leaderElectionManager.init(new LeaderElectionConfiguration("test", "testns"), kubernetesClient);
+    assertTrue(leaderElectionManager.isLeaderElectionEnabled());
+  }
+
+  @Test
+  void testInitInferLeaseNamespace(@TempDir Path tempDir) throws IOException {
+    var namespace = "foo";
+    var namespacePath = tempDir.resolve("namespace");
+    Files.writeString(namespacePath, namespace);
+
+    System.setProperty(KUBERNETES_NAMESPACE_FILE, namespacePath.toString());
+
+    leaderElectionManager.init(new LeaderElectionConfiguration("test"), kubernetesClient);
+    assertTrue(leaderElectionManager.isLeaderElectionEnabled());
+  }
+
+  @Test
+  void testFailedToInitInferLeaseNamespace() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> leaderElectionManager.init(new LeaderElectionConfiguration("test"),
+            kubernetesClient));
+  }
+}

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/LeaderElectionManagerTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/LeaderElectionManagerTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.javaoperatorsdk.operator.api.config.ConfigurationServiceProvider;
 import io.javaoperatorsdk.operator.api.config.LeaderElectionConfiguration;
 
 import static io.fabric8.kubernetes.client.Config.KUBERNETES_AUTH_TRYKUBECONFIG_SYSTEM_PROPERTY;
@@ -33,6 +34,7 @@ class LeaderElectionManagerTest {
 
   @AfterEach
   void tearDown() {
+    ConfigurationServiceProvider.reset();
     System.getProperties().remove(KUBERNETES_NAMESPACE_FILE);
     System.getProperties().remove(KUBERNETES_AUTH_TRYKUBECONFIG_SYSTEM_PROPERTY);
   }

--- a/sample-operators/leader-election/k8s/namespace-inferred-operator-instance-2.yaml
+++ b/sample-operators/leader-election/k8s/namespace-inferred-operator-instance-2.yaml
@@ -8,3 +8,8 @@ spec:
     - name: operator
       image: leader-election-operator
       imagePullPolicy: Never
+      env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name

--- a/sample-operators/leader-election/k8s/namespace-inferred-operator-instance-2.yaml
+++ b/sample-operators/leader-election/k8s/namespace-inferred-operator-instance-2.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: leader-election-operator-2
+spec:
+  serviceAccountName: leader-election-operator
+  containers:
+    - name: operator
+      image: leader-election-operator
+      imagePullPolicy: Never

--- a/sample-operators/leader-election/k8s/namespace-inferred-operator.yaml
+++ b/sample-operators/leader-election/k8s/namespace-inferred-operator.yaml
@@ -58,4 +58,3 @@ rules:
       -  "leases"
     verbs:
       - '*'
-

--- a/sample-operators/leader-election/k8s/namespace-inferred-operator.yaml
+++ b/sample-operators/leader-election/k8s/namespace-inferred-operator.yaml
@@ -14,6 +14,11 @@ spec:
     - name: operator
       image: leader-election-operator
       imagePullPolicy: Never
+      env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/sample-operators/leader-election/k8s/namespace-inferred-operator.yaml
+++ b/sample-operators/leader-election/k8s/namespace-inferred-operator.yaml
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: leader-election-operator
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: leader-election-operator-1
+spec:
+  serviceAccountName: leader-election-operator
+  containers:
+    - name: operator
+      image: leader-election-operator
+      imagePullPolicy: Never
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: operator-admin
+subjects:
+  - kind: ServiceAccount
+    name: leader-election-operator
+roleRef:
+  kind: ClusterRole
+  name: leader-election-operator
+  apiGroup: ""
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: leader-election-operator
+rules:
+  - apiGroups:
+      - "apiextensions.k8s.io"
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - '*'
+  - apiGroups:
+      - "sample.javaoperatorsdk"
+    resources:
+      - leaderelectiontestcustomresources
+      - leaderelectiontestcustomresources/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      -  "leases"
+    verbs:
+      - '*'
+

--- a/sample-operators/leader-election/pom.xml
+++ b/sample-operators/leader-election/pom.xml
@@ -51,6 +51,10 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/sample-operators/leader-election/pom.xml
+++ b/sample-operators/leader-election/pom.xml
@@ -54,6 +54,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>

--- a/sample-operators/leader-election/src/main/java/io/javaoperatorsdk/operator/sample/LeaderElectionTestOperator.java
+++ b/sample-operators/leader-election/src/main/java/io/javaoperatorsdk/operator/sample/LeaderElectionTestOperator.java
@@ -17,14 +17,17 @@ public class LeaderElectionTestOperator {
 
     log.info("Starting operator with identity: {}", identity);
 
+    LeaderElectionConfiguration leaderElectionConfiguration =
+        namespace == null
+            ? new LeaderElectionConfiguration("leader-election-test")
+            : new LeaderElectionConfiguration("leader-election-test", namespace, identity);
+
     var client = new KubernetesClientBuilder().build();
-    Operator operator = new Operator(client,
-        c -> c.withLeaderElectionConfiguration(
-            new LeaderElectionConfiguration("leader-election-test", namespace, identity)));
+    Operator operator =
+        new Operator(client, c -> c.withLeaderElectionConfiguration(leaderElectionConfiguration));
 
     operator.register(new LeaderElectionTestReconciler(identity));
     operator.installShutdownHook();
     operator.start();
   }
-
 }


### PR DESCRIPTION
This PR makes providing lease namespace optional. If unspecified, it will try to read from a file pointed by system property or env var `kubenamespace` with default value as `/var/run/secrets/kubernetes.io/serviceaccount/namespace` which is injected by k8s. The code is inspired by https://github.com/fabric8io/kubernetes-client/blob/master/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java.

The idea is to simplify use code because in most cases users will need to do the same. Please let me know if this makes sense. Thanks.

@csviri @metacosm 