### PR TITLE
improve: possibility to provide id for external resource

### DIFF
--- a/docs/content/en/docs/documentation/dependent-resource-and-workflows/dependent-resources.md
+++ b/docs/content/en/docs/documentation/dependent-resource-and-workflows/dependent-resources.md
@@ -306,10 +306,10 @@ it is always possible to override this automated discrimination using several me
 - Override the [`targetSecondaryResourceID`](https://github.com/operator-framework/java-operator-sdk/blob/main/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResource.java#L282)
   method, if your `DependentResource` extends `KubernetesDependentResource`,
   where it's very often possible to easily determine the `ResourceID` of the secondary resource. This would probably be
-  the easiest solution if you're working with Kubernetes resources. Similarly, for you can override the 
+  the easiest solution if you're working with Kubernetes resources. Similarly, you can override the 
   [`targetSecondaryResourceID`](https://github.com/operator-framework/java-operator-sdk/blob/main/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/AbstractExternalDependentResource.java#L138)
   for external resources. See below the related ID handling
-- If the approach from above doesn't fit your needs, you can override the target resource selection mechanism by overriding
+- If the approach above doesn't fit your needs, you can override the target resource selection mechanism by overriding
   `selectTargetSecondaryResource` for both [`KubernetesDependentResource`](https://github.com/operator-framework/java-operator-sdk/blob/main/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResource.java#L282)
   and [`AbstractExternalDependentResource`](https://github.com/operator-framework/java-operator-sdk/blob/main/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/AbstractExternalDependentResource.java#L148). 
 - As last resort, you can implement your own `getSecondaryResource` method on your `DependentResource` implementation from scratch.

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/AbstractExternalDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/AbstractExternalDependentResource.java
@@ -127,7 +127,7 @@ public abstract class AbstractExternalDependentResource<
   }
 
   /**
-   * Override this method to optimize and not compute the desired when selecting the target
+   * Override this method to optimize and avoid computing the desired when selecting the target
    * secondary resource. Return the target id.
    *
    * @see ExternalDependentIDProvider


### PR DESCRIPTION
PR introduces similar mechanism for external resource as for KubernetesDependetResource to easily override a method to provide an ID if user want't to avoid computing desired states multiple times.
Also improves the docs with pointers where we explain how to avoid calling desired multiple times.