### PR TITLE
fix: spotless maven plugin dependency version for bom

### DIFF
--- a/operator-framework-bom/pom.xml
+++ b/operator-framework-bom/pom.xml
@@ -71,7 +71,7 @@
       <plugin>
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>
-        <version>spotless.version</version>
+        <version>${spotless.version}</version>
         <configuration>
           <pom>
             <includes>


### PR DESCRIPTION
maven gives warning on this

Signed-off-by: Attila Mészáros <a_meszaros@apple.com>
