### PR TITLE
Add ability to provide a preconfigured KubernetesClient

### DIFF
--- a/operator-framework-junit5/src/main/java/io/javaoperatorsdk/operator/junit/AbstractOperatorExtension.java
+++ b/operator-framework-junit5/src/main/java/io/javaoperatorsdk/operator/junit/AbstractOperatorExtension.java
@@ -17,7 +17,6 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.utils.KubernetesResourceUtil;

--- a/operator-framework-junit5/src/main/java/io/javaoperatorsdk/operator/junit/AbstractOperatorExtension.java
+++ b/operator-framework-junit5/src/main/java/io/javaoperatorsdk/operator/junit/AbstractOperatorExtension.java
@@ -50,9 +50,9 @@ public abstract class AbstractOperatorExtension implements HasKubernetesClient,
       Duration infrastructureTimeout,
       boolean oneNamespacePerClass,
       boolean preserveNamespaceOnError,
-      boolean waitForNamespaceDeletion) {
-
-    this.kubernetesClient = new KubernetesClientBuilder().build();
+      boolean waitForNamespaceDeletion,
+      KubernetesClient kubernetesClient) {
+    this.kubernetesClient = kubernetesClient;
     this.configurationService = configurationService;
     this.infrastructure = infrastructure;
     this.infrastructureTimeout = infrastructureTimeout;

--- a/operator-framework-junit5/src/main/java/io/javaoperatorsdk/operator/junit/ClusterDeployedOperatorExtension.java
+++ b/operator-framework-junit5/src/main/java/io/javaoperatorsdk/operator/junit/ClusterDeployedOperatorExtension.java
@@ -12,14 +12,14 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
-import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.javaoperatorsdk.operator.api.config.ConfigurationService;
 
 public class ClusterDeployedOperatorExtension extends AbstractOperatorExtension {
@@ -31,15 +31,15 @@ public class ClusterDeployedOperatorExtension extends AbstractOperatorExtension 
   private final Duration operatorDeploymentTimeout;
 
   private ClusterDeployedOperatorExtension(
-          ConfigurationService configurationService,
-          List<HasMetadata> operatorDeployment,
-          Duration operatorDeploymentTimeout,
-          List<HasMetadata> infrastructure,
-          Duration infrastructureTimeout,
-          boolean preserveNamespaceOnError,
-          boolean waitForNamespaceDeletion,
-          boolean oneNamespacePerClass,
-          KubernetesClient kubernetesClient) {
+      ConfigurationService configurationService,
+      List<HasMetadata> operatorDeployment,
+      Duration operatorDeploymentTimeout,
+      List<HasMetadata> infrastructure,
+      Duration infrastructureTimeout,
+      boolean preserveNamespaceOnError,
+      boolean waitForNamespaceDeletion,
+      boolean oneNamespacePerClass,
+      KubernetesClient kubernetesClient) {
     super(configurationService, infrastructure, infrastructureTimeout, oneNamespacePerClass,
         preserveNamespaceOnError,
         waitForNamespaceDeletion,

--- a/operator-framework-junit5/src/main/java/io/javaoperatorsdk/operator/junit/ClusterDeployedOperatorExtension.java
+++ b/operator-framework-junit5/src/main/java/io/javaoperatorsdk/operator/junit/ClusterDeployedOperatorExtension.java
@@ -12,6 +12,8 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,17 +31,19 @@ public class ClusterDeployedOperatorExtension extends AbstractOperatorExtension 
   private final Duration operatorDeploymentTimeout;
 
   private ClusterDeployedOperatorExtension(
-      ConfigurationService configurationService,
-      List<HasMetadata> operatorDeployment,
-      Duration operatorDeploymentTimeout,
-      List<HasMetadata> infrastructure,
-      Duration infrastructureTimeout,
-      boolean preserveNamespaceOnError,
-      boolean waitForNamespaceDeletion,
-      boolean oneNamespacePerClass) {
+          ConfigurationService configurationService,
+          List<HasMetadata> operatorDeployment,
+          Duration operatorDeploymentTimeout,
+          List<HasMetadata> infrastructure,
+          Duration infrastructureTimeout,
+          boolean preserveNamespaceOnError,
+          boolean waitForNamespaceDeletion,
+          boolean oneNamespacePerClass,
+          KubernetesClient kubernetesClient) {
     super(configurationService, infrastructure, infrastructureTimeout, oneNamespacePerClass,
         preserveNamespaceOnError,
-        waitForNamespaceDeletion);
+        waitForNamespaceDeletion,
+        kubernetesClient);
     this.operatorDeployment = operatorDeployment;
     this.operatorDeploymentTimeout = operatorDeploymentTimeout;
   }
@@ -104,6 +108,7 @@ public class ClusterDeployedOperatorExtension extends AbstractOperatorExtension 
   public static class Builder extends AbstractBuilder<Builder> {
     private final List<HasMetadata> operatorDeployment;
     private Duration deploymentTimeout;
+    private KubernetesClient kubernetesClient;
 
     protected Builder() {
       super();
@@ -135,6 +140,11 @@ public class ClusterDeployedOperatorExtension extends AbstractOperatorExtension 
       return this;
     }
 
+    public Builder withKubernetesClient(KubernetesClient kubernetesClient) {
+      this.kubernetesClient = kubernetesClient;
+      return this;
+    }
+
     public ClusterDeployedOperatorExtension build() {
       return new ClusterDeployedOperatorExtension(
           configurationService,
@@ -144,7 +154,8 @@ public class ClusterDeployedOperatorExtension extends AbstractOperatorExtension 
           infrastructureTimeout,
           preserveNamespaceOnError,
           waitForNamespaceDeletion,
-          oneNamespacePerClass);
+          oneNamespacePerClass,
+          kubernetesClient != null ? kubernetesClient : new KubernetesClientBuilder().build());
     }
   }
 }

--- a/operator-framework-junit5/src/main/java/io/javaoperatorsdk/operator/junit/LocallyRunOperatorExtension.java
+++ b/operator-framework-junit5/src/main/java/io/javaoperatorsdk/operator/junit/LocallyRunOperatorExtension.java
@@ -10,14 +10,14 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.LocalPortForward;
 import io.javaoperatorsdk.operator.Operator;
 import io.javaoperatorsdk.operator.ReconcilerUtils;

--- a/operator-framework-junit5/src/main/java/io/javaoperatorsdk/operator/junit/LocallyRunOperatorExtension.java
+++ b/operator-framework-junit5/src/main/java/io/javaoperatorsdk/operator/junit/LocallyRunOperatorExtension.java
@@ -10,6 +10,8 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,14 +50,16 @@ public class LocallyRunOperatorExtension extends AbstractOperatorExtension {
       Duration infrastructureTimeout,
       boolean preserveNamespaceOnError,
       boolean waitForNamespaceDeletion,
-      boolean oneNamespacePerClass) {
+      boolean oneNamespacePerClass,
+      KubernetesClient kubernetesClient) {
     super(
         configurationService,
         infrastructure,
         infrastructureTimeout,
         oneNamespacePerClass,
         preserveNamespaceOnError,
-        waitForNamespaceDeletion);
+        waitForNamespaceDeletion,
+        kubernetesClient);
     this.reconcilers = reconcilers;
     this.portForwards = portForwards;
     this.localPortForwards = new ArrayList<>(portForwards.size());
@@ -194,6 +198,7 @@ public class LocallyRunOperatorExtension extends AbstractOperatorExtension {
     private final List<ReconcilerSpec> reconcilers;
     private final List<PortForwardSpec> portForwards;
     private final List<Class<? extends CustomResource>> additionalCustomResourceDefinitions;
+    private KubernetesClient kubernetesClient;
 
     protected Builder() {
       super();
@@ -243,6 +248,10 @@ public class LocallyRunOperatorExtension extends AbstractOperatorExtension {
       return this;
     }
 
+    public Builder withKubernetesClient(KubernetesClient kubernetesClient) {
+      this.kubernetesClient = kubernetesClient;
+      return this;
+    }
 
     public Builder withAdditionalCustomResourceDefinition(
         Class<? extends CustomResource> customResource) {
@@ -260,7 +269,8 @@ public class LocallyRunOperatorExtension extends AbstractOperatorExtension {
           infrastructureTimeout,
           preserveNamespaceOnError,
           waitForNamespaceDeletion,
-          oneNamespacePerClass);
+          oneNamespacePerClass,
+          kubernetesClient != null ? kubernetesClient : new KubernetesClientBuilder().build());
     }
   }
 


### PR DESCRIPTION
# Why ?
We are using the Testcontainers K3s-module (https://www.testcontainers.org/modules/k3s/) for integration tests while working on our operators.
These k8s-instances are created on the fly at test-runtime there is never a KUBECONFIG-env or something in ~/.kube/config which means that they can't be used with the default test-implementatio which uses `new KubernetesClientBuilder().build()`and relies on the existence of either of the two.

# What ?
I added the ability to inject your own instanc eof a KubernetesClient to the builders for LocallyRunOperatorExtension and ClusterDeployedOperatorExtension. 
In case none is provided it falls back to the old behaviour.

I hope this helps, feel free to leave comments for things I should change/add :)

Thanks a lot for your great work!