### PR TITLE
feat: add configurable 'or' event filter to allow reconciling on non-…

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/AnnotationControllerConfiguration.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/AnnotationControllerConfiguration.java
@@ -202,6 +202,14 @@ public class AnnotationControllerConfiguration<P extends HasMetadata>
 
   @SuppressWarnings("unchecked")
   @Override
+  public Optional<OnUpdateFilter<P>> onUpdateIncludeFilter() {
+    return Optional.ofNullable(
+        Utils.instantiate(annotation.onUpdateIncludeFilter(), OnUpdateFilter.class,
+            Utils.contextFor(this, null, null)));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
   public Optional<GenericFilter<P>> genericFilter() {
     return Optional.ofNullable(
         Utils.instantiate(annotation.genericFilter(), GenericFilter.class,

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ControllerConfigurationOverrider.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ControllerConfigurationOverrider.java
@@ -36,6 +36,7 @@ public class ControllerConfigurationOverrider<R extends HasMetadata> {
   private final LinkedHashMap<String, DependentResourceSpec> namedDependentResourceSpecs;
   private OnAddFilter<R> onAddFilter;
   private OnUpdateFilter<R> onUpdateFilter;
+  private OnUpdateFilter<R> onUpdateIncludeFilter;
   private GenericFilter<R> genericFilter;
   private RateLimiter rateLimiter;
 
@@ -153,6 +154,12 @@ public class ControllerConfigurationOverrider<R extends HasMetadata> {
     return this;
   }
 
+  public ControllerConfigurationOverrider<R> withOnUpdateIncludeFilter(
+      OnUpdateFilter<R> onUpdateIncludeFilter) {
+    this.onUpdateIncludeFilter = onUpdateIncludeFilter;
+    return this;
+  }
+
   public ControllerConfigurationOverrider<R> withGenericFilter(GenericFilter<R> genericFilter) {
     this.genericFilter = genericFilter;
     return this;
@@ -206,6 +213,7 @@ public class ControllerConfigurationOverrider<R extends HasMetadata> {
         reconciliationMaxInterval,
         onAddFilter,
         onUpdateFilter,
+        onUpdateIncludeFilter,
         genericFilter,
         rateLimiter,
         newDependentSpecs);

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/DefaultControllerConfiguration.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/DefaultControllerConfiguration.java
@@ -47,10 +47,12 @@ public class DefaultControllerConfiguration<R extends HasMetadata>
       Duration reconciliationMaxInterval,
       OnAddFilter<R> onAddFilter,
       OnUpdateFilter<R> onUpdateFilter,
+      OnUpdateFilter<R> onUpdateIncludeFilter,
       GenericFilter<R> genericFilter,
       RateLimiter rateLimiter,
       List<DependentResourceSpec> dependents) {
-    super(labelSelector, resourceClass, onAddFilter, onUpdateFilter, genericFilter, namespaces);
+    super(labelSelector, resourceClass, onAddFilter, onUpdateFilter, onUpdateIncludeFilter,
+        genericFilter, namespaces);
     this.associatedControllerClassName = associatedControllerClassName;
     this.name = name;
     this.crdName = crdName;

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/DefaultResourceConfiguration.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/DefaultResourceConfiguration.java
@@ -18,23 +18,32 @@ public class DefaultResourceConfiguration<R extends HasMetadata>
   private final Class<R> resourceClass;
   private final OnAddFilter<R> onAddFilter;
   private final OnUpdateFilter<R> onUpdateFilter;
+  private final OnUpdateFilter<R> onUpdateIncludeFilter;
   private final GenericFilter<R> genericFilter;
 
   public DefaultResourceConfiguration(String labelSelector, Class<R> resourceClass,
       OnAddFilter<R> onAddFilter,
-      OnUpdateFilter<R> onUpdateFilter, GenericFilter<R> genericFilter, String... namespaces) {
-    this(labelSelector, resourceClass, onAddFilter, onUpdateFilter, genericFilter,
+      OnUpdateFilter<R> onUpdateFilter, GenericFilter<R> genericFilter,
+      OnUpdateFilter<R> onUpdateIncludeFilter, OnUpdateFilter<R> onUpdateIncludeFilter1,
+      String... namespaces) {
+    this(labelSelector, resourceClass, onAddFilter, onUpdateFilter, onUpdateIncludeFilter,
+        genericFilter,
         namespaces == null || namespaces.length == 0 ? DEFAULT_NAMESPACES_SET
             : Set.of(namespaces));
   }
 
-  public DefaultResourceConfiguration(String labelSelector, Class<R> resourceClass,
+  public DefaultResourceConfiguration(String labelSelector,
+      Class<R> resourceClass,
       OnAddFilter<R> onAddFilter,
-      OnUpdateFilter<R> onUpdateFilter, GenericFilter<R> genericFilter, Set<String> namespaces) {
+      OnUpdateFilter<R> onUpdateFilter,
+      OnUpdateFilter<R> onUpdateIncludeFilter,
+      GenericFilter<R> genericFilter,
+      Set<String> namespaces) {
     this.labelSelector = labelSelector;
     this.resourceClass = resourceClass;
     this.onAddFilter = onAddFilter;
     this.onUpdateFilter = onUpdateFilter;
+    this.onUpdateIncludeFilter = onUpdateIncludeFilter;
     this.genericFilter = genericFilter;
     this.namespaces =
         namespaces == null || namespaces.isEmpty() ? DEFAULT_NAMESPACES_SET
@@ -69,6 +78,11 @@ public class DefaultResourceConfiguration<R extends HasMetadata>
   @Override
   public Optional<OnUpdateFilter<R>> onUpdateFilter() {
     return Optional.ofNullable(onUpdateFilter);
+  }
+
+  @Override
+  public Optional<OnUpdateFilter<R>> onUpdateIncludeFilter() {
+    return Optional.ofNullable(onUpdateIncludeFilter);
   }
 
   public Optional<GenericFilter<R>> genericFilter() {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ResourceConfiguration.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ResourceConfiguration.java
@@ -29,6 +29,10 @@ public interface ResourceConfiguration<R extends HasMetadata> {
     return Optional.empty();
   }
 
+  default Optional<OnUpdateFilter<R>> onUpdateIncludeFilter() {
+    return Optional.empty();
+  }
+
   default Optional<GenericFilter<R>> genericFilter() {
     return Optional.empty();
   }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/informer/InformerConfiguration.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/informer/InformerConfiguration.java
@@ -37,9 +37,11 @@ public interface InformerConfiguration<R extends HasMetadata>
         Set<String> namespaces, boolean followControllerNamespaceChanges,
         OnAddFilter<R> onAddFilter,
         OnUpdateFilter<R> onUpdateFilter,
+        OnUpdateFilter<R> onUpdateIncludeFilter,
         OnDeleteFilter<R> onDeleteFilter,
         GenericFilter<R> genericFilter) {
-      super(labelSelector, resourceClass, onAddFilter, onUpdateFilter, genericFilter, namespaces);
+      super(labelSelector, resourceClass, onAddFilter, onUpdateFilter, onUpdateIncludeFilter,
+          genericFilter, namespaces);
       this.followControllerNamespaceChanges = followControllerNamespaceChanges;
 
       this.primaryToSecondaryMapper = primaryToSecondaryMapper;
@@ -99,6 +101,7 @@ public interface InformerConfiguration<R extends HasMetadata>
     private final Class<R> resourceClass;
     private OnAddFilter<R> onAddFilter;
     private OnUpdateFilter<R> onUpdateFilter;
+    private OnUpdateFilter<R> onUpdateIncludeFilter;
     private OnDeleteFilter<R> onDeleteFilter;
     private GenericFilter<R> genericFilter;
     private boolean inheritControllerNamespacesOnChange = false;
@@ -191,6 +194,12 @@ public interface InformerConfiguration<R extends HasMetadata>
       return this;
     }
 
+    public InformerConfigurationBuilder<R> withOnUpdateIncludeFilter(
+        OnUpdateFilter<R> onUpdateIncludeFilter) {
+      this.onUpdateIncludeFilter = onUpdateIncludeFilter;
+      return this;
+    }
+
     public InformerConfigurationBuilder<R> withOnDeleteFilter(
         OnDeleteFilter<R> onDeleteFilter) {
       this.onDeleteFilter = onDeleteFilter;
@@ -207,6 +216,7 @@ public interface InformerConfiguration<R extends HasMetadata>
           primaryToSecondaryMapper,
           secondaryToPrimaryMapper,
           namespaces, inheritControllerNamespacesOnChange, onAddFilter, onUpdateFilter,
+          onUpdateIncludeFilter,
           onDeleteFilter, genericFilter);
     }
   }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/ControllerConfiguration.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/ControllerConfiguration.java
@@ -80,6 +80,10 @@ public @interface ControllerConfiguration {
   /** Filter of onUpdate events of resources. */
   Class<? extends OnUpdateFilter> onUpdateFilter() default OnUpdateFilter.class;
 
+
+  /** Or filter of onUpdate events of resources. Used to include non-generation change events */
+  Class<? extends OnUpdateFilter> onUpdateIncludeFilter() default OnUpdateFilter.class;
+
   /**
    * Filter applied to all operations (add, update, delete). Used to ignore some resources.
    **/

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/ControllerManagerTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/ControllerManagerTest.java
@@ -58,7 +58,7 @@ public class ControllerManagerTest {
     public TestControllerConfiguration(Reconciler<R> controller, Class<R> crClass) {
       super(null, getControllerName(controller),
           CustomResource.getCRDName(crClass), null, false, null, null, null, null, crClass,
-          null, null, null, null, null, null);
+          null, null, null, null, null, null, null);
       this.controller = controller;
     }
 

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/ResourceEventFilterTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/ResourceEventFilterTest.java
@@ -145,7 +145,7 @@ class ResourceEventFilterTest {
           eventFilter,
           customResourceClass,
           null,
-          null, null, null, null, null);
+          null, null, null, null, null, null);
     }
   }
 


### PR DESCRIPTION
…generation change update events.

I am not sure I really like the name of the configuration but naming things is hard.

This adds the ability to optionally configure an or filter that can include events filtered by the default filters. My use case is to run a reconciler when there are specific metadata changes (labels and annotations) that don't impact the spec and thus are still for the same generation.