### PR TITLE
Generate a Versions file to be consumed at runtime

### DIFF
--- a/operator-framework-core/pom.xml
+++ b/operator-framework-core/pom.xml
@@ -47,6 +47,19 @@
           <commitIdGenerationMode>full</commitIdGenerationMode>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>templating-maven-plugin</artifactId>
+        <version>1.0.0</version>
+        <executions>
+          <execution>
+            <id>filtering-java-templates</id>
+            <goals>
+              <goal>filter-sources</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/operator-framework-core/src/main/java-templates/io/javaoperatorsdk/operator/Versions.java
+++ b/operator-framework-core/src/main/java-templates/io/javaoperatorsdk/operator/Versions.java
@@ -1,0 +1,8 @@
+package io.javaoperatorsdk.operator;
+
+public final class Versions {
+
+  public static final String JOSDK = "${project.version}";
+  public static final String KUBERNETES_CLIENT = "${fabric8-client.version}";
+
+}

--- a/operator-framework-core/src/main/java-templates/io/javaoperatorsdk/operator/Versions.java
+++ b/operator-framework-core/src/main/java-templates/io/javaoperatorsdk/operator/Versions.java
@@ -1,8 +1,0 @@
-package io.javaoperatorsdk.operator;
-
-public final class Versions {
-
-  public static final String JOSDK = "${project.version}";
-  public static final String KUBERNETES_CLIENT = "${fabric8-client.version}";
-
-}

--- a/operator-framework-core/src/main/java-templates/io/javaoperatorsdk/operator/api/config/Versions.java
+++ b/operator-framework-core/src/main/java-templates/io/javaoperatorsdk/operator/api/config/Versions.java
@@ -1,0 +1,10 @@
+package io.javaoperatorsdk.operator.api.config;
+
+public final class Versions {
+
+  private Versions() {}
+
+  protected static final String JOSDK = "${project.version}";
+  protected static final String KUBERNETES_CLIENT = "${fabric8-client.version}";
+
+}

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/Version.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/Version.java
@@ -6,7 +6,10 @@ import java.util.Date;
 /** A class encapsulating the version information associated with this SDK instance. */
 public class Version {
 
-  public static final Version UNKNOWN = new Version("unknown", "unknown", Date.from(Instant.EPOCH));
+  public static final Version UNKNOWN =
+      new Version(Versions.JOSDK, "unknown", Date.from(Instant.EPOCH));
+  public static final Version KUBENETES_CLIENT =
+      new Version(Versions.KUBERNETES_CLIENT, "unknown", Date.from(Instant.EPOCH));
 
   private final String sdk;
   private final String commit;

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/config/VersionTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/config/VersionTest.java
@@ -1,0 +1,17 @@
+package io.javaoperatorsdk.operator.api.config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class VersionTest {
+
+  @Test
+  void versionShouldReturnTheSameResultFromMavenAndProperties() {
+    String versionFromProperties = Utils.loadFromProperties().getSdkVersion();
+    String versionFromMaven = Version.UNKNOWN.getSdkVersion();
+
+    assertEquals(versionFromProperties, versionFromMaven);
+  }
+
+}


### PR DESCRIPTION
This will enable compile time checks of the versions in the Quarkus Operator SDK.
ref: https://github.com/quarkiverse/quarkus-operator-sdk/pull/460

cc. @metacosm 