### PR TITLE
showing code to possibly remove the previous annotation

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResource.java
@@ -41,7 +41,7 @@ public abstract class KubernetesDependentResource<R extends HasMetadata, P exten
   private final boolean garbageCollected = this instanceof GarbageCollected;
   private KubernetesDependentResourceConfig<R> kubernetesDependentResourceConfig;
   private volatile Boolean useSSA;
-  private volatile Boolean usePreviousAnnotationForEventFiltering;
+  private volatile Boolean usePreviousAnnotationForEventFiltering = false;
 
   public KubernetesDependentResource() {}
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventProcessor.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventProcessor.java
@@ -202,10 +202,10 @@ public class EventProcessor<P extends HasMetadata> implements EventHandler, Life
         // removed, but also the informers websocket is disconnected and later reconnected. So
         // meanwhile the resource could be deleted and recreated. In this case we just mark a new
         // event as below.
-        markEventReceived(state);
+        markEventReceived(state, event);
       }
     } else if (!state.deleteEventPresent() && !state.processedMarkForDeletionPresent()) {
-      markEventReceived(state);
+      markEventReceived(state, event);
     } else if (log.isDebugEnabled()) {
       log.debug(
           "Skipped marking event as received. Delete event present: {}, processed mark for"
@@ -215,9 +215,9 @@ public class EventProcessor<P extends HasMetadata> implements EventHandler, Life
     }
   }
 
-  private void markEventReceived(ResourceState state) {
+  private void markEventReceived(ResourceState state, Event event) {
     log.debug("Marking event received for: {}", state.getId());
-    state.markEventReceived();
+    state.markEventReceived(event);
   }
 
   private boolean isResourceMarkedForDeletion(ResourceEvent resourceEvent) {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/DependentEvent.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/DependentEvent.java
@@ -1,0 +1,65 @@
+package io.javaoperatorsdk.operator.processing.event.source.informer;
+
+import java.util.Objects;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.javaoperatorsdk.operator.processing.event.Event;
+import io.javaoperatorsdk.operator.processing.event.ResourceID;
+
+public class DependentEvent extends Event {
+
+  private final ResourceID dependent;
+  private final String dependentResourceVersion;
+  private final String kind;
+  private final boolean fromOperator;
+
+  public DependentEvent(
+      ResourceID targetCustomResource,
+      HasMetadata dependent,
+      boolean fromOperator) {
+    super(targetCustomResource);
+    this.dependent = ResourceID.fromResource(dependent);
+    this.dependentResourceVersion = dependent.getMetadata().getResourceVersion();
+    this.kind = dependent.getKind();
+    this.fromOperator = fromOperator;
+  }
+
+  public ResourceID getDependent() {
+    return dependent;
+  }
+
+  public String getDependentResourceVersion() {
+    return dependentResourceVersion;
+  }
+  
+  public String getKind() {
+    return kind;
+  }
+
+  public boolean isFromOperator() {
+    return fromOperator;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    DependentEvent that = (DependentEvent) o;
+    return Objects.equals(dependent, that.dependent)
+        && Objects.equals(dependentResourceVersion, that.dependentResourceVersion)
+        && Objects.equals(kind, that.kind)
+        && fromOperator == that.fromOperator;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), dependent, dependentResourceVersion, kind, fromOperator);
+  }
+}


### PR DESCRIPTION
Pros:
- no additional locking
- could be adapted to not even rely on resourceVersion comparisons

Cons:
- additional state accumulation on ResourceState during processing. This can be narrowed, but that could end up looking like similar to a locking based solution.
- isNextReconciliationImminent is weakened - without further refinement we won't commit to dependent events triggering a next reconciliation until we're done with the current reconcilitation

Another thought - in what situations will dependents have multiple primary resources? We are skipping the reconciliation for all of them if canSkipEvent returns true from the temporary resource cache, but that add/update occurred for just a single primary resource.