### PR TITLE
feat: workflows can be created without associated dependent resource

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationService.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationService.java
@@ -16,6 +16,7 @@ import io.fabric8.kubernetes.client.utils.Serialization;
 import io.javaoperatorsdk.operator.api.monitoring.Metrics;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResourceFactory;
+import io.javaoperatorsdk.operator.processing.dependent.workflow.ManagedWorkflowFactory;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -192,5 +193,9 @@ public interface ConfigurationService {
         System.exit(1);
       }
     });
+  }
+
+  default ManagedWorkflowFactory getWorkflowFactory() {
+    return ManagedWorkflowFactory.DEFAULT;
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/DependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/DependentResource.java
@@ -64,4 +64,8 @@ public interface DependentResource<R, P extends HasMetadata> {
   static String defaultNameFor(Class<? extends DependentResource> dependentResourceClass) {
     return dependentResourceClass.getName();
   }
+
+  static boolean canDeleteIfAble(DependentResource<?, ?> dependentResource) {
+    return dependentResource instanceof Deleter && !(dependentResource instanceof GarbageCollected);
+  }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/DependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/DependentResource.java
@@ -65,7 +65,7 @@ public interface DependentResource<R, P extends HasMetadata> {
     return dependentResourceClass.getName();
   }
 
-  static boolean canDeleteIfAble(DependentResource<?, ?> dependentResource) {
+  static boolean isDeletable(DependentResource<?, ?> dependentResource) {
     return dependentResource instanceof Deleter && !(dependentResource instanceof GarbageCollected);
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/DependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/DependentResource.java
@@ -65,7 +65,7 @@ public interface DependentResource<R, P extends HasMetadata> {
     return dependentResourceClass.getName();
   }
 
-  static boolean isDeletable(DependentResource<?, ?> dependentResource) {
-    return dependentResource instanceof Deleter && !(dependentResource instanceof GarbageCollected);
+  default boolean isDeletable() {
+    return this instanceof Deleter;
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/Controller.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/Controller.java
@@ -81,8 +81,8 @@ public class Controller<P extends HasMetadata>
     this.metrics = Optional.ofNullable(configurationService.getMetrics()).orElse(Metrics.NOOP);
     contextInitializer = reconciler instanceof ContextInitializer;
     isCleaner = reconciler instanceof Cleaner;
-    managedWorkflow = configurationService.getWorkflowFactory()
-        .workflowFor(kubernetesClient, configuration.getDependentResources());
+    managedWorkflow = configurationService.getWorkflowFactory().workflowFor(configuration);
+    managedWorkflow.resolve(kubernetesClient, configuration.getDependentResources());
 
     eventSourceManager = new EventSourceManager<>(this);
     eventProcessor = new EventProcessor<>(eventSourceManager);

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/Controller.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/Controller.java
@@ -77,12 +77,12 @@ public class Controller<P extends HasMetadata>
     this.reconciler = reconciler;
     this.configuration = configuration;
     this.kubernetesClient = kubernetesClient;
-    this.metrics = Optional.ofNullable(ConfigurationServiceProvider.instance().getMetrics())
-        .orElse(Metrics.NOOP);
+    final var configurationService = ConfigurationServiceProvider.instance();
+    this.metrics = Optional.ofNullable(configurationService.getMetrics()).orElse(Metrics.NOOP);
     contextInitializer = reconciler instanceof ContextInitializer;
     isCleaner = reconciler instanceof Cleaner;
-    managedWorkflow =
-        ManagedWorkflow.workflowFor(kubernetesClient, configuration.getDependentResources());
+    managedWorkflow = configurationService.getWorkflowFactory()
+        .workflowFor(kubernetesClient, configuration.getDependentResources());
 
     eventSourceManager = new EventSourceManager<>(this);
     eventProcessor = new EventProcessor<>(eventSourceManager);

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResource.java
@@ -294,4 +294,9 @@ public abstract class KubernetesDependentResource<R extends HasMetadata, P exten
   public Optional<KubernetesDependentResourceConfig<R>> configuration() {
     return Optional.ofNullable(kubernetesDependentResourceConfig);
   }
+
+  @Override
+  public boolean isDeletable() {
+    return super.isDeletable() && !garbageCollected;
+  }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/AbstractDependentResourceNode.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/AbstractDependentResourceNode.java
@@ -8,7 +8,7 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
 
 @SuppressWarnings("rawtypes")
-public abstract class AbstractDependentResourceNode<R, P extends HasMetadata>
+abstract class AbstractDependentResourceNode<R, P extends HasMetadata>
     implements DependentResourceNode<R, P> {
 
   private final List<DependentResourceNode> dependsOn = new LinkedList<>();

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/AbstractDependentResourceNode.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/AbstractDependentResourceNode.java
@@ -1,0 +1,93 @@
+package io.javaoperatorsdk.operator.processing.dependent.workflow;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+
+@SuppressWarnings("rawtypes")
+public abstract class AbstractDependentResourceNode<R, P extends HasMetadata>
+    implements DependentResourceNode<R, P> {
+
+  private final List<DependentResourceNode> dependsOn = new LinkedList<>();
+  private final List<DependentResourceNode> parents = new LinkedList<>();
+  private final String name;
+  private Condition<R, P> reconcilePrecondition;
+  private Condition<R, P> deletePostcondition;
+  private Condition<R, P> readyPostcondition;
+
+  protected AbstractDependentResourceNode(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public List<? extends DependentResourceNode> getDependsOn() {
+    return dependsOn;
+  }
+
+  @Override
+  public void addParent(DependentResourceNode parent) {
+    parents.add(parent);
+  }
+
+  @Override
+  public void addDependsOnRelation(DependentResourceNode node) {
+    node.addParent(this);
+    dependsOn.add(node);
+  }
+
+  @Override
+  public List<DependentResourceNode> getParents() {
+    return parents;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public Optional<Condition<R, P>> getReconcilePrecondition() {
+    return Optional.ofNullable(reconcilePrecondition);
+  }
+
+  @Override
+  public Optional<Condition<R, P>> getDeletePostcondition() {
+    return Optional.ofNullable(deletePostcondition);
+  }
+
+  public void setReconcilePrecondition(Condition<R, P> reconcilePrecondition) {
+    this.reconcilePrecondition = reconcilePrecondition;
+  }
+
+  public void setDeletePostcondition(Condition<R, P> cleanupCondition) {
+    this.deletePostcondition = cleanupCondition;
+  }
+
+  @Override
+  public Optional<Condition<R, P>> getReadyPostcondition() {
+    return Optional.ofNullable(readyPostcondition);
+  }
+
+  public void setReadyPostcondition(Condition<R, P> readyPostcondition) {
+    this.readyPostcondition = readyPostcondition;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    AbstractDependentResourceNode<?, ?> that = (AbstractDependentResourceNode<?, ?>) o;
+    return name.equals(that.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return name.hashCode();
+  }
+}

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/AbstractDependentResourceNode.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/AbstractDependentResourceNode.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
 
 @SuppressWarnings("rawtypes")
 public abstract class AbstractDependentResourceNode<R, P extends HasMetadata>
@@ -16,6 +17,7 @@ public abstract class AbstractDependentResourceNode<R, P extends HasMetadata>
   private Condition<R, P> reconcilePrecondition;
   private Condition<R, P> deletePostcondition;
   private Condition<R, P> readyPostcondition;
+  private DependentResource<R, P> dependentResource;
 
   protected AbstractDependentResourceNode(String name) {
     this.name = name;
@@ -72,6 +74,14 @@ public abstract class AbstractDependentResourceNode<R, P extends HasMetadata>
 
   public void setReadyPostcondition(Condition<R, P> readyPostcondition) {
     this.readyPostcondition = readyPostcondition;
+  }
+
+  public DependentResource<R, P> getDependentResource() {
+    return dependentResource;
+  }
+
+  public void setDependentResource(DependentResource<R, P> dependentResource) {
+    this.dependentResource = dependentResource;
   }
 
   @Override

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/AbstractWorkflowExecutor.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/AbstractWorkflowExecutor.java
@@ -107,8 +107,8 @@ public abstract class AbstractWorkflowExecutor<P extends HasMetadata> {
   protected <R> boolean isConditionMet(Optional<Condition<R, P>> condition,
       DependentResource<R, P> dependentResource) {
     return condition.map(c -> c.isMet(primary,
-            dependentResource.getSecondaryResource(primary, context).orElse(null),
-            context))
+        dependentResource.getSecondaryResource(primary, context).orElse(null),
+        context))
         .orElse(true);
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/AbstractWorkflowExecutor.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/AbstractWorkflowExecutor.java
@@ -1,0 +1,100 @@
+package io.javaoperatorsdk.operator.processing.dependent.workflow;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
+
+@SuppressWarnings("rawtypes")
+public abstract class AbstractWorkflowExecutor<P extends HasMetadata> {
+
+  protected final Workflow<P> workflow;
+  protected final P primary;
+  protected final Context<P> context;
+  /**
+   * Covers both deleted and reconciled
+   */
+  private final Set<DependentResourceNode> alreadyVisited = ConcurrentHashMap.newKeySet();
+  private final Map<DependentResourceNode, Future<?>> actualExecutions = new HashMap<>();
+  private final Map<DependentResourceNode, Exception> exceptionsDuringExecution =
+      new ConcurrentHashMap<>();
+
+  public AbstractWorkflowExecutor(Workflow<P> workflow, P primary, Context<P> context) {
+    this.workflow = workflow;
+    this.primary = primary;
+    this.context = context;
+  }
+
+  protected abstract Logger logger();
+
+  protected void waitForScheduledExecutionsToRun() {
+    while (true) {
+      try {
+        this.wait();
+        if (noMoreExecutionsScheduled()) {
+          break;
+        } else {
+          logger().warn("Notified but still resources under execution. This should not happen.");
+        }
+      } catch (InterruptedException e) {
+        logger().warn("Thread interrupted", e);
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
+  protected boolean noMoreExecutionsScheduled() {
+    return actualExecutions.isEmpty();
+  }
+
+  protected boolean alreadyVisited(DependentResourceNode<?, P> dependentResourceNode) {
+    return alreadyVisited.contains(dependentResourceNode);
+  }
+
+  protected void markAsVisited(DependentResourceNode<?, P> dependentResourceNode) {
+    alreadyVisited.add(dependentResourceNode);
+  }
+
+  protected boolean isExecutingNow(DependentResourceNode<?, P> dependentResourceNode) {
+    return actualExecutions.containsKey(dependentResourceNode);
+  }
+
+  protected void markAsExecuting(DependentResourceNode<?, P> dependentResourceNode,
+      Future<?> future) {
+    actualExecutions.put(dependentResourceNode, future);
+  }
+
+  protected synchronized void handleExceptionInExecutor(
+      DependentResourceNode<?, P> dependentResourceNode,
+      RuntimeException e) {
+    exceptionsDuringExecution.put(dependentResourceNode, e);
+  }
+
+  protected boolean isInError(DependentResourceNode<?, P> dependentResourceNode) {
+    return exceptionsDuringExecution.containsKey(dependentResourceNode);
+  }
+
+  protected Map<DependentResource, Exception> getErroredDependents() {
+    return exceptionsDuringExecution.entrySet().stream()
+        .collect(
+            Collectors.toMap(e -> workflow.getDependentResourceFor(e.getKey()), Entry::getValue));
+  }
+
+  protected synchronized void handleNodeExecutionFinish(
+      DependentResourceNode<?, P> dependentResourceNode) {
+    logger().debug("Finished execution for: {}", dependentResourceNode);
+    actualExecutions.remove(dependentResourceNode);
+    if (noMoreExecutionsScheduled()) {
+      this.notifyAll();
+    }
+  }
+}

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/AbstractWorkflowExecutor.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/AbstractWorkflowExecutor.java
@@ -37,7 +37,7 @@ public abstract class AbstractWorkflowExecutor<P extends HasMetadata> {
 
   protected abstract Logger logger();
 
-  protected void waitForScheduledExecutionsToRun() {
+  protected synchronized void waitForScheduledExecutionsToRun() {
     while (true) {
       try {
         this.wait();

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/AbstractWorkflowExecutor.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/AbstractWorkflowExecutor.java
@@ -3,6 +3,7 @@ package io.javaoperatorsdk.operator.processing.dependent.workflow;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
@@ -96,5 +97,18 @@ public abstract class AbstractWorkflowExecutor<P extends HasMetadata> {
     if (noMoreExecutionsScheduled()) {
       this.notifyAll();
     }
+  }
+
+  @SuppressWarnings("unchecked")
+  protected <R> DependentResource<R, P> getDependentResourceFor(DependentResourceNode<R, P> drn) {
+    return (DependentResource<R, P>) workflow.getDependentResourceFor(drn);
+  }
+
+  protected <R> boolean isConditionMet(Optional<Condition<R, P>> condition,
+      DependentResource<R, P> dependentResource) {
+    return condition.map(c -> c.isMet(primary,
+            dependentResource.getSecondaryResource(primary, context).orElse(null),
+            context))
+        .orElse(true);
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/DefaultDependentResourceNode.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/DefaultDependentResourceNode.java
@@ -6,8 +6,6 @@ import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
 public class DefaultDependentResourceNode<R, P extends HasMetadata>
     extends AbstractDependentResourceNode<R, P> {
 
-  private final DependentResource<R, P> dependentResource;
-
   public DefaultDependentResourceNode(DependentResource<R, P> dependentResource) {
     this(dependentResource, null, null);
   }
@@ -21,17 +19,13 @@ public class DefaultDependentResourceNode<R, P extends HasMetadata>
       Condition<R, P> reconcilePrecondition, Condition<R, P> deletePostcondition) {
     super(DependentResource.defaultNameFor(dependentResource.getClass()) + "#"
         + dependentResource.hashCode());
-    this.dependentResource = dependentResource;
+    setDependentResource(dependentResource);
     setReconcilePrecondition(reconcilePrecondition);
     setDeletePostcondition(deletePostcondition);
   }
 
-  public DependentResource<R, P> getDependentResource() {
-    return dependentResource;
-  }
-
   @Override
   public String toString() {
-    return "DependentResourceNode{" + dependentResource + '}';
+    return "DependentResourceNode{" + getDependentResource() + '}';
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/DefaultDependentResourceNode.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/DefaultDependentResourceNode.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.Optional;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
 
 @SuppressWarnings("rawtypes")
@@ -35,7 +34,6 @@ public class DefaultDependentResourceNode<R, P extends HasMetadata> implements
     this.deletePostcondition = deletePostcondition;
   }
 
-  @Override
   public DependentResource<R, P> getDependentResource() {
     return dependentResource;
   }
@@ -94,7 +92,8 @@ public class DefaultDependentResourceNode<R, P extends HasMetadata> implements
   }
 
   @Override
-  public R getSecondaryResource(P primary, Context<P> context) {
-    return getDependentResource().getSecondaryResource(primary, context).orElse(null);
+  public String getName() {
+    return DependentResource.defaultNameFor(dependentResource.getClass()) + "#"
+        + dependentResource.hashCode();
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/DefaultDependentResourceNode.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/DefaultDependentResourceNode.java
@@ -1,22 +1,12 @@
 package io.javaoperatorsdk.operator.processing.dependent.workflow;
 
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Optional;
-
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
 
-@SuppressWarnings("rawtypes")
-public class DefaultDependentResourceNode<R, P extends HasMetadata> implements
-    DependentResourceNode<R, P> {
+public class DefaultDependentResourceNode<R, P extends HasMetadata>
+    extends AbstractDependentResourceNode<R, P> {
 
   private final DependentResource<R, P> dependentResource;
-  private Condition<R, P> reconcilePrecondition;
-  private Condition<R, P> deletePostcondition;
-  private Condition<R, P> readyPostcondition;
-  private final List<DependentResourceNode> dependsOn = new LinkedList<>();
-  private final List<DependentResourceNode> parents = new LinkedList<>();
 
   public DefaultDependentResourceNode(DependentResource<R, P> dependentResource) {
     this(dependentResource, null, null);
@@ -29,9 +19,11 @@ public class DefaultDependentResourceNode<R, P extends HasMetadata> implements
 
   public DefaultDependentResourceNode(DependentResource<R, P> dependentResource,
       Condition<R, P> reconcilePrecondition, Condition<R, P> deletePostcondition) {
+    super(DependentResource.defaultNameFor(dependentResource.getClass()) + "#"
+        + dependentResource.hashCode());
     this.dependentResource = dependentResource;
-    this.reconcilePrecondition = reconcilePrecondition;
-    this.deletePostcondition = deletePostcondition;
+    setReconcilePrecondition(reconcilePrecondition);
+    setDeletePostcondition(deletePostcondition);
   }
 
   public DependentResource<R, P> getDependentResource() {
@@ -39,61 +31,7 @@ public class DefaultDependentResourceNode<R, P extends HasMetadata> implements
   }
 
   @Override
-  public Optional<Condition<R, P>> getReconcilePrecondition() {
-    return Optional.ofNullable(reconcilePrecondition);
-  }
-
-  @Override
-  public Optional<Condition<R, P>> getDeletePostcondition() {
-    return Optional.ofNullable(deletePostcondition);
-  }
-
-  @Override
-  public List<? extends DependentResourceNode> getDependsOn() {
-    return dependsOn;
-  }
-
-  @Override
-  public void addParent(DependentResourceNode parent) {
-    parents.add(parent);
-  }
-
-  @Override
-  public void addDependsOnRelation(DependentResourceNode node) {
-    node.addParent(this);
-    dependsOn.add(node);
-  }
-
-  @Override
   public String toString() {
     return "DependentResourceNode{" + dependentResource + '}';
-  }
-
-  public void setReconcilePrecondition(Condition<R, P> reconcilePrecondition) {
-    this.reconcilePrecondition = reconcilePrecondition;
-  }
-
-  public void setDeletePostcondition(Condition<R, P> cleanupCondition) {
-    this.deletePostcondition = cleanupCondition;
-  }
-
-  @Override
-  public Optional<Condition<R, P>> getReadyPostcondition() {
-    return Optional.ofNullable(readyPostcondition);
-  }
-
-  public void setReadyPostcondition(Condition<R, P> readyPostcondition) {
-    this.readyPostcondition = readyPostcondition;
-  }
-
-  @Override
-  public List<DependentResourceNode> getParents() {
-    return parents;
-  }
-
-  @Override
-  public String getName() {
-    return DependentResource.defaultNameFor(dependentResource.getClass()) + "#"
-        + dependentResource.hashCode();
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/DefaultDependentResourceNode.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/DefaultDependentResourceNode.java
@@ -12,11 +12,16 @@ class DefaultDependentResourceNode<R, P extends HasMetadata>
 
   public DefaultDependentResourceNode(DependentResource<R, P> dependentResource,
       Condition<R, P> reconcilePrecondition, Condition<R, P> deletePostcondition) {
-    super(DependentResource.defaultNameFor(dependentResource.getClass()) + "#"
-        + dependentResource.hashCode());
+    super(getNameFor(dependentResource));
     setDependentResource(dependentResource);
     setReconcilePrecondition(reconcilePrecondition);
     setDeletePostcondition(deletePostcondition);
+  }
+
+  @SuppressWarnings("rawtypes")
+  static String getNameFor(DependentResource dependentResource) {
+    return DependentResource.defaultNameFor(dependentResource.getClass()) + "#"
+        + dependentResource.hashCode();
   }
 
   @Override

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/DefaultDependentResourceNode.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/DefaultDependentResourceNode.java
@@ -9,14 +9,15 @@ import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
 
 @SuppressWarnings("rawtypes")
-public class DefaultDependentResourceNode<R, P extends HasMetadata> {
+public class DefaultDependentResourceNode<R, P extends HasMetadata> implements
+    DependentResourceNode<R, P> {
 
   private final DependentResource<R, P> dependentResource;
   private Condition<R, P> reconcilePrecondition;
   private Condition<R, P> deletePostcondition;
   private Condition<R, P> readyPostcondition;
-  private final List<DefaultDependentResourceNode> dependsOn = new LinkedList<>();
-  private final List<DefaultDependentResourceNode> parents = new LinkedList<>();
+  private final List<DependentResourceNode> dependsOn = new LinkedList<>();
+  private final List<DependentResourceNode> parents = new LinkedList<>();
 
   public DefaultDependentResourceNode(DependentResource<R, P> dependentResource) {
     this(dependentResource, null, null);
@@ -34,62 +35,66 @@ public class DefaultDependentResourceNode<R, P extends HasMetadata> {
     this.deletePostcondition = deletePostcondition;
   }
 
+  @Override
   public DependentResource<R, P> getDependentResource() {
     return dependentResource;
   }
 
+  @Override
   public Optional<Condition<R, P>> getReconcilePrecondition() {
     return Optional.ofNullable(reconcilePrecondition);
   }
 
+  @Override
   public Optional<Condition<R, P>> getDeletePostcondition() {
     return Optional.ofNullable(deletePostcondition);
   }
 
-  public List<DefaultDependentResourceNode> getDependsOn() {
+  @Override
+  public List<? extends DependentResourceNode> getDependsOn() {
     return dependsOn;
   }
 
-  @SuppressWarnings("unchecked")
-  public void addDependsOnRelation(DefaultDependentResourceNode node) {
-    node.parents.add(this);
+  @Override
+  public void addParent(DependentResourceNode parent) {
+    parents.add(parent);
+  }
+
+  @Override
+  public void addDependsOnRelation(DependentResourceNode node) {
+    node.addParent(this);
     dependsOn.add(node);
   }
 
   @Override
   public String toString() {
-    return "DependentResourceNode{" +
-        "dependentResource=" + dependentResource +
-        '}';
+    return "DependentResourceNode{" + dependentResource + '}';
   }
 
-  public DefaultDependentResourceNode<R, P> setReconcilePrecondition(
-      Condition<R, P> reconcilePrecondition) {
+  public void setReconcilePrecondition(Condition<R, P> reconcilePrecondition) {
     this.reconcilePrecondition = reconcilePrecondition;
-    return this;
   }
 
-  public DefaultDependentResourceNode<R, P> setDeletePostcondition(
-      Condition<R, P> cleanupCondition) {
+  public void setDeletePostcondition(Condition<R, P> cleanupCondition) {
     this.deletePostcondition = cleanupCondition;
-    return this;
   }
 
+  @Override
   public Optional<Condition<R, P>> getReadyPostcondition() {
     return Optional.ofNullable(readyPostcondition);
   }
 
-  public DefaultDependentResourceNode<R, P> setReadyPostcondition(
-      Condition<R, P> readyPostcondition) {
+  public void setReadyPostcondition(Condition<R, P> readyPostcondition) {
     this.readyPostcondition = readyPostcondition;
-    return this;
   }
 
-  public List<DefaultDependentResourceNode> getParents() {
+  @Override
+  public List<DependentResourceNode> getParents() {
     return parents;
   }
 
-  protected R getSecondaryResource(P primary, Context<P> context) {
+  @Override
+  public R getSecondaryResource(P primary, Context<P> context) {
     return getDependentResource().getSecondaryResource(primary, context).orElse(null);
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/DefaultDependentResourceNode.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/DefaultDependentResourceNode.java
@@ -9,25 +9,25 @@ import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
 
 @SuppressWarnings("rawtypes")
-public class DependentResourceNode<R, P extends HasMetadata> {
+public class DefaultDependentResourceNode<R, P extends HasMetadata> {
 
   private final DependentResource<R, P> dependentResource;
   private Condition<R, P> reconcilePrecondition;
   private Condition<R, P> deletePostcondition;
   private Condition<R, P> readyPostcondition;
-  private final List<DependentResourceNode> dependsOn = new LinkedList<>();
-  private final List<DependentResourceNode> parents = new LinkedList<>();
+  private final List<DefaultDependentResourceNode> dependsOn = new LinkedList<>();
+  private final List<DefaultDependentResourceNode> parents = new LinkedList<>();
 
-  public DependentResourceNode(DependentResource<R, P> dependentResource) {
+  public DefaultDependentResourceNode(DependentResource<R, P> dependentResource) {
     this(dependentResource, null, null);
   }
 
-  public DependentResourceNode(DependentResource<R, P> dependentResource,
+  public DefaultDependentResourceNode(DependentResource<R, P> dependentResource,
       Condition<R, P> reconcilePrecondition) {
     this(dependentResource, reconcilePrecondition, null);
   }
 
-  public DependentResourceNode(DependentResource<R, P> dependentResource,
+  public DefaultDependentResourceNode(DependentResource<R, P> dependentResource,
       Condition<R, P> reconcilePrecondition, Condition<R, P> deletePostcondition) {
     this.dependentResource = dependentResource;
     this.reconcilePrecondition = reconcilePrecondition;
@@ -46,12 +46,12 @@ public class DependentResourceNode<R, P extends HasMetadata> {
     return Optional.ofNullable(deletePostcondition);
   }
 
-  public List<DependentResourceNode> getDependsOn() {
+  public List<DefaultDependentResourceNode> getDependsOn() {
     return dependsOn;
   }
 
   @SuppressWarnings("unchecked")
-  public void addDependsOnRelation(DependentResourceNode node) {
+  public void addDependsOnRelation(DefaultDependentResourceNode node) {
     node.parents.add(this);
     dependsOn.add(node);
   }
@@ -63,13 +63,14 @@ public class DependentResourceNode<R, P extends HasMetadata> {
         '}';
   }
 
-  public DependentResourceNode<R, P> setReconcilePrecondition(
+  public DefaultDependentResourceNode<R, P> setReconcilePrecondition(
       Condition<R, P> reconcilePrecondition) {
     this.reconcilePrecondition = reconcilePrecondition;
     return this;
   }
 
-  public DependentResourceNode<R, P> setDeletePostcondition(Condition<R, P> cleanupCondition) {
+  public DefaultDependentResourceNode<R, P> setDeletePostcondition(
+      Condition<R, P> cleanupCondition) {
     this.deletePostcondition = cleanupCondition;
     return this;
   }
@@ -78,12 +79,13 @@ public class DependentResourceNode<R, P extends HasMetadata> {
     return Optional.ofNullable(readyPostcondition);
   }
 
-  public DependentResourceNode<R, P> setReadyPostcondition(Condition<R, P> readyPostcondition) {
+  public DefaultDependentResourceNode<R, P> setReadyPostcondition(
+      Condition<R, P> readyPostcondition) {
     this.readyPostcondition = readyPostcondition;
     return this;
   }
 
-  public List<DependentResourceNode> getParents() {
+  public List<DefaultDependentResourceNode> getParents() {
     return parents;
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/DefaultDependentResourceNode.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/DefaultDependentResourceNode.java
@@ -3,16 +3,11 @@ package io.javaoperatorsdk.operator.processing.dependent.workflow;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
 
-public class DefaultDependentResourceNode<R, P extends HasMetadata>
+class DefaultDependentResourceNode<R, P extends HasMetadata>
     extends AbstractDependentResourceNode<R, P> {
 
   public DefaultDependentResourceNode(DependentResource<R, P> dependentResource) {
     this(dependentResource, null, null);
-  }
-
-  public DefaultDependentResourceNode(DependentResource<R, P> dependentResource,
-      Condition<R, P> reconcilePrecondition) {
-    this(dependentResource, reconcilePrecondition, null);
   }
 
   public DefaultDependentResourceNode(DependentResource<R, P> dependentResource,

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/DefaultManagedWorkflow.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/DefaultManagedWorkflow.java
@@ -8,9 +8,7 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.config.dependent.DependentResourceSpec;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
-import io.javaoperatorsdk.operator.api.reconciler.dependent.Deleter;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
-import io.javaoperatorsdk.operator.api.reconciler.dependent.GarbageCollected;
 
 @SuppressWarnings("rawtypes")
 public class DefaultManagedWorkflow<P extends HasMetadata> implements ManagedWorkflow<P> {
@@ -60,7 +58,7 @@ public class DefaultManagedWorkflow<P extends HasMetadata> implements ManagedWor
     specs.forEach(spec -> {
       final var dr = managedWorkflowSupport.createAndConfigureFrom(spec, client);
       dependentResourcesByName.put(spec.getName(), dr);
-      if (dr instanceof Deleter && !(dr instanceof GarbageCollected)) {
+      if (DependentResource.canDeleteIfAble(dr)) {
         cleanerHolder[0] = true;
       }
     });

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/DependentResourceNode.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/DependentResourceNode.java
@@ -4,13 +4,9 @@ import java.util.List;
 import java.util.Optional;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.javaoperatorsdk.operator.api.reconciler.Context;
-import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
 
 @SuppressWarnings("rawtypes")
 public interface DependentResourceNode<R, P extends HasMetadata> {
-
-  DependentResource<R, P> getDependentResource();
 
   Optional<Condition<R, P>> getReconcilePrecondition();
 
@@ -24,7 +20,7 @@ public interface DependentResourceNode<R, P extends HasMetadata> {
 
   List<? extends DependentResourceNode> getParents();
 
-  R getSecondaryResource(P primary, Context<P> context);
-
   void addParent(DependentResourceNode parent);
+
+  String getName();
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/DependentResourceNode.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/DependentResourceNode.java
@@ -1,0 +1,30 @@
+package io.javaoperatorsdk.operator.processing.dependent.workflow;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
+
+@SuppressWarnings("rawtypes")
+public interface DependentResourceNode<R, P extends HasMetadata> {
+
+  DependentResource<R, P> getDependentResource();
+
+  Optional<Condition<R, P>> getReconcilePrecondition();
+
+  Optional<Condition<R, P>> getDeletePostcondition();
+
+  List<? extends DependentResourceNode> getDependsOn();
+
+  void addDependsOnRelation(DependentResourceNode node);
+
+  Optional<Condition<R, P>> getReadyPostcondition();
+
+  List<? extends DependentResourceNode> getParents();
+
+  R getSecondaryResource(P primary, Context<P> context);
+
+  void addParent(DependentResourceNode parent);
+}

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/DependentResourceNode.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/DependentResourceNode.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Optional;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.javaoperatorsdk.operator.api.config.dependent.DependentResourceSpec;
 
 @SuppressWarnings("rawtypes")
 public interface DependentResourceNode<R, P extends HasMetadata> {
@@ -23,4 +25,6 @@ public interface DependentResourceNode<R, P extends HasMetadata> {
   void addParent(DependentResourceNode parent);
 
   String getName();
+
+  default void resolve(KubernetesClient client, List<DependentResourceSpec> dependentResources) {}
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/ManagedWorkflow.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/ManagedWorkflow.java
@@ -1,14 +1,10 @@
 package io.javaoperatorsdk.operator.processing.dependent.workflow;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.client.KubernetesClient;
-import io.javaoperatorsdk.operator.api.config.dependent.DependentResourceSpec;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
+import java.util.Collections;
+import java.util.Map;
 
 @SuppressWarnings("rawtypes")
 public interface ManagedWorkflow<P extends HasMetadata> {
@@ -39,16 +35,6 @@ public interface ManagedWorkflow<P extends HasMetadata> {
       return Collections.emptyMap();
     }
   };
-
-  @SuppressWarnings("unchecked")
-  static ManagedWorkflow workflowFor(KubernetesClient client,
-      List<DependentResourceSpec> dependentResourceSpecs) {
-    if (dependentResourceSpecs == null || dependentResourceSpecs.isEmpty()) {
-      return noOpWorkflow;
-    }
-    return new DefaultManagedWorkflow(client, dependentResourceSpecs,
-        ManagedWorkflowSupport.instance());
-  }
 
   WorkflowReconcileResult reconcile(P primary, Context<P> context);
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/ManagedWorkflow.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/ManagedWorkflow.java
@@ -1,10 +1,11 @@
 package io.javaoperatorsdk.operator.processing.dependent.workflow;
 
+import java.util.Collections;
+import java.util.Map;
+
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
-import java.util.Collections;
-import java.util.Map;
 
 @SuppressWarnings("rawtypes")
 public interface ManagedWorkflow<P extends HasMetadata> {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/ManagedWorkflow.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/ManagedWorkflow.java
@@ -1,9 +1,12 @@
 package io.javaoperatorsdk.operator.processing.dependent.workflow;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.javaoperatorsdk.operator.api.config.dependent.DependentResourceSpec;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
 
@@ -35,6 +38,11 @@ public interface ManagedWorkflow<P extends HasMetadata> {
     public Map<String, DependentResource> getDependentResourcesByName() {
       return Collections.emptyMap();
     }
+
+    @Override
+    public ManagedWorkflow resolve(KubernetesClient client, List dependentResources) {
+      return this;
+    }
   };
 
   WorkflowReconcileResult reconcile(P primary, Context<P> context);
@@ -46,4 +54,7 @@ public interface ManagedWorkflow<P extends HasMetadata> {
   boolean isEmptyWorkflow();
 
   Map<String, DependentResource> getDependentResourcesByName();
+
+  ManagedWorkflow<P> resolve(KubernetesClient client,
+      List<DependentResourceSpec> dependentResources);
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/ManagedWorkflowFactory.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/ManagedWorkflowFactory.java
@@ -6,22 +6,17 @@ import static io.javaoperatorsdk.operator.processing.dependent.workflow.ManagedW
 
 public interface ManagedWorkflowFactory {
 
-  ManagedWorkflowFactory DEFAULT = (configuration, managedWorkflowSupport) -> {
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  ManagedWorkflowFactory DEFAULT = (configuration) -> {
     final var dependentResourceSpecs = configuration.getDependentResources();
     if (dependentResourceSpecs == null || dependentResourceSpecs.isEmpty()) {
       return noOpWorkflow;
     }
     return new DefaultManagedWorkflow(dependentResourceSpecs,
-        managedWorkflowSupport.createWorkflow(dependentResourceSpecs), managedWorkflowSupport);
+        ManagedWorkflowSupport.instance().createWorkflow(dependentResourceSpecs));
   };
 
   @SuppressWarnings("rawtypes")
-  default ManagedWorkflow workflowFor(ControllerConfiguration configuration) {
-    return workflowFor(configuration, ManagedWorkflowSupport.instance());
-  }
-
-  @SuppressWarnings("rawtypes")
-  ManagedWorkflow workflowFor(ControllerConfiguration configuration,
-      ManagedWorkflowSupport managedWorkflowSupport);
+  ManagedWorkflow workflowFor(ControllerConfiguration configuration);
 }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/ManagedWorkflowFactory.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/ManagedWorkflowFactory.java
@@ -1,25 +1,27 @@
 package io.javaoperatorsdk.operator.processing.dependent.workflow;
 
-import java.util.List;
-
-import io.fabric8.kubernetes.client.KubernetesClient;
-import io.javaoperatorsdk.operator.api.config.dependent.DependentResourceSpec;
+import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
 
 import static io.javaoperatorsdk.operator.processing.dependent.workflow.ManagedWorkflow.noOpWorkflow;
 
 public interface ManagedWorkflowFactory {
 
-  ManagedWorkflowFactory DEFAULT = (client, dependentResourceSpecs) -> {
+  ManagedWorkflowFactory DEFAULT = (configuration, managedWorkflowSupport) -> {
+    final var dependentResourceSpecs = configuration.getDependentResources();
     if (dependentResourceSpecs == null || dependentResourceSpecs.isEmpty()) {
       return noOpWorkflow;
     }
-    return new DefaultManagedWorkflow(client, dependentResourceSpecs,
-        ManagedWorkflowSupport.instance());
+    return new DefaultManagedWorkflow(dependentResourceSpecs,
+        managedWorkflowSupport.createWorkflow(dependentResourceSpecs), managedWorkflowSupport);
   };
 
+  @SuppressWarnings("rawtypes")
+  default ManagedWorkflow workflowFor(ControllerConfiguration configuration) {
+    return workflowFor(configuration, ManagedWorkflowSupport.instance());
+  }
 
   @SuppressWarnings("rawtypes")
-  ManagedWorkflow workflowFor(KubernetesClient client,
-      List<DependentResourceSpec> dependentResourceSpecs);
+  ManagedWorkflow workflowFor(ControllerConfiguration configuration,
+      ManagedWorkflowSupport managedWorkflowSupport);
 }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/ManagedWorkflowFactory.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/ManagedWorkflowFactory.java
@@ -1,0 +1,25 @@
+package io.javaoperatorsdk.operator.processing.dependent.workflow;
+
+import java.util.List;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.javaoperatorsdk.operator.api.config.dependent.DependentResourceSpec;
+
+import static io.javaoperatorsdk.operator.processing.dependent.workflow.ManagedWorkflow.noOpWorkflow;
+
+public interface ManagedWorkflowFactory {
+
+  ManagedWorkflowFactory DEFAULT = (client, dependentResourceSpecs) -> {
+    if (dependentResourceSpecs == null || dependentResourceSpecs.isEmpty()) {
+      return noOpWorkflow;
+    }
+    return new DefaultManagedWorkflow(client, dependentResourceSpecs,
+        ManagedWorkflowSupport.instance());
+  };
+
+
+  @SuppressWarnings("rawtypes")
+  ManagedWorkflow workflowFor(KubernetesClient client,
+      List<DependentResourceSpec> dependentResourceSpecs);
+}
+

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/ManagedWorkflowSupport.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/ManagedWorkflowSupport.java
@@ -10,12 +10,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.OperatorException;
 import io.javaoperatorsdk.operator.api.config.dependent.DependentResourceSpec;
-import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
-import io.javaoperatorsdk.operator.api.reconciler.dependent.EventSourceReferencer;
-import io.javaoperatorsdk.operator.api.reconciler.dependent.managed.KubernetesClientAware;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
 class ManagedWorkflowSupport {
@@ -71,30 +67,6 @@ class ManagedWorkflowSupport {
       node.addDependsOnRelation(dependsOn);
     });
     return node;
-  }
-
-  @SuppressWarnings({"rawtypes"})
-  public DependentResource createAndConfigureFrom(DependentResourceSpec spec,
-      KubernetesClient client) {
-    final var dependentResource = spec.getDependentResource();
-
-    if (dependentResource instanceof KubernetesClientAware) {
-      ((KubernetesClientAware) dependentResource).setKubernetesClient(client);
-    }
-
-    spec.getUseEventSourceWithName()
-        .ifPresent(esName -> {
-          final var name = (String) esName;
-          if (dependentResource instanceof EventSourceReferencer) {
-            ((EventSourceReferencer) dependentResource).useEventSourceWithName(name);
-          } else {
-            throw new IllegalStateException(
-                "DependentResource " + spec + " wants to use EventSource named " + name
-                    + " but doesn't implement support for this feature by implementing "
-                    + EventSourceReferencer.class.getSimpleName());
-          }
-        });
-    return dependentResource;
   }
 
   /**

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/NodeExecutor.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/NodeExecutor.java
@@ -1,0 +1,33 @@
+package io.javaoperatorsdk.operator.processing.dependent.workflow;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
+
+abstract class NodeExecutor<R, P extends HasMetadata> implements Runnable {
+
+  private final DependentResourceNode<R, P> dependentResourceNode;
+  private final AbstractWorkflowExecutor<P> workflowExecutor;
+
+  protected NodeExecutor(DependentResourceNode<R, P> dependentResourceNode,
+      AbstractWorkflowExecutor<P> workflowExecutor) {
+    this.dependentResourceNode = dependentResourceNode;
+    this.workflowExecutor = workflowExecutor;
+  }
+
+  @Override
+  public void run() {
+    try {
+      var dependentResource = workflowExecutor.getDependentResourceFor(dependentResourceNode);
+
+      doRun(dependentResourceNode, dependentResource);
+
+    } catch (RuntimeException e) {
+      workflowExecutor.handleExceptionInExecutor(dependentResourceNode, e);
+    } finally {
+      workflowExecutor.handleNodeExecutionFinish(dependentResourceNode);
+    }
+  }
+
+  protected abstract void doRun(DependentResourceNode<R, P> dependentResourceNode,
+      DependentResource<R, P> dependentResource);
+}

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/SpecDependentResourceNode.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/SpecDependentResourceNode.java
@@ -1,0 +1,63 @@
+package io.javaoperatorsdk.operator.processing.dependent.workflow;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.javaoperatorsdk.operator.api.config.dependent.DependentResourceSpec;
+
+@SuppressWarnings("rawtypes")
+public class SpecDependentResourceNode<R, P extends HasMetadata>
+    implements DependentResourceNode<R, P> {
+
+  private final DependentResourceSpec<R, P, ?> spec;
+  private final List<DependentResourceNode> dependsOn = new LinkedList<>();
+  private final List<DependentResourceNode> parents = new LinkedList<>();
+
+  public SpecDependentResourceNode(DependentResourceSpec<R, P, ?> spec) {
+    this.spec = spec;
+  }
+
+  @Override
+  public Optional<Condition<R, P>> getReconcilePrecondition() {
+    return Optional.ofNullable(spec.getReconcileCondition());
+  }
+
+  @Override
+  public Optional<Condition<R, P>> getDeletePostcondition() {
+    return Optional.ofNullable(spec.getDeletePostCondition());
+  }
+
+  @Override
+  public List<? extends DependentResourceNode> getDependsOn() {
+    return dependsOn;
+  }
+
+  @Override
+  public void addDependsOnRelation(DependentResourceNode node) {
+    node.addParent(this);
+    dependsOn.add(node);
+  }
+
+  @Override
+  public Optional<Condition<R, P>> getReadyPostcondition() {
+    return Optional.ofNullable(spec.getReadyCondition());
+  }
+
+  @Override
+  public List<? extends DependentResourceNode> getParents() {
+    return parents;
+  }
+
+
+  @Override
+  public void addParent(DependentResourceNode parent) {
+    parents.add(parent);
+  }
+
+  @Override
+  public String getName() {
+    return spec.getName();
+  }
+}

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/SpecDependentResourceNode.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/SpecDependentResourceNode.java
@@ -6,7 +6,7 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.config.dependent.DependentResourceSpec;
 
-public class SpecDependentResourceNode<R, P extends HasMetadata>
+class SpecDependentResourceNode<R, P extends HasMetadata>
     extends AbstractDependentResourceNode<R, P> {
   @SuppressWarnings("unchecked")
   public SpecDependentResourceNode(DependentResourceSpec<R, P, ?> spec) {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/SpecDependentResourceNode.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/SpecDependentResourceNode.java
@@ -1,6 +1,9 @@
 package io.javaoperatorsdk.operator.processing.dependent.workflow;
 
+import java.util.List;
+
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.config.dependent.DependentResourceSpec;
 
 public class SpecDependentResourceNode<R, P extends HasMetadata>
@@ -11,5 +14,14 @@ public class SpecDependentResourceNode<R, P extends HasMetadata>
     setReadyPostcondition(spec.getReadyCondition());
     setDeletePostcondition(spec.getDeletePostCondition());
     setReconcilePrecondition(spec.getReconcileCondition());
+  }
+
+  @Override
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  public void resolve(KubernetesClient client, List<DependentResourceSpec> dependentResources) {
+    final var spec = dependentResources.stream()
+        .filter(drs -> drs.getName().equals(getName()))
+        .findFirst().orElseThrow();
+    setDependentResource(ManagedWorkflowSupport.instance().createAndConfigureFrom(spec, client));
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/SpecDependentResourceNode.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/SpecDependentResourceNode.java
@@ -1,63 +1,15 @@
 package io.javaoperatorsdk.operator.processing.dependent.workflow;
 
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Optional;
-
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.javaoperatorsdk.operator.api.config.dependent.DependentResourceSpec;
 
-@SuppressWarnings("rawtypes")
 public class SpecDependentResourceNode<R, P extends HasMetadata>
-    implements DependentResourceNode<R, P> {
-
-  private final DependentResourceSpec<R, P, ?> spec;
-  private final List<DependentResourceNode> dependsOn = new LinkedList<>();
-  private final List<DependentResourceNode> parents = new LinkedList<>();
-
+    extends AbstractDependentResourceNode<R, P> {
+  @SuppressWarnings("unchecked")
   public SpecDependentResourceNode(DependentResourceSpec<R, P, ?> spec) {
-    this.spec = spec;
-  }
-
-  @Override
-  public Optional<Condition<R, P>> getReconcilePrecondition() {
-    return Optional.ofNullable(spec.getReconcileCondition());
-  }
-
-  @Override
-  public Optional<Condition<R, P>> getDeletePostcondition() {
-    return Optional.ofNullable(spec.getDeletePostCondition());
-  }
-
-  @Override
-  public List<? extends DependentResourceNode> getDependsOn() {
-    return dependsOn;
-  }
-
-  @Override
-  public void addDependsOnRelation(DependentResourceNode node) {
-    node.addParent(this);
-    dependsOn.add(node);
-  }
-
-  @Override
-  public Optional<Condition<R, P>> getReadyPostcondition() {
-    return Optional.ofNullable(spec.getReadyCondition());
-  }
-
-  @Override
-  public List<? extends DependentResourceNode> getParents() {
-    return parents;
-  }
-
-
-  @Override
-  public void addParent(DependentResourceNode parent) {
-    parents.add(parent);
-  }
-
-  @Override
-  public String getName() {
-    return spec.getName();
+    super(spec.getName());
+    setReadyPostcondition(spec.getReadyCondition());
+    setDeletePostcondition(spec.getDeletePostCondition());
+    setReconcilePrecondition(spec.getReconcileCondition());
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/Workflow.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/Workflow.java
@@ -132,7 +132,7 @@ public class Workflow<P extends HasMetadata> {
           .forEach(drn -> {
             drn.resolve(client, dependentResources);
             final var dr = dependentResource(drn);
-            if (DependentResource.isDeletable(dr)) {
+            if (dr.isDeletable()) {
               cleanerHolder[0] = true;
             }
           });

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/Workflow.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/Workflow.java
@@ -1,10 +1,12 @@
 package io.javaoperatorsdk.operator.processing.dependent.workflow;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
@@ -24,33 +26,45 @@ public class Workflow<P extends HasMetadata> {
 
   public static final boolean THROW_EXCEPTION_AUTOMATICALLY_DEFAULT = true;
 
-  private final Map<String, ResolvedNode> dependentResourceNodes;
+  private final Map<String, DependentResourceNode> dependentResourceNodes;
   private final Set<DependentResourceNode> topLevelResources = new HashSet<>();
   private final Set<DependentResourceNode> bottomLevelResource = new HashSet<>();
 
   private final boolean throwExceptionAutomatically;
   // it's "global" executor service shared between multiple reconciliations running parallel
   private final ExecutorService executorService;
+  private boolean resolved;
 
   public Workflow(Set<DependentResourceNode> dependentResourceNodes) {
     this(dependentResourceNodes, ExecutorServiceManager.instance().workflowExecutorService(),
-        THROW_EXCEPTION_AUTOMATICALLY_DEFAULT);
+        THROW_EXCEPTION_AUTOMATICALLY_DEFAULT, false);
   }
 
   public Workflow(Set<DependentResourceNode> dependentResourceNodes,
-      ExecutorService executorService, boolean throwExceptionAutomatically) {
+      ExecutorService executorService, boolean throwExceptionAutomatically, boolean resolved) {
     this.executorService = executorService;
     this.dependentResourceNodes = dependentResourceNodes.stream()
-        .collect(Collectors.toMap(DependentResourceNode::getName, ResolvedNode::new));
+        .collect(Collectors.toMap(DependentResourceNode::getName, Function.identity()));
     this.throwExceptionAutomatically = throwExceptionAutomatically;
+    this.resolved = resolved;
     preprocessForReconcile();
   }
 
   public DependentResource getDependentResourceFor(DependentResourceNode node) {
-    return dependentResourceNodes.get(node.getName()).dependentResource();
+    throwIfUnresolved();
+    return ((AbstractDependentResourceNode) dependentResourceNodes.get(node.getName()))
+        .getDependentResource();
+  }
+
+  private void throwIfUnresolved() {
+    if (!resolved) {
+      throw new IllegalStateException(
+          "Should call resolved before trying to access DependentResources");
+    }
   }
 
   public WorkflowReconcileResult reconcile(P primary, Context<P> context) {
+    throwIfUnresolved();
     WorkflowReconcileExecutor<P> workflowReconcileExecutor =
         new WorkflowReconcileExecutor<>(this, primary, context);
     var result = workflowReconcileExecutor.reconcile();
@@ -61,6 +75,7 @@ public class Workflow<P extends HasMetadata> {
   }
 
   public WorkflowCleanupResult cleanup(P primary, Context<P> context) {
+    throwIfUnresolved();
     WorkflowCleanupExecutor<P> workflowCleanupExecutor =
         new WorkflowCleanupExecutor<>(this, primary, context);
     var result = workflowCleanupExecutor.cleanup();
@@ -73,8 +88,7 @@ public class Workflow<P extends HasMetadata> {
   // add cycle detection?
   @SuppressWarnings("unchecked")
   private void preprocessForReconcile() {
-    final var nodes = dependentResourceNodes.values().stream()
-        .map(ResolvedNode::node).collect(Collectors.toList());
+    final var nodes = new ArrayList<>(dependentResourceNodes.values());
     bottomLevelResource.addAll(nodes);
     for (DependentResourceNode<?, P> node : nodes) {
       if (node.getDependsOn().isEmpty()) {
@@ -100,43 +114,14 @@ public class Workflow<P extends HasMetadata> {
   }
 
   Set<DependentResourceNode> nodes() {
-    return dependentResourceNodes.values().stream().map(ResolvedNode::node)
-        .collect(Collectors.toSet());
+    return new HashSet<>(dependentResourceNodes.values());
   }
 
+  @SuppressWarnings("unchecked")
   public void resolve(KubernetesClient client, List<DependentResourceSpec> dependentResources) {
-    dependentResourceNodes.values().forEach(drn -> drn.resolve(client, dependentResources));
-  }
-
-  private static class ResolvedNode {
-
-    private final DependentResourceNode node;
-    private DependentResource dependentResource;
-
-    private ResolvedNode(DependentResourceNode node) {
-      this.node = node;
-      if (node instanceof DefaultDependentResourceNode) {
-        this.dependentResource = ((DefaultDependentResourceNode) node).getDependentResource();
-      }
-    }
-
-    public void setDependentResource(DependentResource dependentResource) {
-      this.dependentResource = dependentResource;
-    }
-
-    public DependentResource dependentResource() {
-      return dependentResource;
-    }
-
-    public DependentResourceNode node() {
-      return node;
-    }
-
-    public void resolve(KubernetesClient client, List<DependentResourceSpec> dependentResources) {
-      final var spec = dependentResources.stream()
-          .filter(drs -> drs.getName().equals(node.getName()))
-          .findFirst().orElseThrow();
-      dependentResource = ManagedWorkflowSupport.instance().createAndConfigureFrom(spec, client);
+    if (!resolved) {
+      dependentResourceNodes.values().forEach(drn -> drn.resolve(client, dependentResources));
+      resolved = true;
     }
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/Workflow.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/Workflow.java
@@ -21,22 +21,22 @@ public class Workflow<P extends HasMetadata> {
 
   public static final boolean THROW_EXCEPTION_AUTOMATICALLY_DEFAULT = true;
 
-  private final Set<DefaultDependentResourceNode> dependentResourceNodes;
-  private final Set<DefaultDependentResourceNode> topLevelResources = new HashSet<>();
-  private final Set<DefaultDependentResourceNode> bottomLevelResource = new HashSet<>();
+  private final Set<DependentResourceNode> dependentResourceNodes;
+  private final Set<DependentResourceNode> topLevelResources = new HashSet<>();
+  private final Set<DependentResourceNode> bottomLevelResource = new HashSet<>();
 
   private final boolean throwExceptionAutomatically;
   // it's "global" executor service shared between multiple reconciliations running parallel
   private final ExecutorService executorService;
 
-  public Workflow(Set<DefaultDependentResourceNode> dependentResourceNodes) {
+  public Workflow(Set<DependentResourceNode> dependentResourceNodes) {
     this.executorService = ExecutorServiceManager.instance().workflowExecutorService();
     this.dependentResourceNodes = dependentResourceNodes;
     this.throwExceptionAutomatically = THROW_EXCEPTION_AUTOMATICALLY_DEFAULT;
     preprocessForReconcile();
   }
 
-  public Workflow(Set<DefaultDependentResourceNode> dependentResourceNodes,
+  public Workflow(Set<DependentResourceNode> dependentResourceNodes,
       ExecutorService executorService, boolean throwExceptionAutomatically) {
     this.executorService = executorService;
     this.dependentResourceNodes = dependentResourceNodes;
@@ -44,7 +44,7 @@ public class Workflow<P extends HasMetadata> {
     preprocessForReconcile();
   }
 
-  public Workflow(Set<DefaultDependentResourceNode> dependentResourceNodes, int globalParallelism) {
+  public Workflow(Set<DependentResourceNode> dependentResourceNodes, int globalParallelism) {
     this(dependentResourceNodes, Executors.newFixedThreadPool(globalParallelism), true);
   }
 
@@ -72,22 +72,22 @@ public class Workflow<P extends HasMetadata> {
   @SuppressWarnings("unchecked")
   private void preprocessForReconcile() {
     bottomLevelResource.addAll(dependentResourceNodes);
-    for (DefaultDependentResourceNode<?, P> node : dependentResourceNodes) {
+    for (DependentResourceNode<?, P> node : dependentResourceNodes) {
       if (node.getDependsOn().isEmpty()) {
         topLevelResources.add(node);
       } else {
-        for (DefaultDependentResourceNode dependsOn : node.getDependsOn()) {
+        for (DependentResourceNode dependsOn : node.getDependsOn()) {
           bottomLevelResource.remove(dependsOn);
         }
       }
     }
   }
 
-  Set<DefaultDependentResourceNode> getTopLevelDependentResources() {
+  Set<DependentResourceNode> getTopLevelDependentResources() {
     return topLevelResources;
   }
 
-  Set<DefaultDependentResourceNode> getBottomLevelResource() {
+  Set<DependentResourceNode> getBottomLevelResource() {
     return bottomLevelResource;
   }
 
@@ -96,7 +96,7 @@ public class Workflow<P extends HasMetadata> {
   }
 
   public Set<DependentResource> getDependentResources() {
-    return dependentResourceNodes.stream().map(DefaultDependentResourceNode::getDependentResource)
+    return dependentResourceNodes.stream().map(DependentResourceNode::getDependentResource)
         .collect(Collectors.toSet());
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/Workflow.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/Workflow.java
@@ -21,22 +21,22 @@ public class Workflow<P extends HasMetadata> {
 
   public static final boolean THROW_EXCEPTION_AUTOMATICALLY_DEFAULT = true;
 
-  private final Set<DependentResourceNode> dependentResourceNodes;
-  private final Set<DependentResourceNode> topLevelResources = new HashSet<>();
-  private final Set<DependentResourceNode> bottomLevelResource = new HashSet<>();
+  private final Set<DefaultDependentResourceNode> dependentResourceNodes;
+  private final Set<DefaultDependentResourceNode> topLevelResources = new HashSet<>();
+  private final Set<DefaultDependentResourceNode> bottomLevelResource = new HashSet<>();
 
   private final boolean throwExceptionAutomatically;
   // it's "global" executor service shared between multiple reconciliations running parallel
   private ExecutorService executorService;
 
-  public Workflow(Set<DependentResourceNode> dependentResourceNodes) {
+  public Workflow(Set<DefaultDependentResourceNode> dependentResourceNodes) {
     this.executorService = ExecutorServiceManager.instance().workflowExecutorService();
     this.dependentResourceNodes = dependentResourceNodes;
     this.throwExceptionAutomatically = THROW_EXCEPTION_AUTOMATICALLY_DEFAULT;
     preprocessForReconcile();
   }
 
-  public Workflow(Set<DependentResourceNode> dependentResourceNodes,
+  public Workflow(Set<DefaultDependentResourceNode> dependentResourceNodes,
       ExecutorService executorService, boolean throwExceptionAutomatically) {
     this.executorService = executorService;
     this.dependentResourceNodes = dependentResourceNodes;
@@ -44,7 +44,7 @@ public class Workflow<P extends HasMetadata> {
     preprocessForReconcile();
   }
 
-  public Workflow(Set<DependentResourceNode> dependentResourceNodes, int globalParallelism) {
+  public Workflow(Set<DefaultDependentResourceNode> dependentResourceNodes, int globalParallelism) {
     this(dependentResourceNodes, Executors.newFixedThreadPool(globalParallelism), true);
   }
 
@@ -69,13 +69,14 @@ public class Workflow<P extends HasMetadata> {
   }
 
   // add cycle detection?
+  @SuppressWarnings("unchecked")
   private void preprocessForReconcile() {
     bottomLevelResource.addAll(dependentResourceNodes);
-    for (DependentResourceNode<?, P> node : dependentResourceNodes) {
+    for (DefaultDependentResourceNode<?, P> node : dependentResourceNodes) {
       if (node.getDependsOn().isEmpty()) {
         topLevelResources.add(node);
       } else {
-        for (DependentResourceNode dependsOn : node.getDependsOn()) {
+        for (DefaultDependentResourceNode dependsOn : node.getDependsOn()) {
           bottomLevelResource.remove(dependsOn);
         }
       }
@@ -90,11 +91,11 @@ public class Workflow<P extends HasMetadata> {
     this.executorService = executorService;
   }
 
-  Set<DependentResourceNode> getTopLevelDependentResources() {
+  Set<DefaultDependentResourceNode> getTopLevelDependentResources() {
     return topLevelResources;
   }
 
-  Set<DependentResourceNode> getBottomLevelResource() {
+  Set<DefaultDependentResourceNode> getBottomLevelResource() {
     return bottomLevelResource;
   }
 
@@ -103,7 +104,7 @@ public class Workflow<P extends HasMetadata> {
   }
 
   public Set<DependentResource> getDependentResources() {
-    return dependentResourceNodes.stream().map(DependentResourceNode::getDependentResource)
+    return dependentResourceNodes.stream().map(DefaultDependentResourceNode::getDependentResource)
         .collect(Collectors.toSet());
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/Workflow.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/Workflow.java
@@ -132,7 +132,7 @@ public class Workflow<P extends HasMetadata> {
           .forEach(drn -> {
             drn.resolve(client, dependentResources);
             final var dr = dependentResource(drn);
-            if (DependentResource.canDeleteIfAble(dr)) {
+            if (DependentResource.isDeletable(dr)) {
               cleanerHolder[0] = true;
             }
           });

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/Workflow.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/Workflow.java
@@ -35,12 +35,12 @@ public class Workflow<P extends HasMetadata> {
   private final ExecutorService executorService;
   private boolean resolved;
 
-  public Workflow(Set<DependentResourceNode> dependentResourceNodes) {
+  Workflow(Set<DependentResourceNode> dependentResourceNodes) {
     this(dependentResourceNodes, ExecutorServiceManager.instance().workflowExecutorService(),
         THROW_EXCEPTION_AUTOMATICALLY_DEFAULT, false);
   }
 
-  public Workflow(Set<DependentResourceNode> dependentResourceNodes,
+  Workflow(Set<DependentResourceNode> dependentResourceNodes,
       ExecutorService executorService, boolean throwExceptionAutomatically, boolean resolved) {
     this.executorService = executorService;
     this.dependentResourceNodes = dependentResourceNodes.stream()

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/Workflow.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/Workflow.java
@@ -27,7 +27,7 @@ public class Workflow<P extends HasMetadata> {
 
   private final boolean throwExceptionAutomatically;
   // it's "global" executor service shared between multiple reconciliations running parallel
-  private ExecutorService executorService;
+  private final ExecutorService executorService;
 
   public Workflow(Set<DefaultDependentResourceNode> dependentResourceNodes) {
     this.executorService = ExecutorServiceManager.instance().workflowExecutorService();
@@ -81,14 +81,6 @@ public class Workflow<P extends HasMetadata> {
         }
       }
     }
-  }
-
-  public boolean isThrowExceptionAutomatically() {
-    return throwExceptionAutomatically;
-  }
-
-  public void setExecutorService(ExecutorService executorService) {
-    this.executorService = executorService;
   }
 
   Set<DefaultDependentResourceNode> getTopLevelDependentResources() {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowBuilder.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowBuilder.java
@@ -25,7 +25,7 @@ public class WorkflowBuilder<P extends HasMetadata> {
 
   public WorkflowBuilder<P> addDependentResource(DependentResource dependentResource) {
     currentNode = new DefaultDependentResourceNode<>(dependentResource);
-    isCleaner = DependentResource.canDeleteIfAble(dependentResource);
+    isCleaner = DependentResource.isDeletable(dependentResource);
     final var name = currentNode.getName();
     dependentResourceNodes.put(name, currentNode);
     return this;

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowBuilder.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowBuilder.java
@@ -17,11 +17,12 @@ public class WorkflowBuilder<P extends HasMetadata> {
 
   private final Set<DefaultDependentResourceNode<?, P>> dependentResourceNodes = new HashSet<>();
   private boolean throwExceptionAutomatically = THROW_EXCEPTION_AUTOMATICALLY_DEFAULT;
-
   private DefaultDependentResourceNode currentNode;
+  private boolean isCleaner = false;
 
   public WorkflowBuilder<P> addDependentResource(DependentResource dependentResource) {
     currentNode = new DefaultDependentResourceNode<>(dependentResource);
+    isCleaner = DependentResource.canDeleteIfAble(dependentResource);
     dependentResourceNodes.add(currentNode);
     return this;
   }
@@ -82,6 +83,7 @@ public class WorkflowBuilder<P extends HasMetadata> {
 
   public Workflow<P> build(ExecutorService executorService) {
     // workflow has been built from dependent resources so it is already resolved
-    return new Workflow(dependentResourceNodes, executorService, throwExceptionAutomatically, true);
+    return new Workflow(dependentResourceNodes, executorService,
+        throwExceptionAutomatically, true, isCleaner);
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowBuilder.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowBuilder.java
@@ -25,7 +25,7 @@ public class WorkflowBuilder<P extends HasMetadata> {
 
   public WorkflowBuilder<P> addDependentResource(DependentResource dependentResource) {
     currentNode = new DefaultDependentResourceNode<>(dependentResource);
-    isCleaner = DependentResource.isDeletable(dependentResource);
+    isCleaner = dependentResource.isDeletable();
     final var name = currentNode.getName();
     dependentResourceNodes.put(name, currentNode);
     return this;

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowBuilder.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowBuilder.java
@@ -1,4 +1,4 @@
-package io.javaoperatorsdk.operator.processing.dependent.workflow.builder;
+package io.javaoperatorsdk.operator.processing.dependent.workflow;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -9,10 +9,6 @@ import java.util.concurrent.Executors;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.javaoperatorsdk.operator.api.config.ExecutorServiceManager;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
-import io.javaoperatorsdk.operator.processing.dependent.workflow.Condition;
-import io.javaoperatorsdk.operator.processing.dependent.workflow.DefaultDependentResourceNode;
-import io.javaoperatorsdk.operator.processing.dependent.workflow.DependentResourceNode;
-import io.javaoperatorsdk.operator.processing.dependent.workflow.Workflow;
 
 import static io.javaoperatorsdk.operator.processing.dependent.workflow.Workflow.THROW_EXCEPTION_AUTOMATICALLY_DEFAULT;
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowCleanupExecutor.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowCleanupExecutor.java
@@ -13,7 +13,6 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.Deleter;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
-import io.javaoperatorsdk.operator.api.reconciler.dependent.GarbageCollected;
 
 @SuppressWarnings("rawtypes")
 public class WorkflowCleanupExecutor<P extends HasMetadata> extends AbstractWorkflowExecutor<P> {
@@ -72,8 +71,7 @@ public class WorkflowCleanupExecutor<P extends HasMetadata> extends AbstractWork
         DependentResource<R, P> dependentResource) {
       var deletePostCondition = dependentResourceNode.getDeletePostcondition();
 
-      if (dependentResource instanceof Deleter
-          && !(dependentResource instanceof GarbageCollected)) {
+      if (DependentResource.canDeleteIfAble(dependentResource)) {
         ((Deleter<P>) dependentResource).delete(primary, context);
         deleteCalled.add(dependentResourceNode);
       }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowCleanupExecutor.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowCleanupExecutor.java
@@ -71,7 +71,7 @@ public class WorkflowCleanupExecutor<P extends HasMetadata> extends AbstractWork
         DependentResource<R, P> dependentResource) {
       var deletePostCondition = dependentResourceNode.getDeletePostcondition();
 
-      if (DependentResource.canDeleteIfAble(dependentResource)) {
+      if (DependentResource.isDeletable(dependentResource)) {
         ((Deleter<P>) dependentResource).delete(primary, context);
         deleteCalled.add(dependentResourceNode);
       }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowCleanupExecutor.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowCleanupExecutor.java
@@ -22,14 +22,14 @@ public class WorkflowCleanupExecutor<P extends HasMetadata> {
 
   private static final Logger log = LoggerFactory.getLogger(WorkflowCleanupExecutor.class);
 
-  private final Map<DefaultDependentResourceNode, Future<?>> actualExecutions =
+  private final Map<DependentResourceNode, Future<?>> actualExecutions =
       new ConcurrentHashMap<>();
-  private final Map<DefaultDependentResourceNode, Exception> exceptionsDuringExecution =
+  private final Map<DependentResourceNode, Exception> exceptionsDuringExecution =
       new ConcurrentHashMap<>();
-  private final Set<DefaultDependentResourceNode> alreadyVisited = ConcurrentHashMap.newKeySet();
-  private final Set<DefaultDependentResourceNode> postDeleteConditionNotMet =
+  private final Set<DependentResourceNode> alreadyVisited = ConcurrentHashMap.newKeySet();
+  private final Set<DependentResourceNode> postDeleteConditionNotMet =
       ConcurrentHashMap.newKeySet();
-  private final Set<DefaultDependentResourceNode> deleteCalled = ConcurrentHashMap.newKeySet();
+  private final Set<DependentResourceNode> deleteCalled = ConcurrentHashMap.newKeySet();
 
   private final Workflow<P> workflow;
   private final P primary;
@@ -42,7 +42,7 @@ public class WorkflowCleanupExecutor<P extends HasMetadata> {
   }
 
   public synchronized WorkflowCleanupResult cleanup() {
-    for (DefaultDependentResourceNode dependentResourceNode : workflow
+    for (DependentResourceNode dependentResourceNode : workflow
         .getBottomLevelResource()) {
       handleCleanup(dependentResourceNode);
     }
@@ -67,7 +67,7 @@ public class WorkflowCleanupExecutor<P extends HasMetadata> {
   }
 
   @SuppressWarnings({"rawtypes", "unchecked"})
-  private synchronized void handleCleanup(DefaultDependentResourceNode dependentResourceNode) {
+  private synchronized void handleCleanup(DependentResourceNode dependentResourceNode) {
     log.debug("Submitting for cleanup: {}", dependentResourceNode);
 
     if (alreadyVisited(dependentResourceNode)
@@ -86,9 +86,9 @@ public class WorkflowCleanupExecutor<P extends HasMetadata> {
 
   private class NodeExecutor<R> implements Runnable {
 
-    private final DefaultDependentResourceNode<R, P> dependentResourceNode;
+    private final DependentResourceNode<R, P> dependentResourceNode;
 
-    private NodeExecutor(DefaultDependentResourceNode<R, P> dependentResourceNode) {
+    private NodeExecutor(DependentResourceNode<R, P> dependentResourceNode) {
       this.dependentResourceNode = dependentResourceNode;
     }
 
@@ -128,7 +128,7 @@ public class WorkflowCleanupExecutor<P extends HasMetadata> {
 
 
   private synchronized void handleDependentCleaned(
-      DefaultDependentResourceNode<?, P> dependentResourceNode) {
+      DependentResourceNode<?, P> dependentResourceNode) {
     var dependOns = dependentResourceNode.getDependsOn();
     if (dependOns != null) {
       dependOns.forEach(d -> {
@@ -139,13 +139,13 @@ public class WorkflowCleanupExecutor<P extends HasMetadata> {
   }
 
   private synchronized void handleExceptionInExecutor(
-      DefaultDependentResourceNode<?, P> dependentResourceNode,
+      DependentResourceNode<?, P> dependentResourceNode,
       RuntimeException e) {
     exceptionsDuringExecution.put(dependentResourceNode, e);
   }
 
   private synchronized void handleNodeExecutionFinish(
-      DefaultDependentResourceNode<?, P> dependentResourceNode) {
+      DependentResourceNode<?, P> dependentResourceNode) {
     log.debug("Finished execution for: {}", dependentResourceNode);
     actualExecutions.remove(dependentResourceNode);
     if (actualExecutions.isEmpty()) {
@@ -153,25 +153,25 @@ public class WorkflowCleanupExecutor<P extends HasMetadata> {
     }
   }
 
-  private boolean isCleaningNow(DefaultDependentResourceNode<?, ?> dependentResourceNode) {
+  private boolean isCleaningNow(DependentResourceNode<?, ?> dependentResourceNode) {
     return actualExecutions.containsKey(dependentResourceNode);
   }
 
-  private boolean alreadyVisited(DefaultDependentResourceNode dependentResourceNode) {
+  private boolean alreadyVisited(DependentResourceNode dependentResourceNode) {
     return alreadyVisited.contains(dependentResourceNode);
   }
 
   @SuppressWarnings("unchecked")
-  private boolean allDependentsCleaned(DefaultDependentResourceNode dependentResourceNode) {
-    List<DefaultDependentResourceNode> parents = dependentResourceNode.getParents();
+  private boolean allDependentsCleaned(DependentResourceNode dependentResourceNode) {
+    List<DependentResourceNode> parents = dependentResourceNode.getParents();
     return parents.isEmpty()
         || parents.stream()
         .allMatch(d -> alreadyVisited(d) && !postDeleteConditionNotMet.contains(d));
   }
 
   @SuppressWarnings("unchecked")
-  private boolean hasErroredDependent(DefaultDependentResourceNode dependentResourceNode) {
-    List<DefaultDependentResourceNode> parents = dependentResourceNode.getParents();
+  private boolean hasErroredDependent(DependentResourceNode dependentResourceNode) {
+    List<DependentResourceNode> parents = dependentResourceNode.getParents();
     return !parents.isEmpty()
         && parents.stream().anyMatch(exceptionsDuringExecution::containsKey);
   }
@@ -180,10 +180,10 @@ public class WorkflowCleanupExecutor<P extends HasMetadata> {
     final var erroredDependents = exceptionsDuringExecution.entrySet().stream()
         .collect(Collectors.toMap(e -> e.getKey().getDependentResource(), Entry::getValue));
     final var postConditionNotMet = postDeleteConditionNotMet.stream()
-        .map(DefaultDependentResourceNode::getDependentResource)
+        .map(DependentResourceNode::getDependentResource)
         .collect(Collectors.toList());
     final var deleteCalled =
-        this.deleteCalled.stream().map(DefaultDependentResourceNode::getDependentResource)
+        this.deleteCalled.stream().map(DependentResourceNode::getDependentResource)
             .collect(Collectors.toList());
     return new WorkflowCleanupResult(erroredDependents, postConditionNotMet, deleteCalled);
   }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowCleanupExecutor.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowCleanupExecutor.java
@@ -71,7 +71,7 @@ public class WorkflowCleanupExecutor<P extends HasMetadata> extends AbstractWork
         DependentResource<R, P> dependentResource) {
       var deletePostCondition = dependentResourceNode.getDeletePostcondition();
 
-      if (DependentResource.isDeletable(dependentResource)) {
+      if (dependentResource.isDeletable()) {
         ((Deleter<P>) dependentResource).delete(primary, context);
         deleteCalled.add(dependentResourceNode);
       }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowCleanupExecutor.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowCleanupExecutor.java
@@ -167,7 +167,7 @@ public class WorkflowCleanupExecutor<P extends HasMetadata> {
     List<DependentResourceNode> parents = dependentResourceNode.getParents();
     return parents.isEmpty()
         || parents.stream()
-        .allMatch(d -> alreadyVisited(d) && !postDeleteConditionNotMet.contains(d));
+            .allMatch(d -> alreadyVisited(d) && !postDeleteConditionNotMet.contains(d));
   }
 
   @SuppressWarnings("unchecked")

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowReconcileExecutor.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowReconcileExecutor.java
@@ -14,7 +14,6 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.Deleter;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
-import io.javaoperatorsdk.operator.api.reconciler.dependent.GarbageCollected;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.ReconcileResult;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 
@@ -149,8 +148,7 @@ public class WorkflowReconcileExecutor<P extends HasMetadata> extends AbstractWo
         DependentResource<R, P> dependentResource) {
       var deletePostCondition = dependentResourceNode.getDeletePostcondition();
 
-      if (dependentResource instanceof Deleter
-          && !(dependentResource instanceof GarbageCollected)) {
+      if (DependentResource.canDeleteIfAble(dependentResource)) {
         ((Deleter<P>) dependentResource).delete(primary, context);
       }
       boolean deletePostConditionMet = isConditionMet(deletePostCondition, dependentResource);
@@ -210,7 +208,7 @@ public class WorkflowReconcileExecutor<P extends HasMetadata> extends AbstractWo
   private boolean hasErroredParent(DependentResourceNode<?, ?> dependentResourceNode) {
     return !dependentResourceNode.getDependsOn().isEmpty()
         && dependentResourceNode.getDependsOn().stream()
-        .anyMatch(this::isInError);
+            .anyMatch(this::isInError);
   }
 
   private WorkflowReconcileResult createReconcileResult() {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowReconcileExecutor.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowReconcileExecutor.java
@@ -1,6 +1,5 @@
 package io.javaoperatorsdk.operator.processing.dependent.workflow;
 
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -20,20 +19,12 @@ import io.javaoperatorsdk.operator.api.reconciler.dependent.ReconcileResult;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
-public class WorkflowReconcileExecutor<P extends HasMetadata> {
+public class WorkflowReconcileExecutor<P extends HasMetadata> extends AbstractWorkflowExecutor<P> {
 
   private static final Logger log = LoggerFactory.getLogger(WorkflowReconcileExecutor.class);
 
-  private final Workflow<P> workflow;
 
-  /**
-   * Covers both deleted and reconciled
-   */
-  private final Set<DependentResourceNode> alreadyVisited = ConcurrentHashMap.newKeySet();
   private final Set<DependentResourceNode> notReady = ConcurrentHashMap.newKeySet();
-  private final Map<DependentResourceNode, Future<?>> actualExecutions = new HashMap<>();
-  private final Map<DependentResourceNode, Exception> exceptionsDuringExecution =
-      new ConcurrentHashMap<>();
 
   private final Set<DependentResourceNode> markedForDelete = ConcurrentHashMap.newKeySet();
   private final Set<DependentResourceNode> deletePostConditionNotMet =
@@ -43,41 +34,28 @@ public class WorkflowReconcileExecutor<P extends HasMetadata> {
   private final Map<DependentResource, ReconcileResult> reconcileResults =
       new ConcurrentHashMap<>();
 
-  private final P primary;
-  private final Context<P> context;
-
   public WorkflowReconcileExecutor(Workflow<P> workflow, P primary, Context<P> context) {
-    this.primary = primary;
-    this.context = context;
-    this.workflow = workflow;
+    super(workflow, primary, context);
   }
 
   public synchronized WorkflowReconcileResult reconcile() {
-    for (DependentResourceNode dependentResourceNode : workflow
-        .getTopLevelDependentResources()) {
+    for (DependentResourceNode dependentResourceNode : workflow.getTopLevelDependentResources()) {
       handleReconcile(dependentResourceNode);
     }
-    while (true) {
-      try {
-        this.wait();
-        if (noMoreExecutionsScheduled()) {
-          break;
-        } else {
-          log.warn("Notified but still resources under execution. This should not happen.");
-        }
-      } catch (InterruptedException e) {
-        log.warn("Thread interrupted", e);
-        Thread.currentThread().interrupt();
-      }
-    }
+    waitForScheduledExecutionsToRun();
     return createReconcileResult();
+  }
+
+  @Override
+  protected Logger logger() {
+    return log;
   }
 
   private synchronized <R> void handleReconcile(DependentResourceNode<R, P> dependentResourceNode) {
     log.debug("Submitting for reconcile: {}", dependentResourceNode);
 
     if (alreadyVisited(dependentResourceNode)
-        || isReconcilingNow(dependentResourceNode)
+        || isExecutingNow(dependentResourceNode)
         || !allParentsReconciledAndReady(dependentResourceNode)
         || markedForDelete.contains(dependentResourceNode)
         || hasErroredParent(dependentResourceNode)) {
@@ -97,7 +75,7 @@ public class WorkflowReconcileExecutor<P extends HasMetadata> {
     } else {
       Future<?> nodeFuture = workflow.getExecutorService()
           .submit(new NodeReconcileExecutor(dependentResourceNode));
-      actualExecutions.put(dependentResourceNode, nodeFuture);
+      markAsExecuting(dependentResourceNode, nodeFuture);
       log.debug("Submitted to reconcile: {}", dependentResourceNode);
     }
   }
@@ -106,7 +84,7 @@ public class WorkflowReconcileExecutor<P extends HasMetadata> {
     log.debug("Submitting for delete: {}", dependentResourceNode);
 
     if (alreadyVisited(dependentResourceNode)
-        || isReconcilingNow(dependentResourceNode)
+        || isExecutingNow(dependentResourceNode)
         || !markedForDelete.contains(dependentResourceNode)
         || !allDependentsDeletedAlready(dependentResourceNode)) {
       log.debug("Skipping submit for delete of: {}, ", dependentResourceNode);
@@ -115,38 +93,21 @@ public class WorkflowReconcileExecutor<P extends HasMetadata> {
 
     Future<?> nodeFuture = workflow.getExecutorService()
         .submit(new NodeDeleteExecutor(dependentResourceNode));
-    actualExecutions.put(dependentResourceNode, nodeFuture);
+    markAsExecuting(dependentResourceNode, nodeFuture);
     log.debug("Submitted to delete: {}", dependentResourceNode);
   }
 
-  private boolean allDependentsDeletedAlready(
-      DependentResourceNode<?, P> dependentResourceNode) {
+  private boolean allDependentsDeletedAlready(DependentResourceNode<?, P> dependentResourceNode) {
     var dependents = dependentResourceNode.getParents();
-    return dependents.stream().allMatch(d -> alreadyVisited.contains(d) && !notReady.contains(d)
-        && !exceptionsDuringExecution.containsKey(d) && !deletePostConditionNotMet.contains(d));
-  }
-
-
-  private synchronized void handleExceptionInExecutor(
-      DependentResourceNode dependentResourceNode,
-      RuntimeException e) {
-    exceptionsDuringExecution.put(dependentResourceNode, e);
-  }
-
-  private synchronized void handleNodeExecutionFinish(
-      DependentResourceNode dependentResourceNode) {
-    log.debug("Finished execution for: {}", dependentResourceNode);
-    actualExecutions.remove(dependentResourceNode);
-    if (actualExecutions.isEmpty()) {
-      this.notifyAll();
-    }
+    return dependents.stream().allMatch(d -> alreadyVisited(d) && !notReady.contains(d)
+        && !isInError(d) && !deletePostConditionNotMet.contains(d));
   }
 
   // needs to be in one step
   private synchronized void setAlreadyReconciledButNotReady(
       DependentResourceNode<?, P> dependentResourceNode) {
     log.debug("Setting already reconciled but not ready for: {}", dependentResourceNode);
-    alreadyVisited.add(dependentResourceNode);
+    markAsVisited(dependentResourceNode);
     notReady.add(dependentResourceNode);
   }
 
@@ -182,7 +143,7 @@ public class WorkflowReconcileExecutor<P extends HasMetadata> {
 
         if (ready) {
           log.debug("Setting already reconciled for: {}", dependentResourceNode);
-          alreadyVisited.add(dependentResourceNode);
+          markAsVisited(dependentResourceNode);
           handleDependentsReconcile(dependentResourceNode);
         } else {
           setAlreadyReconciledButNotReady(dependentResourceNode);
@@ -220,13 +181,13 @@ public class WorkflowReconcileExecutor<P extends HasMetadata> {
                 dependentResource.getSecondaryResource(primary, context).orElse(null),
                 context)).orElse(true);
         if (deletePostConditionMet) {
-          alreadyVisited.add(dependentResourceNode);
+          markAsVisited(dependentResourceNode);
           handleDependentDeleted(dependentResourceNode);
         } else {
           // updating alreadyVisited needs to be the last operation otherwise could lead to a race
           // condition in handleDelete condition checks
           deletePostConditionNotMet.add(dependentResourceNode);
-          alreadyVisited.add(dependentResourceNode);
+          markAsVisited(dependentResourceNode);
         }
       } catch (RuntimeException e) {
         handleExceptionInExecutor(dependentResourceNode, e);
@@ -244,10 +205,6 @@ public class WorkflowReconcileExecutor<P extends HasMetadata> {
     });
   }
 
-  private boolean isReconcilingNow(DependentResourceNode<?, P> dependentResourceNode) {
-    return actualExecutions.containsKey(dependentResourceNode);
-  }
-
   private synchronized void handleDependentsReconcile(
       DependentResourceNode<?, P> dependentResourceNode) {
     var dependents = dependentResourceNode.getParents();
@@ -255,14 +212,6 @@ public class WorkflowReconcileExecutor<P extends HasMetadata> {
       log.debug("Handle reconcile for dependent: {} of parent:{}", d, dependentResourceNode);
       handleReconcile(d);
     });
-  }
-
-  private boolean noMoreExecutionsScheduled() {
-    return actualExecutions.isEmpty();
-  }
-
-  private boolean alreadyVisited(DependentResourceNode<?, P> dependentResourceNode) {
-    return alreadyVisited.contains(dependentResourceNode);
   }
 
 
@@ -292,7 +241,7 @@ public class WorkflowReconcileExecutor<P extends HasMetadata> {
   private boolean hasErroredParent(DependentResourceNode<?, ?> dependentResourceNode) {
     return !dependentResourceNode.getDependsOn().isEmpty()
         && dependentResourceNode.getDependsOn().stream()
-            .anyMatch(exceptionsDuringExecution::containsKey);
+        .anyMatch(this::isInError);
   }
 
   private WorkflowReconcileResult createReconcileResult() {
@@ -303,10 +252,7 @@ public class WorkflowReconcileExecutor<P extends HasMetadata> {
         notReady.stream()
             .map(workflow::getDependentResourceFor)
             .collect(Collectors.toList()),
-        exceptionsDuringExecution
-            .entrySet().stream()
-            .collect(Collectors.toMap(e -> workflow.getDependentResourceFor(e.getKey()),
-                Map.Entry::getValue)),
+        getErroredDependents(),
         reconcileResults);
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowReconcileExecutor.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowReconcileExecutor.java
@@ -286,13 +286,13 @@ public class WorkflowReconcileExecutor<P extends HasMetadata> {
   private boolean allParentsReconciledAndReady(DependentResourceNode<?, ?> dependentResourceNode) {
     return dependentResourceNode.getDependsOn().isEmpty()
         || dependentResourceNode.getDependsOn().stream()
-        .allMatch(d -> alreadyVisited(d) && !notReady.contains(d));
+            .allMatch(d -> alreadyVisited(d) && !notReady.contains(d));
   }
 
   private boolean hasErroredParent(DependentResourceNode<?, ?> dependentResourceNode) {
     return !dependentResourceNode.getDependsOn().isEmpty()
         && dependentResourceNode.getDependsOn().stream()
-        .anyMatch(exceptionsDuringExecution::containsKey);
+            .anyMatch(exceptionsDuringExecution::containsKey);
   }
 
   private WorkflowReconcileResult createReconcileResult() {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowReconcileExecutor.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowReconcileExecutor.java
@@ -148,7 +148,7 @@ public class WorkflowReconcileExecutor<P extends HasMetadata> extends AbstractWo
         DependentResource<R, P> dependentResource) {
       var deletePostCondition = dependentResourceNode.getDeletePostcondition();
 
-      if (DependentResource.canDeleteIfAble(dependentResource)) {
+      if (DependentResource.isDeletable(dependentResource)) {
         ((Deleter<P>) dependentResource).delete(primary, context);
       }
       boolean deletePostConditionMet = isConditionMet(deletePostCondition, dependentResource);

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowReconcileExecutor.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowReconcileExecutor.java
@@ -26,19 +26,21 @@ public class WorkflowReconcileExecutor<P extends HasMetadata> {
 
   private final Workflow<P> workflow;
 
-  /** Covers both deleted and reconciled */
-  private final Set<DependentResourceNode> alreadyVisited = ConcurrentHashMap.newKeySet();
-  private final Set<DependentResourceNode> notReady = ConcurrentHashMap.newKeySet();
-  private final Map<DependentResourceNode, Future<?>> actualExecutions =
+  /**
+   * Covers both deleted and reconciled
+   */
+  private final Set<DefaultDependentResourceNode> alreadyVisited = ConcurrentHashMap.newKeySet();
+  private final Set<DefaultDependentResourceNode> notReady = ConcurrentHashMap.newKeySet();
+  private final Map<DefaultDependentResourceNode, Future<?>> actualExecutions =
       new HashMap<>();
-  private final Map<DependentResourceNode, Exception> exceptionsDuringExecution =
+  private final Map<DefaultDependentResourceNode, Exception> exceptionsDuringExecution =
       new ConcurrentHashMap<>();
 
-  private final Set<DependentResourceNode> markedForDelete = ConcurrentHashMap.newKeySet();
-  private final Set<DependentResourceNode> deletePostConditionNotMet =
+  private final Set<DefaultDependentResourceNode> markedForDelete = ConcurrentHashMap.newKeySet();
+  private final Set<DefaultDependentResourceNode> deletePostConditionNotMet =
       ConcurrentHashMap.newKeySet();
   // used to remember reconciled (not deleted or errored) dependents
-  private final Set<DependentResourceNode> reconciled = ConcurrentHashMap.newKeySet();
+  private final Set<DefaultDependentResourceNode> reconciled = ConcurrentHashMap.newKeySet();
   private final Map<DependentResource, ReconcileResult> reconcileResults =
       new ConcurrentHashMap<>();
 
@@ -52,7 +54,7 @@ public class WorkflowReconcileExecutor<P extends HasMetadata> {
   }
 
   public synchronized WorkflowReconcileResult reconcile() {
-    for (DependentResourceNode dependentResourceNode : workflow
+    for (DefaultDependentResourceNode dependentResourceNode : workflow
         .getTopLevelDependentResources()) {
       handleReconcile(dependentResourceNode);
     }
@@ -72,7 +74,8 @@ public class WorkflowReconcileExecutor<P extends HasMetadata> {
     return createReconcileResult();
   }
 
-  private synchronized <R> void handleReconcile(DependentResourceNode<R, P> dependentResourceNode) {
+  private synchronized <R> void handleReconcile(
+      DefaultDependentResourceNode<R, P> dependentResourceNode) {
     log.debug("Submitting for reconcile: {}", dependentResourceNode);
 
     if (alreadyVisited(dependentResourceNode)
@@ -99,7 +102,7 @@ public class WorkflowReconcileExecutor<P extends HasMetadata> {
     }
   }
 
-  private synchronized void handleDelete(DependentResourceNode dependentResourceNode) {
+  private synchronized void handleDelete(DefaultDependentResourceNode dependentResourceNode) {
     log.debug("Submitting for delete: {}", dependentResourceNode);
 
     if (alreadyVisited(dependentResourceNode)
@@ -116,19 +119,22 @@ public class WorkflowReconcileExecutor<P extends HasMetadata> {
     log.debug("Submitted to delete: {}", dependentResourceNode);
   }
 
-  private boolean allDependentsDeletedAlready(DependentResourceNode<?, P> dependentResourceNode) {
+  private boolean allDependentsDeletedAlready(
+      DefaultDependentResourceNode<?, P> dependentResourceNode) {
     var dependents = dependentResourceNode.getParents();
     return dependents.stream().allMatch(d -> alreadyVisited.contains(d) && !notReady.contains(d)
         && !exceptionsDuringExecution.containsKey(d) && !deletePostConditionNotMet.contains(d));
   }
 
 
-  private synchronized void handleExceptionInExecutor(DependentResourceNode dependentResourceNode,
+  private synchronized void handleExceptionInExecutor(
+      DefaultDependentResourceNode dependentResourceNode,
       RuntimeException e) {
     exceptionsDuringExecution.put(dependentResourceNode, e);
   }
 
-  private synchronized void handleNodeExecutionFinish(DependentResourceNode dependentResourceNode) {
+  private synchronized void handleNodeExecutionFinish(
+      DefaultDependentResourceNode dependentResourceNode) {
     log.debug("Finished execution for: {}", dependentResourceNode);
     actualExecutions.remove(dependentResourceNode);
     if (actualExecutions.isEmpty()) {
@@ -138,7 +144,7 @@ public class WorkflowReconcileExecutor<P extends HasMetadata> {
 
   // needs to be in one step
   private synchronized void setAlreadyReconciledButNotReady(
-      DependentResourceNode<?, P> dependentResourceNode) {
+      DefaultDependentResourceNode<?, P> dependentResourceNode) {
     log.debug("Setting already reconciled but not ready for: {}", dependentResourceNode);
     alreadyVisited.add(dependentResourceNode);
     notReady.add(dependentResourceNode);
@@ -146,9 +152,9 @@ public class WorkflowReconcileExecutor<P extends HasMetadata> {
 
   private class NodeReconcileExecutor<R> implements Runnable {
 
-    private final DependentResourceNode<R, P> dependentResourceNode;
+    private final DefaultDependentResourceNode<R, P> dependentResourceNode;
 
-    private NodeReconcileExecutor(DependentResourceNode dependentResourceNode) {
+    private NodeReconcileExecutor(DefaultDependentResourceNode dependentResourceNode) {
       this.dependentResourceNode = dependentResourceNode;
     }
 
@@ -191,9 +197,9 @@ public class WorkflowReconcileExecutor<P extends HasMetadata> {
 
   private class NodeDeleteExecutor<R> implements Runnable {
 
-    private final DependentResourceNode<R, P> dependentResourceNode;
+    private final DefaultDependentResourceNode<R, P> dependentResourceNode;
 
-    private NodeDeleteExecutor(DependentResourceNode<R, P> dependentResourceNode) {
+    private NodeDeleteExecutor(DefaultDependentResourceNode<R, P> dependentResourceNode) {
       this.dependentResourceNode = dependentResourceNode;
     }
 
@@ -231,19 +237,19 @@ public class WorkflowReconcileExecutor<P extends HasMetadata> {
   }
 
   private synchronized void handleDependentDeleted(
-      DependentResourceNode<?, P> dependentResourceNode) {
+      DefaultDependentResourceNode<?, P> dependentResourceNode) {
     dependentResourceNode.getDependsOn().forEach(dr -> {
       log.debug("Handle deleted for: {} with dependent: {}", dr, dependentResourceNode);
       handleDelete(dr);
     });
   }
 
-  private boolean isReconcilingNow(DependentResourceNode<?, P> dependentResourceNode) {
+  private boolean isReconcilingNow(DefaultDependentResourceNode<?, P> dependentResourceNode) {
     return actualExecutions.containsKey(dependentResourceNode);
   }
 
   private synchronized void handleDependentsReconcile(
-      DependentResourceNode<?, P> dependentResourceNode) {
+      DefaultDependentResourceNode<?, P> dependentResourceNode) {
     var dependents = dependentResourceNode.getParents();
     dependents.forEach(d -> {
       log.debug("Handle reconcile for dependent: {} of parent:{}", d, dependentResourceNode);
@@ -256,19 +262,20 @@ public class WorkflowReconcileExecutor<P extends HasMetadata> {
   }
 
   private boolean alreadyVisited(
-      DependentResourceNode<?, P> dependentResourceNode) {
+      DefaultDependentResourceNode<?, P> dependentResourceNode) {
     return alreadyVisited.contains(dependentResourceNode);
   }
 
 
-  private void handleReconcileConditionNotMet(DependentResourceNode<?, P> dependentResourceNode) {
-    Set<DependentResourceNode> bottomNodes = new HashSet<>();
+  private void handleReconcileConditionNotMet(
+      DefaultDependentResourceNode<?, P> dependentResourceNode) {
+    Set<DefaultDependentResourceNode> bottomNodes = new HashSet<>();
     markDependentsForDelete(dependentResourceNode, bottomNodes);
     bottomNodes.forEach(this::handleDelete);
   }
 
-  private void markDependentsForDelete(DependentResourceNode<?, P> dependentResourceNode,
-      Set<DependentResourceNode> bottomNodes) {
+  private void markDependentsForDelete(DefaultDependentResourceNode<?, P> dependentResourceNode,
+      Set<DefaultDependentResourceNode> bottomNodes) {
     markedForDelete.add(dependentResourceNode);
     var dependents = dependentResourceNode.getParents();
     if (dependents.isEmpty()) {
@@ -279,25 +286,25 @@ public class WorkflowReconcileExecutor<P extends HasMetadata> {
   }
 
   private boolean allParentsReconciledAndReady(
-      DependentResourceNode<?, ?> dependentResourceNode) {
+      DefaultDependentResourceNode<?, ?> dependentResourceNode) {
     return dependentResourceNode.getDependsOn().isEmpty()
         || dependentResourceNode.getDependsOn().stream()
-            .allMatch(d -> alreadyVisited(d) && !notReady.contains(d));
+        .allMatch(d -> alreadyVisited(d) && !notReady.contains(d));
   }
 
   private boolean hasErroredParent(
-      DependentResourceNode<?, ?> dependentResourceNode) {
+      DefaultDependentResourceNode<?, ?> dependentResourceNode) {
     return !dependentResourceNode.getDependsOn().isEmpty()
         && dependentResourceNode.getDependsOn().stream()
-            .anyMatch(exceptionsDuringExecution::containsKey);
+        .anyMatch(exceptionsDuringExecution::containsKey);
   }
 
   private WorkflowReconcileResult createReconcileResult() {
     return new WorkflowReconcileResult(
         reconciled.stream()
-            .map(DependentResourceNode::getDependentResource).collect(Collectors.toList()),
+            .map(DefaultDependentResourceNode::getDependentResource).collect(Collectors.toList()),
         notReady.stream()
-            .map(DependentResourceNode::getDependentResource)
+            .map(DefaultDependentResourceNode::getDependentResource)
             .collect(Collectors.toList()),
         exceptionsDuringExecution
             .entrySet().stream()

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowReconcileExecutor.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowReconcileExecutor.java
@@ -148,7 +148,7 @@ public class WorkflowReconcileExecutor<P extends HasMetadata> extends AbstractWo
         DependentResource<R, P> dependentResource) {
       var deletePostCondition = dependentResourceNode.getDeletePostcondition();
 
-      if (DependentResource.isDeletable(dependentResource)) {
+      if (dependentResource.isDeletable()) {
         ((Deleter<P>) dependentResource).delete(primary, context);
       }
       boolean deletePostConditionMet = isConditionMet(deletePostCondition, dependentResource);

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/builder/WorkflowBuilder.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/builder/WorkflowBuilder.java
@@ -85,6 +85,7 @@ public class WorkflowBuilder<P extends HasMetadata> {
   }
 
   public Workflow<P> build(ExecutorService executorService) {
-    return new Workflow(dependentResourceNodes, executorService, throwExceptionAutomatically);
+    // workflow has been built from dependent resources so it is already resolved
+    return new Workflow(dependentResourceNodes, executorService, throwExceptionAutomatically, true);
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/builder/WorkflowBuilder.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/builder/WorkflowBuilder.java
@@ -10,6 +10,7 @@ import io.javaoperatorsdk.operator.api.config.ExecutorServiceManager;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
 import io.javaoperatorsdk.operator.processing.dependent.workflow.Condition;
 import io.javaoperatorsdk.operator.processing.dependent.workflow.DefaultDependentResourceNode;
+import io.javaoperatorsdk.operator.processing.dependent.workflow.DependentResourceNode;
 import io.javaoperatorsdk.operator.processing.dependent.workflow.Workflow;
 
 import static io.javaoperatorsdk.operator.processing.dependent.workflow.Workflow.THROW_EXCEPTION_AUTOMATICALLY_DEFAULT;
@@ -17,7 +18,7 @@ import static io.javaoperatorsdk.operator.processing.dependent.workflow.Workflow
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class WorkflowBuilder<P extends HasMetadata> {
 
-  private final Set<DefaultDependentResourceNode<?, P>> dependentResourceNodes = new HashSet<>();
+  private final Set<DependentResourceNode<?, P>> dependentResourceNodes = new HashSet<>();
   private boolean throwExceptionAutomatically = THROW_EXCEPTION_AUTOMATICALLY_DEFAULT;
 
   private DefaultDependentResourceNode currentNode;
@@ -58,8 +59,7 @@ public class WorkflowBuilder<P extends HasMetadata> {
     return this;
   }
 
-  DefaultDependentResourceNode getNodeByDependentResource(
-      DependentResource<?, ?> dependentResource) {
+  DependentResourceNode getNodeByDependentResource(DependentResource<?, ?> dependentResource) {
     return dependentResourceNodes.stream()
         .filter(dr -> dr.getDependentResource() == dependentResource)
         .findFirst()

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/builder/WorkflowBuilder.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/builder/WorkflowBuilder.java
@@ -9,7 +9,7 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.javaoperatorsdk.operator.api.config.ExecutorServiceManager;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
 import io.javaoperatorsdk.operator.processing.dependent.workflow.Condition;
-import io.javaoperatorsdk.operator.processing.dependent.workflow.DependentResourceNode;
+import io.javaoperatorsdk.operator.processing.dependent.workflow.DefaultDependentResourceNode;
 import io.javaoperatorsdk.operator.processing.dependent.workflow.Workflow;
 
 import static io.javaoperatorsdk.operator.processing.dependent.workflow.Workflow.THROW_EXCEPTION_AUTOMATICALLY_DEFAULT;
@@ -17,13 +17,13 @@ import static io.javaoperatorsdk.operator.processing.dependent.workflow.Workflow
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class WorkflowBuilder<P extends HasMetadata> {
 
-  private final Set<DependentResourceNode<?, P>> dependentResourceNodes = new HashSet<>();
+  private final Set<DefaultDependentResourceNode<?, P>> dependentResourceNodes = new HashSet<>();
   private boolean throwExceptionAutomatically = THROW_EXCEPTION_AUTOMATICALLY_DEFAULT;
 
-  private DependentResourceNode currentNode;
+  private DefaultDependentResourceNode currentNode;
 
   public WorkflowBuilder<P> addDependentResource(DependentResource dependentResource) {
-    currentNode = new DependentResourceNode<>(dependentResource);
+    currentNode = new DefaultDependentResourceNode<>(dependentResource);
     dependentResourceNodes.add(currentNode);
     return this;
   }
@@ -58,7 +58,8 @@ public class WorkflowBuilder<P extends HasMetadata> {
     return this;
   }
 
-  DependentResourceNode getNodeByDependentResource(DependentResource<?, ?> dependentResource) {
+  DefaultDependentResourceNode getNodeByDependentResource(
+      DependentResource<?, ?> dependentResource) {
     return dependentResourceNodes.stream()
         .filter(dr -> dr.getDependentResource() == dependentResource)
         .findFirst()

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/builder/WorkflowBuilder.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/builder/WorkflowBuilder.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.javaoperatorsdk.operator.api.config.ExecutorServiceManager;
@@ -18,7 +19,7 @@ import static io.javaoperatorsdk.operator.processing.dependent.workflow.Workflow
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class WorkflowBuilder<P extends HasMetadata> {
 
-  private final Set<DependentResourceNode<?, P>> dependentResourceNodes = new HashSet<>();
+  private final Set<DefaultDependentResourceNode<?, P>> dependentResourceNodes = new HashSet<>();
   private boolean throwExceptionAutomatically = THROW_EXCEPTION_AUTOMATICALLY_DEFAULT;
 
   private DefaultDependentResourceNode currentNode;
@@ -76,13 +77,11 @@ public class WorkflowBuilder<P extends HasMetadata> {
   }
 
   public Workflow<P> build() {
-    return new Workflow(
-        dependentResourceNodes, ExecutorServiceManager.instance().workflowExecutorService(),
-        throwExceptionAutomatically);
+    return build(ExecutorServiceManager.instance().workflowExecutorService());
   }
 
   public Workflow<P> build(int parallelism) {
-    return new Workflow(dependentResourceNodes, parallelism);
+    return build(Executors.newFixedThreadPool(parallelism));
   }
 
   public Workflow<P> build(ExecutorService executorService) {

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/workflow/AbstractWorkflowExecutorTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/workflow/AbstractWorkflowExecutorTest.java
@@ -4,11 +4,14 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.Deleter;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.GarbageCollected;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.ReconcileResult;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependentResource;
 import io.javaoperatorsdk.operator.sample.simple.TestCustomResource;
 
 public class AbstractWorkflowExecutorTest {
@@ -28,24 +31,21 @@ public class AbstractWorkflowExecutorTest {
   protected List<ReconcileRecord> executionHistory =
       Collections.synchronizedList(new ArrayList<>());
 
-  public class TestDependent implements DependentResource<String, TestCustomResource> {
+  public class TestDependent extends KubernetesDependentResource<ConfigMap, TestCustomResource> {
 
     private final String name;
 
     public TestDependent(String name) {
+      super(ConfigMap.class);
       this.name = name;
     }
 
     @Override
-    public ReconcileResult<String> reconcile(TestCustomResource primary,
+    public ReconcileResult<ConfigMap> reconcile(TestCustomResource primary,
         Context<TestCustomResource> context) {
       executionHistory.add(new ReconcileRecord(this));
-      return ReconcileResult.resourceCreated(VALUE);
-    }
-
-    @Override
-    public Class<String> resourceType() {
-      return String.class;
+      return ReconcileResult
+          .resourceCreated(new ConfigMapBuilder().addToBinaryData("key", VALUE).build());
     }
 
     @Override

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/workflow/ManagedWorkflowSupportTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/workflow/ManagedWorkflowSupportTest.java
@@ -151,8 +151,10 @@ class ManagedWorkflowSupportTest {
     assertThat(workflow.getDependentResources()).containsExactlyInAnyOrder(drByName.values()
         .toArray(new DependentResource[0]));
     assertThat(workflow.getTopLevelDependentResources())
-        .map(DependentResourceNode::getDependentResource).containsExactly(drByName.get(NAME_1));
-    assertThat(workflow.getBottomLevelResource()).map(DependentResourceNode::getDependentResource)
+        .map(DefaultDependentResourceNode::getDependentResource)
+        .containsExactly(drByName.get(NAME_1));
+    assertThat(workflow.getBottomLevelResource())
+        .map(DefaultDependentResourceNode::getDependentResource)
         .containsExactly(drByName.get(NAME_4));
   }
 

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/workflow/ManagedWorkflowSupportTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/workflow/ManagedWorkflowSupportTest.java
@@ -144,7 +144,7 @@ class ManagedWorkflowSupportTest {
     var workflow = managedWorkflowSupport.createWorkflow(specs);
     workflow.resolve(client, specs);
 
-    assertThat(workflow.nodes()).map(DependentResourceNode::getName)
+    assertThat(workflow.nodes().values()).map(DependentResourceNode::getName)
         .containsExactlyInAnyOrder(NAME_1, NAME_2, NAME_3, NAME_4);
     assertThat(workflow.getTopLevelDependentResources())
         .map(DependentResourceNode::getName)

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/workflow/ManagedWorkflowSupportTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/workflow/ManagedWorkflowSupportTest.java
@@ -151,10 +151,10 @@ class ManagedWorkflowSupportTest {
     assertThat(workflow.getDependentResources()).containsExactlyInAnyOrder(drByName.values()
         .toArray(new DependentResource[0]));
     assertThat(workflow.getTopLevelDependentResources())
-        .map(DefaultDependentResourceNode::getDependentResource)
+        .map(DependentResourceNode::getDependentResource)
         .containsExactly(drByName.get(NAME_1));
     assertThat(workflow.getBottomLevelResource())
-        .map(DefaultDependentResourceNode::getDependentResource)
+        .map(DependentResourceNode::getDependentResource)
         .containsExactly(drByName.get(NAME_4));
   }
 

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/workflow/ManagedWorkflowSupportTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/workflow/ManagedWorkflowSupportTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.OperatorException;
 import io.javaoperatorsdk.operator.api.config.dependent.DependentResourceSpec;
-import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
 
 import static io.javaoperatorsdk.operator.processing.dependent.workflow.ManagedWorkflowTestUtils.createDRS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -141,21 +140,18 @@ class ManagedWorkflowSupportTest {
         createDRS(NAME_3, NAME_1),
         createDRS(NAME_4, NAME_3, NAME_2));
 
-    var drByName = specs
-        .stream().collect(Collectors.toMap(DependentResourceSpec::getName,
-            spec -> managedWorkflowSupport.createAndConfigureFrom(spec,
-                mock(KubernetesClient.class))));
+    final var client = mock(KubernetesClient.class);
+    var workflow = managedWorkflowSupport.createWorkflow(specs);
+    workflow.resolve(client, specs);
 
-    var workflow = managedWorkflowSupport.createWorkflow(specs, drByName);
-
-    assertThat(workflow.getDependentResources()).containsExactlyInAnyOrder(drByName.values()
-        .toArray(new DependentResource[0]));
+    assertThat(workflow.nodes()).map(DependentResourceNode::getName)
+        .containsExactlyInAnyOrder(NAME_1, NAME_2, NAME_3, NAME_4);
     assertThat(workflow.getTopLevelDependentResources())
-        .map(DependentResourceNode::getDependentResource)
-        .containsExactly(drByName.get(NAME_1));
+        .map(DependentResourceNode::getName)
+        .containsExactly(NAME_1);
     assertThat(workflow.getBottomLevelResource())
-        .map(DependentResourceNode::getDependentResource)
-        .containsExactly(drByName.get(NAME_4));
+        .map(DependentResourceNode::getName)
+        .containsExactly(NAME_4);
   }
 
 }

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/workflow/ManagedWorkflowTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/workflow/ManagedWorkflowTest.java
@@ -34,9 +34,8 @@ class ManagedWorkflowTest {
     when(managedWorkflowSupportMock.createWorkflow(any())).thenReturn(mockWorkflow);
     when(managedWorkflowSupportMock.createAndConfigureFrom(any(), any()))
         .thenReturn(mock(DependentResource.class));
-    assertThat(managedWorkflow().isEmptyWorkflow()).isTrue();
 
-    // when(mockWorkflow.getDependentResources()).thenReturn(Set.of(mock(DependentResource.class)));
+    assertThat(managedWorkflow().isEmptyWorkflow()).isTrue();
     assertThat(managedWorkflow(createDRS(NAME)).isEmptyWorkflow()).isFalse();
   }
 

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/workflow/ManagedWorkflowTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/workflow/ManagedWorkflowTest.java
@@ -9,86 +9,57 @@ import io.javaoperatorsdk.operator.api.config.ConfigurationServiceProvider;
 import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
 import io.javaoperatorsdk.operator.api.config.dependent.DependentResourceSpec;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.Deleter;
-import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.GarbageCollected;
 
 import static io.javaoperatorsdk.operator.processing.dependent.workflow.ManagedWorkflowTestUtils.createDRS;
+import static io.javaoperatorsdk.operator.processing.dependent.workflow.ManagedWorkflowTestUtils.createDRSWithTraits;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.withSettings;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
 class ManagedWorkflowTest {
 
   public static final String NAME = "name";
 
-  ManagedWorkflowSupport managedWorkflowSupportMock = mock(ManagedWorkflowSupport.class);
-  KubernetesClient kubernetesClientMock = mock(KubernetesClient.class);
-
   @Test
   void checksIfWorkflowEmpty() {
-    var mockWorkflow = mock(Workflow.class);
-    when(managedWorkflowSupportMock.createWorkflow(any())).thenReturn(mockWorkflow);
-    when(managedWorkflowSupportMock.createAndConfigureFrom(any(), any()))
-        .thenReturn(mock(DependentResource.class));
-
     assertThat(managedWorkflow().isEmptyWorkflow()).isTrue();
     assertThat(managedWorkflow(createDRS(NAME)).isEmptyWorkflow()).isFalse();
   }
 
   @Test
   void isNotCleanerIfNoDeleter() {
-    var mockWorkflow = mock(Workflow.class);
-    when(managedWorkflowSupportMock.createWorkflow(any())).thenReturn(mockWorkflow);
-    when(managedWorkflowSupportMock.createAndConfigureFrom(any(), any()))
-        .thenReturn(mock(DependentResource.class));
-
     assertThat(managedWorkflow(createDRS(NAME)).isCleaner()).isFalse();
   }
 
   @Test
   void isNotCleanerIfNoGarbageCollected() {
-    var mockWorkflow = mock(Workflow.class);
-    when(managedWorkflowSupportMock.createWorkflow(any())).thenReturn(mockWorkflow);
-    when(managedWorkflowSupportMock.createAndConfigureFrom(any(), any()))
-        .thenReturn(
-            mock(DependentResource.class, withSettings().extraInterfaces(GarbageCollected.class)));
-
-    assertThat(managedWorkflow(createDRS(NAME)).isCleaner()).isFalse();
+    assertThat(managedWorkflow(createDRSWithTraits(NAME, GarbageCollected.class))
+        .isCleaner()).isFalse();
   }
 
   @Test
   void isCleanerIfHasDeleter() {
-    var mockWorkflow = mock(Workflow.class);
-    when(managedWorkflowSupportMock.createWorkflow(any())).thenReturn(mockWorkflow);
-
-    var spec = createDRS(NAME);
-    when(managedWorkflowSupportMock.createAndConfigureFrom(eq(spec), any()))
-        .thenReturn(mock(DependentResource.class, withSettings().extraInterfaces(Deleter.class)));
+    var spec = createDRSWithTraits(NAME, Deleter.class);
     assertThat(managedWorkflow(spec).isCleaner()).isTrue();
   }
 
   @Test
   void isNotCleanerIfDeleterIsGarbageCollected() {
-    var mockWorkflow = mock(Workflow.class);
-    when(managedWorkflowSupportMock.createWorkflow(any())).thenReturn(mockWorkflow);
-
-    var spec = createDRS(NAME);
-    when(managedWorkflowSupportMock.createAndConfigureFrom(eq(spec), any()))
-        .thenReturn(mock(DependentResource.class,
-            withSettings().extraInterfaces(Deleter.class, GarbageCollected.class)));
-    assertThat(managedWorkflow(createDRS(NAME)).isCleaner()).isFalse();
+    var spec = createDRSWithTraits(NAME, Deleter.class, GarbageCollected.class);
+    assertThat(managedWorkflow(spec).isCleaner()).isFalse();
   }
 
   ManagedWorkflow managedWorkflow(DependentResourceSpec... specs) {
     final var configuration = mock(ControllerConfiguration.class);
     final var specList = List.of(specs);
+
+    KubernetesClient kubernetesClientMock = mock(KubernetesClient.class);
+
     when(configuration.getDependentResources()).thenReturn(specList);
     return ConfigurationServiceProvider.instance().getWorkflowFactory()
-        .workflowFor(configuration, managedWorkflowSupportMock)
+        .workflowFor(configuration)
         .resolve(kubernetesClientMock, specList);
   }
 

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/workflow/ManagedWorkflowTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/workflow/ManagedWorkflowTest.java
@@ -34,7 +34,7 @@ class ManagedWorkflowTest {
   }
 
   @Test
-  void isNotCleanerIfNoGarbageCollected() {
+  void isNotCleanerIfGarbageCollected() {
     assertThat(managedWorkflow(createDRSWithTraits(NAME, GarbageCollected.class))
         .isCleaner()).isFalse();
   }
@@ -43,12 +43,6 @@ class ManagedWorkflowTest {
   void isCleanerIfHasDeleter() {
     var spec = createDRSWithTraits(NAME, Deleter.class);
     assertThat(managedWorkflow(spec).isCleaner()).isTrue();
-  }
-
-  @Test
-  void isNotCleanerIfDeleterIsGarbageCollected() {
-    var spec = createDRSWithTraits(NAME, Deleter.class, GarbageCollected.class);
-    assertThat(managedWorkflow(spec).isCleaner()).isFalse();
   }
 
   ManagedWorkflow managedWorkflow(DependentResourceSpec... specs) {

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/workflow/ManagedWorkflowTestUtils.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/workflow/ManagedWorkflowTestUtils.java
@@ -1,11 +1,13 @@
 package io.javaoperatorsdk.operator.processing.dependent.workflow;
 
+import java.util.Arrays;
 import java.util.Set;
 
 import org.mockito.Mockito;
 
 import io.javaoperatorsdk.operator.api.config.dependent.DependentResourceSpec;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.GarbageCollected;
 import io.javaoperatorsdk.operator.processing.dependent.EmptyTestDependentResource;
 
 import static org.mockito.Mockito.mock;
@@ -23,11 +25,19 @@ public class ManagedWorkflowTestUtils {
 
   public static DependentResourceSpec createDRSWithTraits(String name,
       Class<?>... dependentResourceTraits) {
-    final var drs = createDRS(name);
-    final var spy = Mockito.spy(drs);
-    when(spy.getDependentResource())
-        .thenReturn(
-            mock(DependentResource.class, withSettings().extraInterfaces(dependentResourceTraits)));
+    final var spy = Mockito.mock(DependentResourceSpec.class);
+    when(spy.getName()).thenReturn(name);
+
+    Class<? extends DependentResource> toMock = DependentResource.class;
+    final var garbageCollected = dependentResourceTraits != null &&
+        Arrays.asList(dependentResourceTraits).contains(GarbageCollected.class);
+
+    final var dr = mock(toMock, withSettings().extraInterfaces(dependentResourceTraits));
+    // it would be better to call the real method here but it doesn't work because
+    // KubernetesDependentResource checks for GarbageCollected trait when instantiated which doesn't
+    // happen when using mocks
+    when(dr.isDeletable()).thenReturn(!garbageCollected);
+    when(spy.getDependentResource()).thenReturn(dr);
     return spy;
   }
 

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/workflow/ManagedWorkflowTestUtils.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/workflow/ManagedWorkflowTestUtils.java
@@ -2,8 +2,15 @@ package io.javaoperatorsdk.operator.processing.dependent.workflow;
 
 import java.util.Set;
 
+import org.mockito.Mockito;
+
 import io.javaoperatorsdk.operator.api.config.dependent.DependentResourceSpec;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
 import io.javaoperatorsdk.operator.processing.dependent.EmptyTestDependentResource;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 @SuppressWarnings("rawtypes")
 public class ManagedWorkflowTestUtils {
@@ -12,6 +19,16 @@ public class ManagedWorkflowTestUtils {
   public static DependentResourceSpec createDRS(String name, String... dependOns) {
     return new DependentResourceSpec(new EmptyTestDependentResource(), name, Set.of(dependOns),
         null, null, null, null);
+  }
+
+  public static DependentResourceSpec createDRSWithTraits(String name,
+      Class<?>... dependentResourceTraits) {
+    final var drs = createDRS(name);
+    final var spy = Mockito.spy(drs);
+    when(spy.getDependentResource())
+        .thenReturn(
+            mock(DependentResource.class, withSettings().extraInterfaces(dependentResourceTraits)));
+    return spy;
   }
 
 }

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowCleanupExecutorTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowCleanupExecutorTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test;
 
 import io.javaoperatorsdk.operator.AggregatedOperatorException;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
-import io.javaoperatorsdk.operator.processing.dependent.workflow.builder.WorkflowBuilder;
 import io.javaoperatorsdk.operator.sample.simple.TestCustomResource;
 
 import static io.javaoperatorsdk.operator.processing.dependent.workflow.ExecutionAssert.assertThat;
@@ -17,6 +16,7 @@ class WorkflowCleanupExecutorTest extends AbstractWorkflowExecutorTest {
   protected TestDeleterDependent dd1 = new TestDeleterDependent("DR_DELETER_1");
   protected TestDeleterDependent dd2 = new TestDeleterDependent("DR_DELETER_2");
   protected TestDeleterDependent dd3 = new TestDeleterDependent("DR_DELETER_3");
+  @SuppressWarnings("unchecked")
   Context<TestCustomResource> mockContext = mock(Context.class);
 
   @Test

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowReconcileExecutorTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowReconcileExecutorTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test;
 
 import io.javaoperatorsdk.operator.AggregatedOperatorException;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
-import io.javaoperatorsdk.operator.processing.dependent.workflow.builder.WorkflowBuilder;
 import io.javaoperatorsdk.operator.sample.simple.TestCustomResource;
 
 import static io.javaoperatorsdk.operator.processing.dependent.workflow.ExecutionAssert.assertThat;
@@ -23,6 +22,7 @@ class WorkflowReconcileExecutorTest extends AbstractWorkflowExecutorTest {
   private final Condition<String, TestCustomResource> notMetReadyCondition =
       (primary, secondary, context) -> false;
 
+  @SuppressWarnings("unchecked")
   Context<TestCustomResource> mockContext = mock(Context.class);
 
   @Test

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowTest.java
@@ -29,7 +29,7 @@ class WorkflowTest {
 
     Set<DependentResource> topResources =
         workflow.getTopLevelDependentResources().stream()
-            .map(DependentResourceNode::getDependentResource)
+            .map(DefaultDependentResourceNode::getDependentResource)
             .collect(Collectors.toSet());
 
     assertThat(topResources).containsExactlyInAnyOrder(dr1, independentDR);
@@ -49,7 +49,7 @@ class WorkflowTest {
 
     Set<DependentResource> bottomResources =
         workflow.getBottomLevelResource().stream()
-            .map(DependentResourceNode::getDependentResource)
+            .map(DefaultDependentResourceNode::getDependentResource)
             .collect(Collectors.toSet());
 
     assertThat(bottomResources).containsExactlyInAnyOrder(dr2, independentDR);

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowTest.java
@@ -29,7 +29,7 @@ class WorkflowTest {
 
     Set<DependentResource> topResources =
         workflow.getTopLevelDependentResources().stream()
-            .map(DefaultDependentResourceNode::getDependentResource)
+            .map(DependentResourceNode::getDependentResource)
             .collect(Collectors.toSet());
 
     assertThat(topResources).containsExactlyInAnyOrder(dr1, independentDR);
@@ -49,7 +49,7 @@ class WorkflowTest {
 
     Set<DependentResource> bottomResources =
         workflow.getBottomLevelResource().stream()
-            .map(DefaultDependentResourceNode::getDependentResource)
+            .map(DependentResourceNode::getDependentResource)
             .collect(Collectors.toSet());
 
     assertThat(bottomResources).containsExactlyInAnyOrder(dr2, independentDR);

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowTest.java
@@ -29,7 +29,7 @@ class WorkflowTest {
 
     Set<DependentResource> topResources =
         workflow.getTopLevelDependentResources().stream()
-            .map(DependentResourceNode::getDependentResource)
+            .map(workflow::getDependentResourceFor)
             .collect(Collectors.toSet());
 
     assertThat(topResources).containsExactlyInAnyOrder(dr1, independentDR);
@@ -49,7 +49,7 @@ class WorkflowTest {
 
     Set<DependentResource> bottomResources =
         workflow.getBottomLevelResource().stream()
-            .map(DependentResourceNode::getDependentResource)
+            .map(workflow::getDependentResourceFor)
             .collect(Collectors.toSet());
 
     assertThat(bottomResources).containsExactlyInAnyOrder(dr2, independentDR);

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowTest.java
@@ -6,7 +6,6 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
-import io.javaoperatorsdk.operator.processing.dependent.workflow.builder.WorkflowBuilder;
 import io.javaoperatorsdk.operator.sample.simple.TestCustomResource;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/sample-operators/webpage/src/main/java/io/javaoperatorsdk/operator/sample/WebPageDependentsWorkflowReconciler.java
+++ b/sample-operators/webpage/src/main/java/io/javaoperatorsdk/operator/sample/WebPageDependentsWorkflowReconciler.java
@@ -19,7 +19,7 @@ import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependentResource;
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependentResourceConfig;
 import io.javaoperatorsdk.operator.processing.dependent.workflow.Workflow;
-import io.javaoperatorsdk.operator.processing.dependent.workflow.builder.WorkflowBuilder;
+import io.javaoperatorsdk.operator.processing.dependent.workflow.WorkflowBuilder;
 import io.javaoperatorsdk.operator.processing.event.source.EventSource;
 
 import static io.javaoperatorsdk.operator.sample.Utils.createStatus;
@@ -31,6 +31,7 @@ import static io.javaoperatorsdk.operator.sample.Utils.simulateErrorIfRequested;
  */
 @ControllerConfiguration(
     labelSelector = WebPageDependentsWorkflowReconciler.DEPENDENT_RESOURCE_LABEL_SELECTOR)
+@SuppressWarnings("unused")
 public class WebPageDependentsWorkflowReconciler
     implements Reconciler<WebPage>, ErrorStatusHandler<WebPage>, EventSourceInitializer<WebPage> {
 
@@ -79,7 +80,7 @@ public class WebPageDependentsWorkflowReconciler
     return handleError(resource, e);
   }
 
-  @SuppressWarnings("rawtypes")
+  @SuppressWarnings({"rawtypes", "unchecked"})
   private void initDependentResources(KubernetesClient client) {
     this.configMapDR = new ConfigMapDependentResource();
     this.deploymentDR = new DeploymentDependentResource();


### PR DESCRIPTION
This allows for the workflow graph to be resolved at build time from a 
factory, the dependent resources being configured as needed at runtime
via the resolve mechanism.