### PR TITLE
fix: CreateOnlyIfNotExistingDependentWithSSAIT actually use SSA for the test

### DIFF
--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/createonlyifnotexistsdependentwithssa/ConfigMapDependentResource.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/createonlyifnotexistsdependentwithssa/ConfigMapDependentResource.java
@@ -11,6 +11,8 @@ public class ConfigMapDependentResource
     extends CRUDKubernetesDependentResource<
         ConfigMap, CreateOnlyIfNotExistingDependentWithSSACustomResource> {
 
+  public static final String DRKEY = "drkey";
+
   @Override
   protected ConfigMap desired(
       CreateOnlyIfNotExistingDependentWithSSACustomResource primary,
@@ -21,7 +23,7 @@ public class ConfigMapDependentResource
             .withName(primary.getMetadata().getName())
             .withNamespace(primary.getMetadata().getNamespace())
             .build());
-    configMap.setData(Map.of("drkey", "v"));
+    configMap.setData(Map.of(DRKEY, "v"));
     return configMap;
   }
 }

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/createonlyifnotexistsdependentwithssa/CreateOnlyIfNotExistingDependentWithSSAIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/createonlyifnotexistsdependentwithssa/CreateOnlyIfNotExistingDependentWithSSAIT.java
@@ -2,6 +2,7 @@ package io.javaoperatorsdk.operator.dependent.createonlyifnotexistsdependentwith
 
 import java.time.Duration;
 import java.util.Map;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -22,6 +23,7 @@ class CreateOnlyIfNotExistingDependentWithSSAIT {
   @RegisterExtension
   LocallyRunOperatorExtension extension =
       LocallyRunOperatorExtension.builder()
+          .withConfigurationService(o -> o.withDefaultNonSSAResource(Set.of()))
           .withReconciler(new CreateOnlyIfNotExistingDependentWithSSAReconciler())
           .build();
 
@@ -41,7 +43,7 @@ class CreateOnlyIfNotExistingDependentWithSSAIT {
         .untilAsserted(
             () -> {
               var currentCM = extension.get(ConfigMap.class, TEST_RESOURCE_NAME);
-              assertThat(currentCM.getData()).containsKey(KEY);
+              assertThat(currentCM.getData()).containsOnlyKeys(KEY);
             });
   }
 


### PR DESCRIPTION
Signed-off-by: Attila Mészáros <a_meszaros@apple.com>
