### PR TITLE
fix: correct parameters order in GenericKubernetesResourceMatcher call to JsonDiff.asJson

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/GenericKubernetesResourceMatcher.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/GenericKubernetesResourceMatcher.java
@@ -175,7 +175,7 @@ public class GenericKubernetesResourceMatcher<R extends HasMetadata, P extends H
     final var kubernetesSerialization = context.getClient().getKubernetesSerialization();
     var desiredNode = kubernetesSerialization.convertValue(desired, JsonNode.class);
     var actualNode = kubernetesSerialization.convertValue(actualResource, JsonNode.class);
-    var wholeDiffJsonPatch = JsonDiff.asJson(desiredNode, actualNode);
+    var wholeDiffJsonPatch = JsonDiff.asJson(actualNode, desiredNode);
 
     boolean matched = true;
     for (int i = 0; i < wholeDiffJsonPatch.size() && matched; i++) {


### PR DESCRIPTION

https://github.com/operator-framework/java-operator-sdk/issues/2997

