### PR TITLE
improve: marking long running tests as integration test

### DIFF
--- a/bootstrapper-maven-plugin/src/test/java/io/javaoperatorsdk/bootstrapper/BootstrapperIT.java
+++ b/bootstrapper-maven-plugin/src/test/java/io/javaoperatorsdk/bootstrapper/BootstrapperIT.java
@@ -13,9 +13,9 @@ import io.javaoperatorsdk.boostrapper.Bootstrapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class BootstrapperTest {
+class BootstrapperIT {
 
-  private static final Logger log = LoggerFactory.getLogger(BootstrapperTest.class);
+  private static final Logger log = LoggerFactory.getLogger(BootstrapperIT.class);
 
   Bootstrapper bootstrapper = new Bootstrapper();
 

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/OperatorIT.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/OperatorIT.java
@@ -15,7 +15,8 @@ import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SuppressWarnings("rawtypes")
-class OperatorTest {
+class OperatorIT {
+
   @Test
   void shouldBePossibleToRetrieveNumberOfRegisteredControllers() {
     final var operator = new Operator();

--- a/operator-framework-junit5/src/test/java/io/javaoperatorsdk/operator/junit/LocallyRunOperatorExtensionIT.java
+++ b/operator-framework-junit5/src/test/java/io/javaoperatorsdk/operator/junit/LocallyRunOperatorExtensionIT.java
@@ -9,7 +9,7 @@ import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class LocallyRunOperatorExtensionTest {
+class LocallyRunOperatorExtensionIT {
 
   @Test
   void getAdditionalCRDsFromFiles() {


### PR DESCRIPTION
It seems that something changed in fabric8 client at some point, therefore these tests try to connect to a cluster, when the client is created. We can simply mark them as integration tests, so runs part of that suit, and does not prolong the build

Signed-off-by: Attila Mészáros <a_meszaros@apple.com>
