### PR TITLE
fix: handle all exceptions to support Kotlin

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/AbstractWorkflowExecutor.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/AbstractWorkflowExecutor.java
@@ -111,8 +111,9 @@ abstract class AbstractWorkflowExecutor<P extends HasMetadata> {
     actualExecutions.put(dependentResourceNode, future);
   }
 
+  // Exception is required because of Kotlin
   protected synchronized void handleExceptionInExecutor(
-      DependentResourceNode<?, P> dependentResourceNode, RuntimeException e) {
+      DependentResourceNode<?, P> dependentResourceNode, Exception e) {
     createOrGetResultFor(dependentResourceNode).withError(e);
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/NodeExecutor.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/NodeExecutor.java
@@ -19,7 +19,8 @@ abstract class NodeExecutor<R, P extends HasMetadata> implements Runnable {
     try {
       doRun(dependentResourceNode);
 
-    } catch (RuntimeException e) {
+    } catch (Exception e) {
+      // Exception is required because of Kotlin
       workflowExecutor.handleExceptionInExecutor(dependentResourceNode, e);
     } finally {
       workflowExecutor.handleNodeExecutionFinish(dependentResourceNode);

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/polling/PollingEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/polling/PollingEventSource.java
@@ -73,7 +73,8 @@ public class PollingEventSource<R, P extends HasMetadata>
               }
               getStateAndFillCache();
               healthy.set(true);
-            } catch (RuntimeException e) {
+            } catch (Exception e) {
+              // Exception is required because of Kotlin
               healthy.set(false);
               log.error("Error during polling.", e);
             }


### PR DESCRIPTION
When using JOSDK with Kotlin I ran into the problem that the retry did not work when the create method of a DependentResource throws an Exception not inherited from RuntimeException.

The change switches the handling from RuntimeException to Exception so that it works with Kotlin where you can throw Exceptions from methods which don't declare that they throw.

I changed this in the NodeExecutor to address the problem I specifically ran into. Then I also grepped for other places where RuntimeException is catched and then changed it in PollingEventSource as well.

Maybe there are other places (e.g. OperatorException) which should be changed. 