### PR TITLE
removing tombstones

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationService.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationService.java
@@ -491,18 +491,16 @@ public interface ConfigurationService {
 
   /**
    * If the event logic should parse the resourceVersion to determine the ordering of dependent
-   * resource events. This is typically not needed.
+   * resource events.
    *
-   * <p>Disabled by default as Kubernetes does not support, and discourages, this interpretation of
-   * resourceVersions. Enable only if your api server event processing seems to lag the operator
-   * logic, and you want to further minimize the amount of work done / updates issued by the
-   * operator.
+   * <p>Enabled by default as Kubernetes does support this interpretation of resourceVersions.
+   * Disable only if your api server provides non comparable resource versions..
    *
    * @return if resource version should be parsed (as integer)
    * @since 4.5.0
    */
   default boolean parseResourceVersionsForEventFilteringAndCaching() {
-    return false;
+    return true;
   }
 
   /**

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/informer/InformerEventSourceConfiguration.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/informer/InformerEventSourceConfiguration.java
@@ -96,18 +96,21 @@ public interface InformerEventSourceConfiguration<R extends HasMetadata> extends
     private final GroupVersionKind groupVersionKind;
     private final InformerConfiguration<R> informerConfig;
     private final KubernetesClient kubernetesClient;
+    private final boolean comparableResourceVersions;
 
     protected DefaultInformerEventSourceConfiguration(
         GroupVersionKind groupVersionKind,
         PrimaryToSecondaryMapper<?> primaryToSecondaryMapper,
         SecondaryToPrimaryMapper<R> secondaryToPrimaryMapper,
         InformerConfiguration<R> informerConfig,
-        KubernetesClient kubernetesClient) {
+        KubernetesClient kubernetesClient,
+        boolean comparableResourceVersions) {
       this.informerConfig = Objects.requireNonNull(informerConfig);
       this.groupVersionKind = groupVersionKind;
       this.primaryToSecondaryMapper = primaryToSecondaryMapper;
       this.secondaryToPrimaryMapper = secondaryToPrimaryMapper;
       this.kubernetesClient = kubernetesClient;
+      this.comparableResourceVersions = comparableResourceVersions;
     }
 
     @Override
@@ -135,6 +138,11 @@ public interface InformerEventSourceConfiguration<R extends HasMetadata> extends
     public Optional<KubernetesClient> getKubernetesClient() {
       return Optional.ofNullable(kubernetesClient);
     }
+
+    @Override
+    public boolean parseResourceVersionsForEventFilteringAndCaching() {
+      return this.comparableResourceVersions;
+    }
   }
 
   @SuppressWarnings({"unused", "UnusedReturnValue"})
@@ -148,6 +156,7 @@ public interface InformerEventSourceConfiguration<R extends HasMetadata> extends
     private PrimaryToSecondaryMapper<?> primaryToSecondaryMapper;
     private SecondaryToPrimaryMapper<R> secondaryToPrimaryMapper;
     private KubernetesClient kubernetesClient;
+    private boolean comparableResourceVersions = true;
 
     private Builder(Class<R> resourceClass, Class<? extends HasMetadata> primaryResourceClass) {
       this(resourceClass, primaryResourceClass, null);
@@ -285,6 +294,11 @@ public interface InformerEventSourceConfiguration<R extends HasMetadata> extends
       return this;
     }
 
+    public Builder<R> parseResourceVersionsForEventFilteringAndCaching(boolean parse) {
+      this.comparableResourceVersions = parse;
+      return this;
+    }
+
     public void updateFrom(InformerConfiguration<R> informerConfig) {
       if (informerConfig != null) {
         final var informerConfigName = informerConfig.getName();
@@ -324,7 +338,10 @@ public interface InformerEventSourceConfiguration<R extends HasMetadata> extends
                   HasMetadata.getKind(primaryResourceClass),
                   false)),
           config.build(),
-          kubernetesClient);
+          kubernetesClient,
+          comparableResourceVersions);
     }
   }
+
+  boolean parseResourceVersionsForEventFilteringAndCaching();
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/PrimaryUpdateAndCacheUtils.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/PrimaryUpdateAndCacheUtils.java
@@ -451,6 +451,11 @@ public class PrimaryUpdateAndCacheUtils {
     }
   }
 
+  public static int compareResourceVersions(HasMetadata h1, HasMetadata h2) {
+    return compareResourceVersions(
+        h1.getMetadata().getResourceVersion(), h2.getMetadata().getResourceVersion());
+  }
+
   public static int compareResourceVersions(String v1, String v2) {
     var v1Length = v1.length();
     if (v1Length == 0) {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/controller/ControllerEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/controller/ControllerEventSource.java
@@ -47,7 +47,14 @@ public class ControllerEventSource<T extends HasMetadata>
 
   @SuppressWarnings({"unchecked", "rawtypes"})
   public ControllerEventSource(Controller<T> controller) {
-    super(NAME, controller.getCRClient(), controller.getConfiguration(), false);
+    super(
+        NAME,
+        controller.getCRClient(),
+        controller.getConfiguration(),
+        controller
+            .getConfiguration()
+            .getConfigurationService()
+            .parseResourceVersionsForEventFilteringAndCaching());
     this.controller = controller;
 
     final var config = controller.getConfiguration();

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerManager.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerManager.java
@@ -221,6 +221,11 @@ class InformerManager<R extends HasMetadata, C extends Informable<R>>
                     : r);
   }
 
+  public Optional<String> getLastSyncResourceVersion(Optional<String> namespace) {
+    return getSource(namespace.orElse(WATCH_ALL_NAMESPACES))
+        .map(source -> source.getLastSyncResourceVersion());
+  }
+
   @Override
   public Stream<ResourceID> keys() {
     return sources.values().stream().flatMap(Cache::keys);

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerWrapper.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerWrapper.java
@@ -156,6 +156,10 @@ class InformerWrapper<T extends HasMetadata>
     return Optional.ofNullable(cache.getByKey(getKey(resourceID)));
   }
 
+  public String getLastSyncResourceVersion() {
+    return this.informer.lastSyncResourceVersion();
+  }
+
   private String getKey(ResourceID resourceID) {
     return Cache.namespaceKeyFunc(resourceID.getNamespace().orElse(null), resourceID.getName());
   }

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSourceTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSourceTest.java
@@ -94,9 +94,11 @@ class InformerEventSourceTest {
   }
 
   @Test
-  void skipsEventPropagationIfResourceWithSameVersionInResourceCache() {
+  void skipsEventPropagation() {
     when(temporaryResourceCacheMock.getResourceFromCache(any()))
         .thenReturn(Optional.of(testDeployment()));
+
+    when(temporaryResourceCacheMock.canSkipEvent(any(), any())).thenReturn(true);
 
     informerEventSource.onAdd(testDeployment());
     informerEventSource.onUpdate(testDeployment(), testDeployment());

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/externalstate/ExternalStateReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/externalstate/ExternalStateReconciler.java
@@ -104,7 +104,7 @@ public class ExternalStateReconciler
             .withData(Map.of(ID_KEY, createdResource.getId()))
             .build();
     configMap.addOwnerReference(resource);
-    context.getClient().configMaps().resource(configMap).create();
+    configMap = context.getClient().configMaps().resource(configMap).create();
 
     var primaryID = ResourceID.fromResource(resource);
     // Making sure that the created resources are in the cache for the next reconciliation.
@@ -128,6 +128,7 @@ public class ExternalStateReconciler
     return DeleteControl.defaultDelete();
   }
 
+  @Override
   public int getNumberOfExecutions() {
     return numberOfExecutions.get();
   }


### PR DESCRIPTION
@csviri I misread your working draft at some point and thought you were tracking a single latest revision - that's all I need to remove tombstone tracking. If we are not relying on comparable resource versions, then I think we can simply reuse the informer last synced version to reason about all puts - not just creates.

I've left the latest check as non-compiling as that will line up with changes you have in other prs.