### PR TITLE
feat: runtime info for health probes

### DIFF
--- a/docs/documentation/features.md
+++ b/docs/documentation/features.md
@@ -705,7 +705,7 @@ See sample configuration in the [E2E test](https://github.com/java-operator-sdk/
 is accessed. You can access mainly health information of event sources. Based on that liveness probes can be registered
 and a custom logic implemented, when the operator is considered live. Note that this can be used with combination of
 [stopOnInformerErrorDuringStartup](https://github.com/java-operator-sdk/java-operator-sdk/blob/main/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationService.java#L168-L168)
-setting.
+setting, where this flag usually needs to be set to false, in order to control the exact liveness properties.
 
 See also an example implementation in the 
 [WebPage sample](https://github.com/java-operator-sdk/java-operator-sdk/blob/3e2e7c4c834ef1c409d636156b988125744ca911/sample-operators/webpage/src/main/java/io/javaoperatorsdk/operator/sample/WebPageOperator.java#L38-L43)

--- a/docs/documentation/features.md
+++ b/docs/documentation/features.md
@@ -699,6 +699,17 @@ leader left off should one of them become elected leader.
 See sample configuration in the [E2E test](https://github.com/java-operator-sdk/java-operator-sdk/blob/8865302ac0346ee31f2d7b348997ec2913d5922b/sample-operators/leader-election/src/main/java/io/javaoperatorsdk/operator/sample/LeaderElectionTestOperator.java#L21-L23)
 .
 
+## Runtime Info
+
+[RuntimeInfo](https://github.com/java-operator-sdk/java-operator-sdk/blob/main/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/RuntimeInfo.java#L16-L16) 
+is accessed. You can access mainly health information of event sources. Based on that liveness probes can be registered
+and a custom logic implemented, when the operator is considered live. Note that this can be used with combination of
+[stopOnInformerErrorDuringStartup](https://github.com/java-operator-sdk/java-operator-sdk/blob/main/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationService.java#L168-L168)
+setting.
+
+See also an example implementation in the 
+[WebPage sample](https://github.com/java-operator-sdk/java-operator-sdk/blob/3e2e7c4c834ef1c409d636156b988125744ca911/sample-operators/webpage/src/main/java/io/javaoperatorsdk/operator/sample/WebPageOperator.java#L38-L43)
+
 ## Monitoring with Micrometer
 
 ## Automatic Generation of CRDs

--- a/docs/documentation/features.md
+++ b/docs/documentation/features.md
@@ -702,8 +702,9 @@ See sample configuration in the [E2E test](https://github.com/java-operator-sdk/
 ## Runtime Info
 
 [RuntimeInfo](https://github.com/java-operator-sdk/java-operator-sdk/blob/main/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/RuntimeInfo.java#L16-L16) 
-is accessed. You can access mainly health information of event sources. Based on that liveness probes can be registered
-and a custom logic implemented, when the operator is considered live. Note that this can be used with combination of
+is used mainly to check the actual health of event sources. Based on this information it is easy to implement custom 
+liveness probes.
+
 [stopOnInformerErrorDuringStartup](https://github.com/java-operator-sdk/java-operator-sdk/blob/main/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationService.java#L168-L168)
 setting, where this flag usually needs to be set to false, in order to control the exact liveness properties.
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Operator.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Operator.java
@@ -80,12 +80,11 @@ public class Operator implements LifecycleAware {
    * where there is no obvious entrypoint to the application which can trigger the injection process
    * and start the cluster monitoring processes.
    */
-  public void start() {
+  public synchronized void start() {
     try {
       if (started) {
         return;
       }
-      started = true;
       controllerManager.shouldStart();
       final var version = ConfigurationServiceProvider.instance().getVersion();
       log.info(
@@ -101,6 +100,7 @@ public class Operator implements LifecycleAware {
       // the leader election would start subsequently the processor if on
       controllerManager.start(!leaderElectionManager.isLeaderElectionEnabled());
       leaderElectionManager.start();
+      started = true;
     } catch (Exception e) {
       log.error("Error starting operator", e);
       stop();

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Operator.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Operator.java
@@ -1,5 +1,6 @@
 package io.javaoperatorsdk.operator;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -207,4 +208,11 @@ public class Operator implements LifecycleAware {
     return controllerManager.size();
   }
 
+   public RuntimeInfo getRuntimeInfo() {
+      return new RuntimeInfo(new ArrayList<>(controllerManager.controllers()));
+   }
+
+  public boolean isStarted() {
+    return started;
+  }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Operator.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Operator.java
@@ -1,6 +1,5 @@
 package io.javaoperatorsdk.operator;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -209,10 +208,10 @@ public class Operator implements LifecycleAware {
   }
 
   public RuntimeInfo getRuntimeInfo() {
-    return new RuntimeInfo(new ArrayList<>(controllerManager.controllers()));
+    return new RuntimeInfo(this);
   }
 
-  public boolean isStarted() {
+  boolean isStarted() {
     return started;
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Operator.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Operator.java
@@ -208,9 +208,9 @@ public class Operator implements LifecycleAware {
     return controllerManager.size();
   }
 
-   public RuntimeInfo getRuntimeInfo() {
-      return new RuntimeInfo(new ArrayList<>(controllerManager.controllers()));
-   }
+  public RuntimeInfo getRuntimeInfo() {
+    return new RuntimeInfo(new ArrayList<>(controllerManager.controllers()));
+  }
 
   public boolean isStarted() {
     return started;

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/RegisteredController.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/RegisteredController.java
@@ -3,7 +3,12 @@ package io.javaoperatorsdk.operator;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
 import io.javaoperatorsdk.operator.api.config.NamespaceChangeable;
+import io.javaoperatorsdk.operator.health.ControllerHealthInfo;
 
 public interface RegisteredController<P extends HasMetadata> extends NamespaceChangeable {
+
   ControllerConfiguration<P> getConfiguration();
+
+  ControllerHealthInfo getControllerHealthInfo();
+
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/RuntimeInfo.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/RuntimeInfo.java
@@ -1,47 +1,46 @@
 package io.javaoperatorsdk.operator;
 
-import io.javaoperatorsdk.operator.RegisteredController;
-import io.javaoperatorsdk.operator.health.EventSourceHealthIndicator;
-import io.javaoperatorsdk.operator.health.InformerEventSourceHealthIndicator;
-import io.javaoperatorsdk.operator.processing.event.source.EventSource;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import io.javaoperatorsdk.operator.health.EventSourceHealthIndicator;
+import io.javaoperatorsdk.operator.health.InformerEventSourceHealthIndicator;
+
 @SuppressWarnings("rawtypes")
 public class RuntimeInfo {
 
-    private final List<RegisteredController> registeredControllers;
+  private final List<RegisteredController> registeredControllers;
 
-    public RuntimeInfo(List<RegisteredController> registeredControllers) {
-        this.registeredControllers = registeredControllers;
-    }
+  public RuntimeInfo(List<RegisteredController> registeredControllers) {
+    this.registeredControllers = registeredControllers;
+  }
 
-    public List<RegisteredController> getRegisteredControllers() {
-        return registeredControllers;
-    }
+  public List<RegisteredController> getRegisteredControllers() {
+    return registeredControllers;
+  }
 
-    public boolean allEventSourcesAreHealthy() {
-        return registeredControllers.stream()
-                .filter(rc->!rc.getControllerHealthInfo().unhealthyEventSources().isEmpty())
-                .findFirst().isEmpty();
-    }
+  public boolean allEventSourcesAreHealthy() {
+    return registeredControllers.stream()
+        .filter(rc -> !rc.getControllerHealthInfo().unhealthyEventSources().isEmpty())
+        .findFirst().isEmpty();
+  }
 
-    public Map<String,Map<String, EventSourceHealthIndicator>> unhealthyEventSources() {
-        Map<String,Map<String,EventSourceHealthIndicator>> res = new HashMap<>();
-        for (var rc : registeredControllers) {
-            res.put(rc.getConfiguration().getName(),rc.getControllerHealthInfo().unhealthyEventSources());
-        }
-        return res;
+  public Map<String, Map<String, EventSourceHealthIndicator>> unhealthyEventSources() {
+    Map<String, Map<String, EventSourceHealthIndicator>> res = new HashMap<>();
+    for (var rc : registeredControllers) {
+      res.put(rc.getConfiguration().getName(),
+          rc.getControllerHealthInfo().unhealthyEventSources());
     }
+    return res;
+  }
 
-    public Map<String,Map<String, InformerEventSourceHealthIndicator>> unhealthyInformerEventSources() {
-        Map<String,Map<String,InformerEventSourceHealthIndicator>> res = new HashMap<>();
-        for (var rc : registeredControllers) {
-            res.put(rc.getConfiguration().getName(),rc.getControllerHealthInfo()
-                    .unhealthyInformerEventSourceHealthIndicators());
-        }
-        return res;
+  public Map<String, Map<String, InformerEventSourceHealthIndicator>> unhealthyInformerEventSources() {
+    Map<String, Map<String, InformerEventSourceHealthIndicator>> res = new HashMap<>();
+    for (var rc : registeredControllers) {
+      res.put(rc.getConfiguration().getName(), rc.getControllerHealthInfo()
+          .unhealthyInformerEventSourceHealthIndicators());
     }
+    return res;
+  }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/RuntimeInfo.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/RuntimeInfo.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Map;
 
 import io.javaoperatorsdk.operator.health.EventSourceHealthIndicator;
-import io.javaoperatorsdk.operator.health.InformerEventSourceHealthIndicator;
+import io.javaoperatorsdk.operator.health.InformerWrappingEventSourceHealthIndicator;
 
 @SuppressWarnings("rawtypes")
 public class RuntimeInfo {
@@ -35,8 +35,8 @@ public class RuntimeInfo {
     return res;
   }
 
-  public Map<String, Map<String, InformerEventSourceHealthIndicator>> unhealthyInformerEventSources() {
-    Map<String, Map<String, InformerEventSourceHealthIndicator>> res = new HashMap<>();
+  public Map<String, Map<String, InformerWrappingEventSourceHealthIndicator>> unhealthyInformerWrappingEventSourceHealthIndicator() {
+    Map<String, Map<String, InformerWrappingEventSourceHealthIndicator>> res = new HashMap<>();
     for (var rc : registeredControllers) {
       res.put(rc.getConfiguration().getName(), rc.getControllerHealthInfo()
           .unhealthyInformerEventSourceHealthIndicators());

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/RuntimeInfo.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/RuntimeInfo.java
@@ -1,0 +1,47 @@
+package io.javaoperatorsdk.operator;
+
+import io.javaoperatorsdk.operator.RegisteredController;
+import io.javaoperatorsdk.operator.health.EventSourceHealthIndicator;
+import io.javaoperatorsdk.operator.health.InformerEventSourceHealthIndicator;
+import io.javaoperatorsdk.operator.processing.event.source.EventSource;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@SuppressWarnings("rawtypes")
+public class RuntimeInfo {
+
+    private final List<RegisteredController> registeredControllers;
+
+    public RuntimeInfo(List<RegisteredController> registeredControllers) {
+        this.registeredControllers = registeredControllers;
+    }
+
+    public List<RegisteredController> getRegisteredControllers() {
+        return registeredControllers;
+    }
+
+    public boolean allEventSourcesAreHealthy() {
+        return registeredControllers.stream()
+                .filter(rc->!rc.getControllerHealthInfo().unhealthyEventSources().isEmpty())
+                .findFirst().isEmpty();
+    }
+
+    public Map<String,Map<String, EventSourceHealthIndicator>> unhealthyEventSources() {
+        Map<String,Map<String,EventSourceHealthIndicator>> res = new HashMap<>();
+        for (var rc : registeredControllers) {
+            res.put(rc.getConfiguration().getName(),rc.getControllerHealthInfo().unhealthyEventSources());
+        }
+        return res;
+    }
+
+    public Map<String,Map<String, InformerEventSourceHealthIndicator>> unhealthyInformerEventSources() {
+        Map<String,Map<String,InformerEventSourceHealthIndicator>> res = new HashMap<>();
+        for (var rc : registeredControllers) {
+            res.put(rc.getConfiguration().getName(),rc.getControllerHealthInfo()
+                    .unhealthyInformerEventSourceHealthIndicators());
+        }
+        return res;
+    }
+}

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/health/ControllerHealthInfo.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/health/ControllerHealthInfo.java
@@ -25,20 +25,20 @@ public class ControllerHealthInfo {
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
-  public Map<String, InformerEventSourceHealthIndicator> informerEventSourceHealthIndicators() {
+  public Map<String, InformerWrappingEventSourceHealthIndicator> informerEventSourceHealthIndicators() {
     return eventSourceManager.allEventSources().entrySet().stream()
-        .filter(e -> e.getValue() instanceof InformerEventSourceHealthIndicator)
+        .filter(e -> e.getValue() instanceof InformerWrappingEventSourceHealthIndicator)
         .collect(Collectors.toMap(Map.Entry::getKey,
-            e -> (InformerEventSourceHealthIndicator) e.getValue()));
+            e -> (InformerWrappingEventSourceHealthIndicator) e.getValue()));
 
   }
 
-  public Map<String, InformerEventSourceHealthIndicator> unhealthyInformerEventSourceHealthIndicators() {
+  public Map<String, InformerWrappingEventSourceHealthIndicator> unhealthyInformerEventSourceHealthIndicators() {
     return eventSourceManager.allEventSources().entrySet().stream()
         .filter(e -> e.getValue().getStatus() == Status.UNHEALTHY)
-        .filter(e -> e.getValue() instanceof InformerEventSourceHealthIndicator)
+        .filter(e -> e.getValue() instanceof InformerWrappingEventSourceHealthIndicator)
         .collect(Collectors.toMap(Map.Entry::getKey,
-            e -> (InformerEventSourceHealthIndicator) e.getValue()));
+            e -> (InformerWrappingEventSourceHealthIndicator) e.getValue()));
   }
 
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/health/ControllerHealthInfo.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/health/ControllerHealthInfo.java
@@ -33,6 +33,12 @@ public class ControllerHealthInfo {
 
   }
 
+  /**
+   * @return Map with event sources that wraps an informer. Thus, either a
+   *         {@link io.javaoperatorsdk.operator.processing.event.source.controller.ControllerResourceEventSource}
+   *         or an
+   *         {@link io.javaoperatorsdk.operator.processing.event.source.informer.InformerEventSource}.
+   */
   public Map<String, InformerWrappingEventSourceHealthIndicator> unhealthyInformerEventSourceHealthIndicators() {
     return eventSourceManager.allEventSources().entrySet().stream()
         .filter(e -> e.getValue().getStatus() == Status.UNHEALTHY)

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/health/ControllerHealthInfo.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/health/ControllerHealthInfo.java
@@ -1,44 +1,44 @@
 package io.javaoperatorsdk.operator.health;
 
-import io.javaoperatorsdk.operator.processing.event.EventSourceManager;
-import io.javaoperatorsdk.operator.processing.event.source.EventSource;
-
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
+
+import io.javaoperatorsdk.operator.processing.event.EventSourceManager;
 
 @SuppressWarnings("rawtypes")
 public class ControllerHealthInfo {
 
-    private EventSourceManager<?> eventSourceManager;
+  private EventSourceManager<?> eventSourceManager;
 
-    public ControllerHealthInfo(EventSourceManager eventSourceManager) {
-        this.eventSourceManager = eventSourceManager;
-    }
+  public ControllerHealthInfo(EventSourceManager eventSourceManager) {
+    this.eventSourceManager = eventSourceManager;
+  }
 
-    public Map<String,EventSourceHealthIndicator> eventSourceHealthIndicators() {
-        return eventSourceManager.allEventSources().entrySet().stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-    }
+  public Map<String, EventSourceHealthIndicator> eventSourceHealthIndicators() {
+    return eventSourceManager.allEventSources().entrySet().stream()
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
 
-    public Map<String,EventSourceHealthIndicator> unhealthyEventSources() {
-        return eventSourceManager.allEventSources().entrySet().stream()
-                .filter(e->e.getValue().getStatus() == Status.UNHEALTHY)
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-    }
+  public Map<String, EventSourceHealthIndicator> unhealthyEventSources() {
+    return eventSourceManager.allEventSources().entrySet().stream()
+        .filter(e -> e.getValue().getStatus() == Status.UNHEALTHY)
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
 
-    public Map<String,InformerEventSourceHealthIndicator> informerEventSourceHealthIndicators() {
-        return eventSourceManager.allEventSources().entrySet().stream()
-                .filter(e-> e.getValue() instanceof InformerEventSourceHealthIndicator)
-                .collect(Collectors.toMap(Map.Entry::getKey, e->(InformerEventSourceHealthIndicator)e.getValue()));
+  public Map<String, InformerEventSourceHealthIndicator> informerEventSourceHealthIndicators() {
+    return eventSourceManager.allEventSources().entrySet().stream()
+        .filter(e -> e.getValue() instanceof InformerEventSourceHealthIndicator)
+        .collect(Collectors.toMap(Map.Entry::getKey,
+            e -> (InformerEventSourceHealthIndicator) e.getValue()));
 
-    }
-    public Map<String,InformerEventSourceHealthIndicator> unhealthyInformerEventSourceHealthIndicators() {
-        return eventSourceManager.allEventSources().entrySet().stream()
-                .filter(e-> e.getValue().getStatus() == Status.UNHEALTHY)
-                .filter(e-> e.getValue() instanceof InformerEventSourceHealthIndicator)
-                .collect(Collectors.toMap(Map.Entry::getKey, e->(InformerEventSourceHealthIndicator)e.getValue()));
-    }
+  }
+
+  public Map<String, InformerEventSourceHealthIndicator> unhealthyInformerEventSourceHealthIndicators() {
+    return eventSourceManager.allEventSources().entrySet().stream()
+        .filter(e -> e.getValue().getStatus() == Status.UNHEALTHY)
+        .filter(e -> e.getValue() instanceof InformerEventSourceHealthIndicator)
+        .collect(Collectors.toMap(Map.Entry::getKey,
+            e -> (InformerEventSourceHealthIndicator) e.getValue()));
+  }
 
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/health/ControllerHealthInfo.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/health/ControllerHealthInfo.java
@@ -1,0 +1,44 @@
+package io.javaoperatorsdk.operator.health;
+
+import io.javaoperatorsdk.operator.processing.event.EventSourceManager;
+import io.javaoperatorsdk.operator.processing.event.source.EventSource;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@SuppressWarnings("rawtypes")
+public class ControllerHealthInfo {
+
+    private EventSourceManager<?> eventSourceManager;
+
+    public ControllerHealthInfo(EventSourceManager eventSourceManager) {
+        this.eventSourceManager = eventSourceManager;
+    }
+
+    public Map<String,EventSourceHealthIndicator> eventSourceHealthIndicators() {
+        return eventSourceManager.allEventSources().entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    public Map<String,EventSourceHealthIndicator> unhealthyEventSources() {
+        return eventSourceManager.allEventSources().entrySet().stream()
+                .filter(e->e.getValue().getStatus() == Status.UNHEALTHY)
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    public Map<String,InformerEventSourceHealthIndicator> informerEventSourceHealthIndicators() {
+        return eventSourceManager.allEventSources().entrySet().stream()
+                .filter(e-> e.getValue() instanceof InformerEventSourceHealthIndicator)
+                .collect(Collectors.toMap(Map.Entry::getKey, e->(InformerEventSourceHealthIndicator)e.getValue()));
+
+    }
+    public Map<String,InformerEventSourceHealthIndicator> unhealthyInformerEventSourceHealthIndicators() {
+        return eventSourceManager.allEventSources().entrySet().stream()
+                .filter(e-> e.getValue().getStatus() == Status.UNHEALTHY)
+                .filter(e-> e.getValue() instanceof InformerEventSourceHealthIndicator)
+                .collect(Collectors.toMap(Map.Entry::getKey, e->(InformerEventSourceHealthIndicator)e.getValue()));
+    }
+
+}

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/health/EventSourceHealthIndicator.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/health/EventSourceHealthIndicator.java
@@ -1,0 +1,6 @@
+package io.javaoperatorsdk.operator.health;
+
+public interface EventSourceHealthIndicator {
+
+    Status getStatus();
+}

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/health/EventSourceHealthIndicator.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/health/EventSourceHealthIndicator.java
@@ -2,5 +2,5 @@ package io.javaoperatorsdk.operator.health;
 
 public interface EventSourceHealthIndicator {
 
-    Status getStatus();
+  Status getStatus();
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/health/InformerEventSourceHealthIndicator.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/health/InformerEventSourceHealthIndicator.java
@@ -4,12 +4,12 @@ import java.util.Map;
 
 public interface InformerEventSourceHealthIndicator extends EventSourceHealthIndicator {
 
-    Map<String,InformerHealthIndicator> informerHealthIndicators();
+  Map<String, InformerHealthIndicator> informerHealthIndicators();
 
-    @Override
-    default Status getStatus() {
-        var nonUp = informerHealthIndicators().values().stream()
-                .filter(i->i.getStatus() != Status.HEALTHY).findAny();
-        return nonUp.isPresent() ? Status.UNHEALTHY : Status.HEALTHY;
-    }
+  @Override
+  default Status getStatus() {
+    var nonUp = informerHealthIndicators().values().stream()
+        .filter(i -> i.getStatus() != Status.HEALTHY).findAny();
+    return nonUp.isPresent() ? Status.UNHEALTHY : Status.HEALTHY;
+  }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/health/InformerEventSourceHealthIndicator.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/health/InformerEventSourceHealthIndicator.java
@@ -1,0 +1,15 @@
+package io.javaoperatorsdk.operator.health;
+
+import java.util.Map;
+
+public interface InformerEventSourceHealthIndicator extends EventSourceHealthIndicator {
+
+    Map<String,InformerHealthIndicator> informerHealthIndicators();
+
+    @Override
+    default Status getStatus() {
+        var nonUp = informerHealthIndicators().values().stream()
+                .filter(i->i.getStatus() != Status.HEALTHY).findAny();
+        return nonUp.isPresent() ? Status.UNHEALTHY : Status.HEALTHY;
+    }
+}

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/health/InformerHealthIndicator.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/health/InformerHealthIndicator.java
@@ -2,14 +2,14 @@ package io.javaoperatorsdk.operator.health;
 
 public interface InformerHealthIndicator extends EventSourceHealthIndicator {
 
-    boolean hasSynced();
+  boolean hasSynced();
 
-    boolean isWatching();
+  boolean isWatching();
 
-    boolean isRunning();
+  boolean isRunning();
 
-    @Override
-    default Status getStatus() {
-        return isRunning() && hasSynced() && isWatching() ? Status.HEALTHY : Status.UNHEALTHY;
-    }
+  @Override
+  default Status getStatus() {
+    return isRunning() && hasSynced() && isWatching() ? Status.HEALTHY : Status.UNHEALTHY;
+  }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/health/InformerHealthIndicator.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/health/InformerHealthIndicator.java
@@ -1,0 +1,15 @@
+package io.javaoperatorsdk.operator.health;
+
+public interface InformerHealthIndicator extends EventSourceHealthIndicator {
+
+    boolean hasSynced();
+
+    boolean isWatching();
+
+    boolean isRunning();
+
+    @Override
+    default Status getStatus() {
+        return isRunning() && hasSynced() && isWatching() ? Status.HEALTHY : Status.UNHEALTHY;
+    }
+}

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/health/InformerHealthIndicator.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/health/InformerHealthIndicator.java
@@ -12,4 +12,6 @@ public interface InformerHealthIndicator extends EventSourceHealthIndicator {
   default Status getStatus() {
     return isRunning() && hasSynced() && isWatching() ? Status.HEALTHY : Status.UNHEALTHY;
   }
+
+  String getTargetNamespace();
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/health/InformerWrappingEventSourceHealthIndicator.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/health/InformerWrappingEventSourceHealthIndicator.java
@@ -2,7 +2,11 @@ package io.javaoperatorsdk.operator.health;
 
 import java.util.Map;
 
-public interface InformerEventSourceHealthIndicator extends EventSourceHealthIndicator {
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.javaoperatorsdk.operator.api.config.ResourceConfiguration;
+
+public interface InformerWrappingEventSourceHealthIndicator<R extends HasMetadata>
+    extends EventSourceHealthIndicator {
 
   Map<String, InformerHealthIndicator> informerHealthIndicators();
 
@@ -10,6 +14,9 @@ public interface InformerEventSourceHealthIndicator extends EventSourceHealthInd
   default Status getStatus() {
     var nonUp = informerHealthIndicators().values().stream()
         .filter(i -> i.getStatus() != Status.HEALTHY).findAny();
+
     return nonUp.isPresent() ? Status.UNHEALTHY : Status.HEALTHY;
   }
+
+  ResourceConfiguration<R> getInformerConfiguration();
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/health/Status.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/health/Status.java
@@ -1,0 +1,12 @@
+package io.javaoperatorsdk.operator.health;
+
+public enum Status {
+
+    HEALTHY,
+    UNHEALTHY,
+    /**
+     * For event sources where it cannot be determined if it is healthy ot not.
+     */
+    UNKNOWN
+
+}

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/health/Status.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/health/Status.java
@@ -2,11 +2,10 @@ package io.javaoperatorsdk.operator.health;
 
 public enum Status {
 
-    HEALTHY,
-    UNHEALTHY,
-    /**
-     * For event sources where it cannot be determined if it is healthy ot not.
-     */
-    UNKNOWN
+  HEALTHY, UNHEALTHY,
+  /**
+   * For event sources where it cannot be determined if it is healthy ot not.
+   */
+  UNKNOWN
 
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/Controller.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/Controller.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import io.javaoperatorsdk.operator.health.ControllerHealthInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,6 +39,7 @@ import io.javaoperatorsdk.operator.api.reconciler.dependent.EventSourceNotFoundE
 import io.javaoperatorsdk.operator.api.reconciler.dependent.EventSourceProvider;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.EventSourceReferencer;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.managed.DefaultManagedDependentResourceContext;
+import io.javaoperatorsdk.operator.health.ControllerHealthInfo;
 import io.javaoperatorsdk.operator.processing.dependent.workflow.ManagedWorkflow;
 import io.javaoperatorsdk.operator.processing.dependent.workflow.WorkflowCleanupResult;
 import io.javaoperatorsdk.operator.processing.event.EventProcessor;

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/Controller.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/Controller.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import io.javaoperatorsdk.operator.health.ControllerHealthInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,6 +68,7 @@ public class Controller<P extends HasMetadata>
 
   private final GroupVersionKind associatedGVK;
   private final EventProcessor<P> eventProcessor;
+  private final ControllerHealthInfo controllerHealthInfo;
 
   public Controller(Reconciler<P> reconciler,
       ControllerConfiguration<P> configuration,
@@ -86,6 +88,7 @@ public class Controller<P extends HasMetadata>
     eventSourceManager = new EventSourceManager<>(this);
     eventProcessor = new EventProcessor<>(eventSourceManager);
     eventSourceManager.postProcessDefaultEventSourcesAfterProcessorInitializer();
+    controllerHealthInfo = new ControllerHealthInfo(eventSourceManager);
   }
 
   @Override
@@ -283,6 +286,11 @@ public class Controller<P extends HasMetadata>
 
   public ControllerConfiguration<P> getConfiguration() {
     return configuration;
+  }
+
+  @Override
+  public ControllerHealthInfo getControllerHealthInfo() {
+    return controllerHealthInfo;
   }
 
   public KubernetesClient getClient() {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventSourceManager.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventSourceManager.java
@@ -2,7 +2,6 @@ package io.javaoperatorsdk.operator.processing.event;
 
 import java.util.*;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -172,9 +171,9 @@ public class EventSourceManager<P extends HasMetadata>
         .collect(Collectors.toCollection(LinkedHashSet::new));
   }
 
-  public Map<String,EventSource> allEventSources() {
+  public Map<String, EventSource> allEventSources() {
     return eventSources.allNamedEventSources().collect(Collectors.toMap(NamedEventSource::name,
-            NamedEventSource::original));
+        NamedEventSource::original));
   }
 
   public ControllerResourceEventSource<P> getControllerResourceEventSource() {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventSourceManager.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventSourceManager.java
@@ -1,10 +1,8 @@
 package io.javaoperatorsdk.operator.processing.event;
 
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -172,6 +170,11 @@ public class EventSourceManager<P extends HasMetadata>
     return eventSources.flatMappedSources()
         .map(NamedEventSource::original)
         .collect(Collectors.toCollection(LinkedHashSet::new));
+  }
+
+  public Map<String,EventSource> allEventSources() {
+    return eventSources.allNamedEventSources().collect(Collectors.toMap(NamedEventSource::name,
+            NamedEventSource::original));
   }
 
   public ControllerResourceEventSource<P> getControllerResourceEventSource() {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventSources.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventSources.java
@@ -48,9 +48,9 @@ class EventSources<R extends HasMetadata> {
 
   public Stream<NamedEventSource> allNamedEventSources() {
     return Stream.concat(Stream.of(namedControllerResourceEventSource(),
-                    new NamedEventSource(retryAndRescheduleTimerEventSource,
-                            RETRY_RESCHEDULE_TIMER_EVENT_SOURCE_NAME)),
-            flatMappedSources());
+        new NamedEventSource(retryAndRescheduleTimerEventSource,
+            RETRY_RESCHEDULE_TIMER_EVENT_SOURCE_NAME)),
+        flatMappedSources());
   }
 
   Stream<EventSource> additionalEventSources() {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventSources.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventSources.java
@@ -46,6 +46,13 @@ class EventSources<R extends HasMetadata> {
         flatMappedSources());
   }
 
+  public Stream<NamedEventSource> allNamedEventSources() {
+    return Stream.concat(Stream.of(namedControllerResourceEventSource(),
+                    new NamedEventSource(retryAndRescheduleTimerEventSource,
+                            RETRY_RESCHEDULE_TIMER_EVENT_SOURCE_NAME)),
+            flatMappedSources());
+  }
+
   Stream<EventSource> additionalEventSources() {
     return Stream.concat(
         Stream.of(retryEventSource()).filter(Objects::nonNull),

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/EventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/EventSource.java
@@ -1,5 +1,7 @@
 package io.javaoperatorsdk.operator.processing.event.source;
 
+import io.javaoperatorsdk.operator.health.EventSourceHealthIndicator;
+import io.javaoperatorsdk.operator.health.Status;
 import io.javaoperatorsdk.operator.processing.LifecycleAware;
 import io.javaoperatorsdk.operator.processing.event.EventHandler;
 
@@ -10,7 +12,7 @@ import io.javaoperatorsdk.operator.processing.event.EventHandler;
  * your reconciler implement
  * {@link io.javaoperatorsdk.operator.api.reconciler.EventSourceInitializer}.
  */
-public interface EventSource extends LifecycleAware {
+public interface EventSource extends LifecycleAware, EventSourceHealthIndicator {
 
   /**
    * Sets the {@link EventHandler} that is linked to your reconciler when this EventSource is
@@ -22,5 +24,10 @@ public interface EventSource extends LifecycleAware {
 
   default EventSourceStartPriority priority() {
     return EventSourceStartPriority.DEFAULT;
+  }
+
+  @Override
+  default Status getStatus() {
+    return Status.UNKNOWN;
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSource.java
@@ -1,13 +1,9 @@
 package io.javaoperatorsdk.operator.processing.event.source.informer;
 
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import io.javaoperatorsdk.operator.health.InformerEventSourceHealthIndicator;
-import io.javaoperatorsdk.operator.health.InformerHealthIndicator;
-import io.javaoperatorsdk.operator.health.Status;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -70,8 +66,7 @@ import io.javaoperatorsdk.operator.processing.event.source.PrimaryToSecondaryMap
  */
 public class InformerEventSource<R extends HasMetadata, P extends HasMetadata>
     extends ManagedInformerEventSource<R, P, InformerConfiguration<R>>
-    implements ResourceEventHandler<R>, RecentOperationEventFilter<R>
-{
+    implements ResourceEventHandler<R>, RecentOperationEventFilter<R> {
 
   private static final Logger log = LoggerFactory.getLogger(InformerEventSource.class);
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSource.java
@@ -1,9 +1,13 @@
 package io.javaoperatorsdk.operator.processing.event.source.informer;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import io.javaoperatorsdk.operator.health.InformerEventSourceHealthIndicator;
+import io.javaoperatorsdk.operator.health.InformerHealthIndicator;
+import io.javaoperatorsdk.operator.health.Status;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,7 +70,8 @@ import io.javaoperatorsdk.operator.processing.event.source.PrimaryToSecondaryMap
  */
 public class InformerEventSource<R extends HasMetadata, P extends HasMetadata>
     extends ManagedInformerEventSource<R, P, InformerConfiguration<R>>
-    implements ResourceEventHandler<R>, RecentOperationEventFilter<R> {
+    implements ResourceEventHandler<R>, RecentOperationEventFilter<R>
+{
 
   private static final Logger log = LoggerFactory.getLogger(InformerEventSource.class);
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerManager.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerManager.java
@@ -7,7 +7,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import io.javaoperatorsdk.operator.health.InformerHealthIndicator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,6 +21,7 @@ import io.javaoperatorsdk.operator.ReconcilerUtils;
 import io.javaoperatorsdk.operator.api.config.Cloner;
 import io.javaoperatorsdk.operator.api.config.ConfigurationServiceProvider;
 import io.javaoperatorsdk.operator.api.config.ResourceConfiguration;
+import io.javaoperatorsdk.operator.health.InformerHealthIndicator;
 import io.javaoperatorsdk.operator.processing.LifecycleAware;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import io.javaoperatorsdk.operator.processing.event.source.Cache;

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerManager.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerManager.java
@@ -7,6 +7,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import io.javaoperatorsdk.operator.health.InformerHealthIndicator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -178,5 +179,9 @@ public class InformerManager<T extends HasMetadata, C extends ResourceConfigurat
         + "] watching: "
         + configuration.getEffectiveNamespaces()
         + (selector != null ? " selector: " + selector : "");
+  }
+
+  public Map<String, InformerHealthIndicator> informerHealthIndicators() {
+    return Collections.unmodifiableMap(sources);
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerManager.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerManager.java
@@ -27,10 +27,11 @@ import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import io.javaoperatorsdk.operator.processing.event.source.Cache;
 import io.javaoperatorsdk.operator.processing.event.source.IndexerResourceCache;
 
+import static io.javaoperatorsdk.operator.api.reconciler.Constants.WATCH_ALL_NAMESPACES;
+
 public class InformerManager<T extends HasMetadata, C extends ResourceConfiguration<T>>
     implements LifecycleAware, IndexerResourceCache<T> {
 
-  private static final String ALL_NAMESPACES_MAP_KEY = "allNamespaces";
   private static final Logger log = LoggerFactory.getLogger(InformerManager.class);
 
   private final Map<String, InformerWrapper<T>> sources = new ConcurrentHashMap<>();
@@ -59,7 +60,7 @@ public class InformerManager<T extends HasMetadata, C extends ResourceConfigurat
       final var filteredBySelectorClient =
           client.inAnyNamespace().withLabelSelector(labelSelector);
       final var source =
-          createEventSource(filteredBySelectorClient, eventHandler, ALL_NAMESPACES_MAP_KEY);
+          createEventSource(filteredBySelectorClient, eventHandler, WATCH_ALL_NAMESPACES);
       log.debug("Registered {} -> {} for any namespace", this, source);
     } else {
       targetNamespaces.forEach(
@@ -97,10 +98,11 @@ public class InformerManager<T extends HasMetadata, C extends ResourceConfigurat
 
   private InformerWrapper<T> createEventSource(
       FilterWatchListDeletable<T, KubernetesResourceList<T>, Resource<T>> filteredBySelectorClient,
-      ResourceEventHandler<T> eventHandler, String key) {
-    var source = new InformerWrapper<>(filteredBySelectorClient.runnableInformer(0));
+      ResourceEventHandler<T> eventHandler, String namespaceIdentifier) {
+    var source =
+        new InformerWrapper<>(filteredBySelectorClient.runnableInformer(0), namespaceIdentifier);
     source.addEventHandler(eventHandler);
-    sources.put(key, source);
+    sources.put(namespaceIdentifier, source);
     return source;
   }
 
@@ -128,7 +130,7 @@ public class InformerManager<T extends HasMetadata, C extends ResourceConfigurat
   @Override
   public Stream<T> list(String namespace, Predicate<T> predicate) {
     if (isWatchingAllNamespaces()) {
-      return getSource(ALL_NAMESPACES_MAP_KEY)
+      return getSource(WATCH_ALL_NAMESPACES)
           .map(source -> source.list(namespace, predicate))
           .orElseGet(Stream::empty);
     } else {
@@ -140,7 +142,7 @@ public class InformerManager<T extends HasMetadata, C extends ResourceConfigurat
 
   @Override
   public Optional<T> get(ResourceID resourceID) {
-    return getSource(resourceID.getNamespace().orElse(ALL_NAMESPACES_MAP_KEY))
+    return getSource(resourceID.getNamespace().orElse(WATCH_ALL_NAMESPACES))
         .flatMap(source -> source.get(resourceID))
         .map(cloner::clone);
   }
@@ -151,11 +153,11 @@ public class InformerManager<T extends HasMetadata, C extends ResourceConfigurat
   }
 
   private boolean isWatchingAllNamespaces() {
-    return sources.containsKey(ALL_NAMESPACES_MAP_KEY);
+    return sources.containsKey(WATCH_ALL_NAMESPACES);
   }
 
   private Optional<InformerWrapper<T>> getSource(String namespace) {
-    namespace = isWatchingAllNamespaces() || namespace == null ? ALL_NAMESPACES_MAP_KEY : namespace;
+    namespace = isWatchingAllNamespaces() || namespace == null ? WATCH_ALL_NAMESPACES : namespace;
     return Optional.ofNullable(sources.get(namespace));
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerWrapper.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerWrapper.java
@@ -10,7 +10,6 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-import io.javaoperatorsdk.operator.health.InformerHealthIndicator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,6 +21,7 @@ import io.fabric8.kubernetes.client.informers.cache.Cache;
 import io.javaoperatorsdk.operator.OperatorException;
 import io.javaoperatorsdk.operator.ReconcilerUtils;
 import io.javaoperatorsdk.operator.api.config.ConfigurationServiceProvider;
+import io.javaoperatorsdk.operator.health.InformerHealthIndicator;
 import io.javaoperatorsdk.operator.processing.LifecycleAware;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import io.javaoperatorsdk.operator.processing.event.source.IndexerResourceCache;

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerWrapper.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerWrapper.java
@@ -33,10 +33,13 @@ class InformerWrapper<T extends HasMetadata>
 
   private final SharedIndexInformer<T> informer;
   private final Cache<T> cache;
+  private final String namespaceIdentifier;
 
-  public InformerWrapper(SharedIndexInformer<T> informer) {
+  public InformerWrapper(SharedIndexInformer<T> informer, String namespaceIdentifier) {
     this.informer = informer;
+    this.namespaceIdentifier = namespaceIdentifier;
     this.cache = (Cache<T>) informer.getStore();
+
   }
 
   @Override
@@ -160,5 +163,10 @@ class InformerWrapper<T extends HasMetadata>
   @Override
   public boolean isRunning() {
     return informer.isRunning();
+  }
+
+  @Override
+  public String getTargetNamespace() {
+    return namespaceIdentifier;
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerWrapper.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerWrapper.java
@@ -10,6 +10,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
+import io.javaoperatorsdk.operator.health.InformerHealthIndicator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,7 +27,7 @@ import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import io.javaoperatorsdk.operator.processing.event.source.IndexerResourceCache;
 
 class InformerWrapper<T extends HasMetadata>
-    implements LifecycleAware, IndexerResourceCache<T> {
+    implements LifecycleAware, IndexerResourceCache<T>, InformerHealthIndicator {
 
   private static final Logger log = LoggerFactory.getLogger(InformerWrapper.class);
 
@@ -144,5 +145,20 @@ class InformerWrapper<T extends HasMetadata>
   @Override
   public String toString() {
     return "InformerWrapper [" + versionedFullResourceName() + "] (" + informer + ')';
+  }
+
+  @Override
+  public boolean hasSynced() {
+    return informer.hasSynced();
+  }
+
+  @Override
+  public boolean isWatching() {
+    return informer.isWatching();
+  }
+
+  @Override
+  public boolean isRunning() {
+    return informer.isRunning();
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/ManagedInformerEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/ManagedInformerEventSource.java
@@ -8,6 +8,9 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
+import io.javaoperatorsdk.operator.health.InformerEventSourceHealthIndicator;
+import io.javaoperatorsdk.operator.health.InformerHealthIndicator;
+import io.javaoperatorsdk.operator.health.Status;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,8 +28,7 @@ import io.javaoperatorsdk.operator.processing.event.source.*;
 public abstract class ManagedInformerEventSource<R extends HasMetadata, P extends HasMetadata, C extends ResourceConfiguration<R>>
     extends AbstractResourceEventSource<R, P>
     implements ResourceEventHandler<R>, Cache<R>, IndexerResourceCache<R>,
-    RecentOperationCacheFiller<R>,
-    NamespaceChangeable {
+    RecentOperationCacheFiller<R>, NamespaceChangeable, InformerEventSourceHealthIndicator {
 
   private static final Logger log = LoggerFactory.getLogger(ManagedInformerEventSource.class);
 
@@ -133,4 +135,13 @@ public abstract class ManagedInformerEventSource<R extends HasMetadata, P extend
     return cache.list(predicate);
   }
 
+  @Override
+  public Map<String, InformerHealthIndicator> informerHealthIndicators() {
+    return cache.informerHealthIndicators();
+  }
+
+  @Override
+  public Status getStatus() {
+    return InformerEventSourceHealthIndicator.super.getStatus();
+  }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/ManagedInformerEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/ManagedInformerEventSource.java
@@ -19,8 +19,8 @@ import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
 import io.javaoperatorsdk.operator.api.config.NamespaceChangeable;
 import io.javaoperatorsdk.operator.api.config.ResourceConfiguration;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.RecentOperationCacheFiller;
-import io.javaoperatorsdk.operator.health.InformerEventSourceHealthIndicator;
 import io.javaoperatorsdk.operator.health.InformerHealthIndicator;
+import io.javaoperatorsdk.operator.health.InformerWrappingEventSourceHealthIndicator;
 import io.javaoperatorsdk.operator.health.Status;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import io.javaoperatorsdk.operator.processing.event.source.*;
@@ -28,17 +28,20 @@ import io.javaoperatorsdk.operator.processing.event.source.*;
 public abstract class ManagedInformerEventSource<R extends HasMetadata, P extends HasMetadata, C extends ResourceConfiguration<R>>
     extends AbstractResourceEventSource<R, P>
     implements ResourceEventHandler<R>, Cache<R>, IndexerResourceCache<R>,
-    RecentOperationCacheFiller<R>, NamespaceChangeable, InformerEventSourceHealthIndicator {
+    RecentOperationCacheFiller<R>, NamespaceChangeable,
+    InformerWrappingEventSourceHealthIndicator<R> {
 
   private static final Logger log = LoggerFactory.getLogger(ManagedInformerEventSource.class);
 
   protected TemporaryResourceCache<R> temporaryResourceCache = new TemporaryResourceCache<>(this);
   protected InformerManager<R, C> cache = new InformerManager<>();
+  protected C configuration;
 
   protected ManagedInformerEventSource(
       MixedOperation<R, KubernetesResourceList<R>, Resource<R>> client, C configuration) {
     super(configuration.getResourceClass());
     manager().initSources(client, configuration, this);
+    this.configuration = configuration;
   }
 
   @Override
@@ -142,6 +145,11 @@ public abstract class ManagedInformerEventSource<R extends HasMetadata, P extend
 
   @Override
   public Status getStatus() {
-    return InformerEventSourceHealthIndicator.super.getStatus();
+    return InformerWrappingEventSourceHealthIndicator.super.getStatus();
+  }
+
+  @Override
+  public ResourceConfiguration<R> getInformerConfiguration() {
+    return configuration;
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/ManagedInformerEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/ManagedInformerEventSource.java
@@ -8,9 +8,6 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-import io.javaoperatorsdk.operator.health.InformerEventSourceHealthIndicator;
-import io.javaoperatorsdk.operator.health.InformerHealthIndicator;
-import io.javaoperatorsdk.operator.health.Status;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,6 +19,9 @@ import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
 import io.javaoperatorsdk.operator.api.config.NamespaceChangeable;
 import io.javaoperatorsdk.operator.api.config.ResourceConfiguration;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.RecentOperationCacheFiller;
+import io.javaoperatorsdk.operator.health.InformerEventSourceHealthIndicator;
+import io.javaoperatorsdk.operator.health.InformerHealthIndicator;
+import io.javaoperatorsdk.operator.health.Status;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import io.javaoperatorsdk.operator.processing.event.source.*;
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/polling/PerResourcePollingEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/polling/PerResourcePollingEventSource.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.javaoperatorsdk.operator.OperatorException;
+import io.javaoperatorsdk.operator.health.Status;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import io.javaoperatorsdk.operator.processing.event.source.Cache;
 import io.javaoperatorsdk.operator.processing.event.source.CacheKeyMapper;
@@ -39,6 +40,7 @@ public class PerResourcePollingEventSource<R, P extends HasMetadata>
   private final Predicate<P> registerPredicate;
   private final long period;
   private final Set<ResourceID> fetchedForPrimaries = ConcurrentHashMap.newKeySet();
+  private volatile boolean healthy = true;
 
   public PerResourcePollingEventSource(ResourceFetcher<R, P> resourceFetcher,
       Cache<P> resourceCache, long period, Class<R> resourceClass) {
@@ -64,10 +66,16 @@ public class PerResourcePollingEventSource<R, P extends HasMetadata>
   }
 
   private Set<R> getAndCacheResource(P primary, boolean fromGetter) {
-    var values = resourceFetcher.fetchResources(primary);
-    handleResources(ResourceID.fromResource(primary), values, !fromGetter);
-    fetchedForPrimaries.add(ResourceID.fromResource(primary));
-    return values;
+    try {
+      var values = resourceFetcher.fetchResources(primary);
+      handleResources(ResourceID.fromResource(primary), values, !fromGetter);
+      fetchedForPrimaries.add(ResourceID.fromResource(primary));
+      healthy = true;
+      return values;
+    } catch (RuntimeException e) {
+      healthy = false;
+      throw e;
+    }
   }
 
   @Override
@@ -151,5 +159,11 @@ public class PerResourcePollingEventSource<R, P extends HasMetadata>
   public void stop() throws OperatorException {
     super.stop();
     timer.cancel();
+  }
+
+  @Override
+  public Status getStatus() {
+    // todo unit test
+    return healthy ? Status.HEALTHY : Status.UNHEALTHY;
   }
 }

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/informerrelatedbehavior/InformerRelatedBehaviorTestReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/informerrelatedbehavior/InformerRelatedBehaviorTestReconciler.java
@@ -10,10 +10,17 @@ import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.Dependent;
 import io.javaoperatorsdk.operator.support.TestExecutionInfoProvider;
 
-@ControllerConfiguration(dependents = @Dependent(type = ConfigMapDependentResource.class))
+@ControllerConfiguration(
+    name = InformerRelatedBehaviorTestReconciler.INFORMER_RELATED_BEHAVIOR_TEST_RECONCILER,
+    dependents = @Dependent(
+        name = InformerRelatedBehaviorTestReconciler.CONFIG_MAP_DEPENDENT_RESOURCE,
+        type = ConfigMapDependentResource.class))
 public class InformerRelatedBehaviorTestReconciler
     implements Reconciler<InformerRelatedBehaviorTestCustomResource>, TestExecutionInfoProvider {
 
+  public static final String INFORMER_RELATED_BEHAVIOR_TEST_RECONCILER =
+      "InformerRelatedBehaviorTestReconciler";
+  public static final String CONFIG_MAP_DEPENDENT_RESOURCE = "ConfigMapDependentResource";
 
   private final AtomicInteger numberOfExecutions = new AtomicInteger(0);
   private KubernetesClient client;

--- a/sample-operators/webpage/k8s/operator.yaml
+++ b/sample-operators/webpage/k8s/operator.yaml
@@ -25,17 +25,18 @@ spec:
         imagePullPolicy: Never
         ports:
         - containerPort: 80
-        readinessProbe:
+        startupProbe:
           httpGet:
-            path: /health
+            path: /startup
             port: 8080
-          initialDelaySeconds: 1
-          timeoutSeconds: 1
+          initialDelaySeconds: 3
+          timeoutSeconds: 3
+          failureThreshold: 10
         livenessProbe:
           httpGet:
-            path: /health
+            path: /healthz
             port: 8080
-          initialDelaySeconds: 30
+          initialDelaySeconds: 5
           timeoutSeconds: 1
 
 ---

--- a/sample-operators/webpage/k8s/operator.yaml
+++ b/sample-operators/webpage/k8s/operator.yaml
@@ -29,8 +29,9 @@ spec:
           httpGet:
             path: /startup
             port: 8080
-          initialDelaySeconds: 3
-          timeoutSeconds: 3
+          initialDelaySeconds: 1
+          periodSeconds: 2
+          timeoutSeconds: 1
           failureThreshold: 10
         livenessProbe:
           httpGet:
@@ -38,6 +39,8 @@ spec:
             port: 8080
           initialDelaySeconds: 5
           timeoutSeconds: 1
+          periodSeconds: 2
+          failureThreshold: 3
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/sample-operators/webpage/src/main/java/io/javaoperatorsdk/operator/sample/LivenessHandler.java
+++ b/sample-operators/webpage/src/main/java/io/javaoperatorsdk/operator/sample/LivenessHandler.java
@@ -1,0 +1,29 @@
+package io.javaoperatorsdk.operator.sample;
+
+import java.io.IOException;
+
+import io.javaoperatorsdk.operator.Operator;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+
+import static io.javaoperatorsdk.operator.sample.StartupHandler.sendMessage;
+
+public class LivenessHandler implements HttpHandler {
+
+  private final Operator operator;
+
+  public LivenessHandler(Operator operator) {
+    this.operator = operator;
+  }
+
+  // custom logic can be added here based on the health of event sources
+  @Override
+  public void handle(HttpExchange httpExchange) throws IOException {
+    if (operator.getRuntimeInfo().allEventSourcesAreHealthy()) {
+      sendMessage(httpExchange, 200, "healthy");
+    } else {
+      sendMessage(httpExchange, 400, "an event source is not healthy");
+    }
+  }
+}

--- a/sample-operators/webpage/src/main/java/io/javaoperatorsdk/operator/sample/StartupHandler.java
+++ b/sample-operators/webpage/src/main/java/io/javaoperatorsdk/operator/sample/StartupHandler.java
@@ -18,7 +18,7 @@ public class StartupHandler implements HttpHandler {
 
   @Override
   public void handle(HttpExchange httpExchange) throws IOException {
-    if (operator.isStarted()) {
+    if (operator.getRuntimeInfo().isStarted()) {
       sendMessage(httpExchange, 200, "started");
     } else {
       sendMessage(httpExchange, 400, "not started yet");

--- a/sample-operators/webpage/src/main/java/io/javaoperatorsdk/operator/sample/StartupHandler.java
+++ b/sample-operators/webpage/src/main/java/io/javaoperatorsdk/operator/sample/StartupHandler.java
@@ -1,0 +1,37 @@
+package io.javaoperatorsdk.operator.sample;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import io.javaoperatorsdk.operator.Operator;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+
+public class StartupHandler implements HttpHandler {
+
+  private final Operator operator;
+
+  public StartupHandler(Operator operator) {
+    this.operator = operator;
+  }
+
+  @Override
+  public void handle(HttpExchange httpExchange) throws IOException {
+    if (operator.isStarted()) {
+      sendMessage(httpExchange, 200, "started");
+    } else {
+      sendMessage(httpExchange, 400, "not started yet");
+    }
+  }
+
+  public static void sendMessage(HttpExchange httpExchange, int code, String message)
+      throws IOException {
+    try (var outputStream = httpExchange.getResponseBody()) {
+      var bytes = message.getBytes(StandardCharsets.UTF_8);
+      httpExchange.sendResponseHeaders(code, bytes.length);
+      outputStream.write(bytes);
+      outputStream.flush();
+    }
+  }
+}

--- a/sample-operators/webpage/src/main/java/io/javaoperatorsdk/operator/sample/WebPageOperator.java
+++ b/sample-operators/webpage/src/main/java/io/javaoperatorsdk/operator/sample/WebPageOperator.java
@@ -1,16 +1,15 @@
 package io.javaoperatorsdk.operator.sample;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.takes.facets.fork.FkRegex;
-import org.takes.facets.fork.TkFork;
-import org.takes.http.Exit;
-import org.takes.http.FtBasic;
 
 import io.fabric8.kubernetes.client.*;
 import io.javaoperatorsdk.operator.Operator;
+
+import com.sun.net.httpserver.HttpServer;
 
 public class WebPageOperator {
   public static final String WEBPAGE_RECONCILER_ENV = "WEBPAGE_RECONCILER";
@@ -23,7 +22,7 @@ public class WebPageOperator {
     log.info("WebServer Operator starting!");
 
     KubernetesClient client = new KubernetesClientBuilder().build();
-    Operator operator = new Operator(client);
+    Operator operator = new Operator(client, o -> o.withStopOnInformerErrorDuringStartup(false));
     String reconcilerEnvVar = System.getenv(WEBPAGE_RECONCILER_ENV);
     if (WEBPAGE_CLASSIC_RECONCILER_ENV_VALUE.equals(reconcilerEnvVar)) {
       operator.register(new WebPageReconciler(client));
@@ -36,6 +35,11 @@ public class WebPageOperator {
     operator.installShutdownHook();
     operator.start();
 
-    new FtBasic(new TkFork(new FkRegex("/health", "ALL GOOD!")), 8080).start(Exit.NEVER);
+    HttpServer server = HttpServer.create(new InetSocketAddress(8080), 0);
+    server.createContext("/startup", new StartupHandler(operator));
+    // we want to restart the operator if something goes wrong with (maybe just some) event sources
+    server.createContext("/healthz", new LivenessHandler(operator));
+    server.setExecutor(null);
+    server.start();
   }
 }


### PR DESCRIPTION
Expose runtime information mainly about event sources and informers so that can be used to create custom / tailored liveness probes.