### PR TITLE
refactor: remove the use of knownResourceVersions

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSource.java
@@ -192,9 +192,6 @@ public class InformerEventSource<R extends HasMetadata, P extends HasMetadata>
   }
 
   private boolean canSkipEvent(R newObject, R oldObject, ResourceID resourceID) {
-    if (temporaryResourceCache.isKnownResourceVersion(newObject)) {
-      return true;
-    }
     var res = temporaryResourceCache.getResourceFromCache(resourceID);
     if (res.isEmpty()) {
       return isEventKnownFromAnnotation(newObject, oldObject);
@@ -208,7 +205,8 @@ public class InformerEventSource<R extends HasMetadata, P extends HasMetadata>
         "Resource found in temporal cache for id: {} resource versions equal: {}",
         resourceID,
         resVersionsEqual);
-    return resVersionsEqual;
+    return resVersionsEqual
+        || temporaryResourceCache.isLaterResourceVersion(resourceID, res.get(), newObject);
   }
 
   private boolean isEventKnownFromAnnotation(R newObject, R oldObject) {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/TemporaryResourceCache.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/TemporaryResourceCache.java
@@ -80,19 +80,12 @@ public class TemporaryResourceCache<T extends HasMetadata> {
   private final ExpirationCache<String> tombstones = new ExpirationCache<>(1000000, 1200000);
   private final ManagedInformerEventSource<T, ?, ?> managedInformerEventSource;
   private final boolean parseResourceVersions;
-  private final ExpirationCache<String> knownResourceVersions;
 
   public TemporaryResourceCache(
       ManagedInformerEventSource<T, ?, ?> managedInformerEventSource,
       boolean parseResourceVersions) {
     this.managedInformerEventSource = managedInformerEventSource;
     this.parseResourceVersions = parseResourceVersions;
-    if (parseResourceVersions) {
-      // keep up to the 50000 add/updates for up to 5 minutes
-      knownResourceVersions = new ExpirationCache<>(50000, 600000);
-    } else {
-      knownResourceVersions = null;
-    }
   }
 
   public synchronized void onDeleteEvent(T resource, boolean unknownState) {
@@ -122,9 +115,6 @@ public class TemporaryResourceCache<T extends HasMetadata> {
    * @param previousResourceVersion null indicates an add
    */
   public synchronized void putResource(T newResource, String previousResourceVersion) {
-    if (knownResourceVersions != null) {
-      knownResourceVersions.add(newResource.getMetadata().getResourceVersion());
-    }
     var resourceId = ResourceID.fromResource(newResource);
     var cachedResource = managedInformerEventSource.get(resourceId).orElse(null);
 
@@ -159,17 +149,12 @@ public class TemporaryResourceCache<T extends HasMetadata> {
     }
   }
 
-  public synchronized boolean isKnownResourceVersion(T resource) {
-    return knownResourceVersions != null
-        && knownResourceVersions.contains(resource.getMetadata().getResourceVersion());
-  }
-
   /**
    * @return true if {@link ConfigurationService#parseResourceVersionsForEventFilteringAndCaching()}
    *     is enabled and the resourceVersion of newResource is numerically greater than
    *     cachedResource, otherwise false
    */
-  private boolean isLaterResourceVersion(ResourceID resourceId, T newResource, T cachedResource) {
+  public boolean isLaterResourceVersion(ResourceID resourceId, T newResource, T cachedResource) {
     try {
       if (parseResourceVersions
           && Long.parseLong(newResource.getMetadata().getResourceVersion())

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/informer/TemporaryPrimaryResourceCacheTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/informer/TemporaryPrimaryResourceCacheTest.java
@@ -96,8 +96,6 @@ class TemporaryPrimaryResourceCacheTest {
   void resourceVersionParsing() {
     this.temporaryResourceCache = new TemporaryResourceCache<>(informerEventSource, true);
 
-    assertThat(temporaryResourceCache.isKnownResourceVersion(testResource())).isFalse();
-
     ConfigMap testResource = propagateTestResourceToCache();
 
     // an event with a newer version will not remove
@@ -108,7 +106,6 @@ class TemporaryPrimaryResourceCacheTest {
             .endMetadata()
             .build());
 
-    assertThat(temporaryResourceCache.isKnownResourceVersion(testResource)).isTrue();
     assertThat(temporaryResourceCache.getResourceFromCache(ResourceID.fromResource(testResource)))
         .isPresent();
 


### PR DESCRIPTION
closes: #2984

After seeing that comparable version support is coming in https://github.com/operator-framework/java-operator-sdk/issues/2981#issuecomment-3384461777 I reviewed the current logic and decided that it could be simplified.

We don't need to explicitly track known versions as a check of whether it's an unknown later version will work just as well.

A reason not to do this is if locking is not used, and you want to react to an older version that may have contained competing changes. However that doesn't seem like a valid thing to do from an eventual consistency perspective.