### PR TITLE
chore(deps): bump Fabric8 client to 7.2.0 for 5.0.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <fabric8-httpclient-impl.name>jdk</fabric8-httpclient-impl.name>
 
     <junit.version>5.12.0</junit.version>
-    <fabric8-client.version>7.1.0</fabric8-client.version>
+    <fabric8-client.version>7.2.0</fabric8-client.version>
     <slf4j.version>2.0.12</slf4j.version>
     <log4j.version>2.24.3</log4j.version>
     <mokito.version>5.16.0</mokito.version>


### PR DESCRIPTION
Note that this isn't meant to be merged, the purpose is to check compatibility of the client with the 5.0.x series.

Signed-off-by: Chris Laprun <metacosm@gmail.com>
