### PR TITLE
fix: remove problematic leader election unit test

### DIFF
--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/LeaderElectionManagerTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/LeaderElectionManagerTest.java
@@ -66,12 +66,4 @@ class LeaderElectionManagerTest {
         () -> leaderElectionManager.init(new LeaderElectionConfiguration("test"),
             kubernetesClient));
   }
-
-  @Test
-  void testFailedToInitInferLeaseNamespaceProbablyUsingKubeConfig() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> leaderElectionManager.init(new LeaderElectionConfiguration("test"),
-            kubernetesClient));
-  }
 }


### PR DESCRIPTION
this test would fail for anyone that has kube config inited locally that makes is quite problematic, would rather remove it