### PR TITLE
fix: non-independent unit tests because static state

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/dependent/DependentResourceConfigurationResolver.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/dependent/DependentResourceConfigurationResolver.java
@@ -147,6 +147,12 @@ public class DependentResourceConfigurationResolver {
     knownConverters.put(converterClass, converter);
   }
 
+  /** To support independent unit tests */
+  public static void clear() {
+    converters.clear();
+    knownConverters.clear();
+  }
+
   private static class ConfiguredClassPair {
     private final Configured configured;
     private final Class<? extends DependentResource> annotatedClass;

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/config/ControllerConfigurationOverriderTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/config/ControllerConfigurationOverriderTest.java
@@ -33,7 +33,7 @@ class ControllerConfigurationOverriderTest {
 
 
   @BeforeEach
-  void clearState() {
+  void clearStaticState() {
     DependentResourceConfigurationResolver.clear();
   }
 

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/config/ControllerConfigurationOverriderTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/config/ControllerConfigurationOverriderTest.java
@@ -3,6 +3,7 @@ package io.javaoperatorsdk.operator.api.config;
 import java.util.Optional;
 import java.util.Set;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
@@ -29,6 +30,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ControllerConfigurationOverriderTest {
   private final BaseConfigurationService configurationService = new BaseConfigurationService();
+
+
+  @BeforeEach
+  void clearState() {
+    DependentResourceConfigurationResolver.clear();
+  }
 
   @Test
   void overridingNSShouldPreserveUntouchedDependents() {


### PR DESCRIPTION
This fixes an issue with unit tests where order matters. But state state should be avoided in the future, also this refactored.