### PR TITLE
fix: leader election manager init when not using config overrider

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Operator.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Operator.java
@@ -60,9 +60,9 @@ public class Operator implements LifecycleAware {
   public Operator(KubernetesClient kubernetesClient, ConfigurationService configurationService) {
     this.kubernetesClient =
         kubernetesClient != null ? kubernetesClient : new KubernetesClientBuilder().build();
+    ConfigurationServiceProvider.set(configurationService);
     configurationService.getLeaderElectionConfiguration()
         .ifPresent(c -> leaderElectionManager.init(c, this.kubernetesClient));
-    ConfigurationServiceProvider.set(configurationService);
   }
 
   /** Adds a shutdown hook that automatically calls {@link #stop()} when the app shuts down. */


### PR DESCRIPTION
If you create an Operator instance without using the `overrider` to set the leader election config, the configuration singleton is set twice leading to a ISE. 

The method `LeaderElectionManager#init` relies on the singleton config but the config is not set yet at that moment.

Note that I found out this issue by using [Quarkus Operator SDK 5.0.2.Beta](https://github.com/quarkiverse/quarkus-operator-sdk)