### PR TITLE
fix: deprecate install webhook

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Operator.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Operator.java
@@ -66,6 +66,7 @@ public class Operator implements LifecycleAware {
   }
 
   /** Adds a shutdown hook that automatically calls {@link #stop()} when the app shuts down. */
+  @Deprecated(forRemoval = true)
   public void installShutdownHook() {
     Runtime.getRuntime().addShutdownHook(new Thread(this::stop));
   }

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/InformerRelatedBehaviorITS.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/InformerRelatedBehaviorITS.java
@@ -211,7 +211,6 @@ class InformerRelatedBehaviorITS {
           }
         });
     operator.register(reconciler);
-    operator.installShutdownHook();
     operator.start();
     return operator;
   }

--- a/sample-operators/leader-election/src/main/java/io/javaoperatorsdk/operator/sample/LeaderElectionTestOperator.java
+++ b/sample-operators/leader-election/src/main/java/io/javaoperatorsdk/operator/sample/LeaderElectionTestOperator.java
@@ -27,7 +27,6 @@ public class LeaderElectionTestOperator {
         new Operator(client, c -> c.withLeaderElectionConfiguration(leaderElectionConfiguration));
 
     operator.register(new LeaderElectionTestReconciler(identity));
-    operator.installShutdownHook();
     operator.start();
   }
 }

--- a/sample-operators/mysql-schema/src/main/java/io/javaoperatorsdk/operator/sample/MySQLSchemaOperator.java
+++ b/sample-operators/mysql-schema/src/main/java/io/javaoperatorsdk/operator/sample/MySQLSchemaOperator.java
@@ -34,7 +34,6 @@ public class MySQLSchemaOperator {
         configOverrider -> configOverrider.replacingNamedDependentResourceConfig(
             SchemaDependentResource.NAME,
             new ResourcePollerConfig(300, MySQLDbConfig.loadFromEnvironmentVars())));
-    operator.installShutdownHook();
     operator.start();
 
     new FtBasic(new TkFork(new FkRegex("/health", "ALL GOOD!")), 8080).start(Exit.NEVER);

--- a/sample-operators/tomcat-operator/src/main/java/io/javaoperatorsdk/operator/sample/TomcatOperator.java
+++ b/sample-operators/tomcat-operator/src/main/java/io/javaoperatorsdk/operator/sample/TomcatOperator.java
@@ -22,7 +22,6 @@ public class TomcatOperator {
     Operator operator = new Operator(client);
     operator.register(new TomcatReconciler());
     operator.register(new WebappReconciler(client));
-    operator.installShutdownHook();
     operator.start();
 
     new FtBasic(new TkFork(new FkRegex("/health", "ALL GOOD.")), 8080).start(Exit.NEVER);

--- a/sample-operators/webpage/src/main/java/io/javaoperatorsdk/operator/sample/WebPageOperator.java
+++ b/sample-operators/webpage/src/main/java/io/javaoperatorsdk/operator/sample/WebPageOperator.java
@@ -33,7 +33,6 @@ public class WebPageOperator {
     } else {
       operator.register(new WebPageStandaloneDependentsReconciler(client));
     }
-    operator.installShutdownHook();
     operator.start();
 
     new FtBasic(new TkFork(new FkRegex("/health", "ALL GOOD!")), 8080).start(Exit.NEVER);


### PR DESCRIPTION
The graceful shutdown does not help. We should remove this. Users can directly add shutdown hooks anyway if needed just with plain Java API.