### PR TITLE
fix: remove unnecessary release step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,11 +45,3 @@ jobs:
     with:
       version_branch: ${{needs.prepare-release.outputs.version_branch}}
       project_dir: '.'
-
-  release-bom:
-    needs: [ prepare-release, release-sdk ] # needs prepare-release to be able to get the proper version branch name
-    uses: ./.github/workflows/release-project-in-dir.yml
-    secrets: inherit
-    with:
-      version_branch: ${{needs.prepare-release.outputs.version_branch}}
-      project_dir: './operator-framework-bom'


### PR DESCRIPTION
This fixes the release so it won't fail after a successful actual release of artifacts:
https://github.com/java-operator-sdk/java-operator-sdk/actions/runs/3282025485

we can properly refactor later.