### PR TITLE
improve: remove resource version comparison from 5.2

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/PrimaryUpdateAndCacheUtils.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/PrimaryUpdateAndCacheUtils.java
@@ -450,40 +450,4 @@ public class PrimaryUpdateAndCacheUtils {
           e);
     }
   }
-
-  public static int compareResourceVersions(String v1, String v2) {
-    int v1Length = validateResourceVersion(v1);
-    int v2Length = validateResourceVersion(v2);
-    int comparison = v1Length - v2Length;
-    if (comparison != 0) {
-      return comparison;
-    }
-    for (int i = 0; i < v2Length; i++) {
-      int comp = v1.charAt(i) - v2.charAt(i);
-      if (comp != 0) {
-        return comp;
-      }
-    }
-    return 0;
-  }
-
-  private static int validateResourceVersion(String v1) {
-    int v1Length = v1.length();
-    if (v1Length == 0) {
-      throw new NonComparableResourceVersionException("Resource version is empty");
-    }
-    for (int i = 0; i < v1Length; i++) {
-      char char1 = v1.charAt(i);
-      if (char1 == '0') {
-        if (i == 0) {
-          throw new NonComparableResourceVersionException(
-              "Resource version cannot begin with 0: " + v1);
-        }
-      } else if (char1 < '0' || char1 > '9') {
-        throw new NonComparableResourceVersionException(
-            "Non numeric characters in resource version: " + v1);
-      }
-    }
-    return v1Length;
-  }
 }

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/reconciler/PrimaryUpdateAndCacheUtilsTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/reconciler/PrimaryUpdateAndCacheUtilsTest.java
@@ -19,7 +19,6 @@ import java.util.Optional;
 import java.util.function.UnaryOperator;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,7 +39,6 @@ import io.javaoperatorsdk.operator.processing.event.source.controller.Controller
 import io.javaoperatorsdk.operator.sample.simple.TestCustomResource;
 
 import static io.javaoperatorsdk.operator.api.reconciler.PrimaryUpdateAndCacheUtils.DEFAULT_MAX_RETRY;
-import static io.javaoperatorsdk.operator.api.reconciler.PrimaryUpdateAndCacheUtils.compareResourceVersions;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -181,54 +179,5 @@ class PrimaryUpdateAndCacheUtilsTest {
                     50L,
                     10L));
     assertThat(ex.getMessage()).contains("Timeout");
-  }
-
-  @Test
-  public void compareResourceVersionsTest() {
-    assertThat(compareResourceVersions("11", "22")).isNegative();
-    assertThat(compareResourceVersions("22", "11")).isPositive();
-    assertThat(compareResourceVersions("1", "1")).isZero();
-    assertThat(compareResourceVersions("11", "11")).isZero();
-    assertThat(compareResourceVersions("123", "2")).isPositive();
-    assertThat(compareResourceVersions("3", "211")).isNegative();
-
-    assertThrows(
-        NonComparableResourceVersionException.class, () -> compareResourceVersions("aa", "22"));
-    assertThrows(
-        NonComparableResourceVersionException.class, () -> compareResourceVersions("11", "ba"));
-    assertThrows(
-        NonComparableResourceVersionException.class, () -> compareResourceVersions("", "22"));
-    assertThrows(
-        NonComparableResourceVersionException.class, () -> compareResourceVersions("11", ""));
-    assertThrows(
-        NonComparableResourceVersionException.class, () -> compareResourceVersions("01", "123"));
-    assertThrows(
-        NonComparableResourceVersionException.class, () -> compareResourceVersions("123", "01"));
-    assertThrows(
-        NonComparableResourceVersionException.class, () -> compareResourceVersions("3213", "123a"));
-    assertThrows(
-        NonComparableResourceVersionException.class, () -> compareResourceVersions("321", "123a"));
-  }
-
-  // naive performance test that compares the work case scenario for the parsing and non-parsing
-  // variants
-  @Test
-  @Disabled("test sometimes fails, we plan to iterate over it and related features for 5.3")
-  public void compareResourcePerformanceTest() {
-    var execNum = 30000000;
-    var startTime = System.currentTimeMillis();
-    for (int i = 0; i < execNum; i++) {
-      var res = compareResourceVersions("123456788", "123456789");
-    }
-    var dur1 = System.currentTimeMillis() - startTime;
-    log.info("Duration without parsing: {}", dur1);
-    startTime = System.currentTimeMillis();
-    for (int i = 0; i < execNum; i++) {
-      var res = Long.parseLong("123456788") > Long.parseLong("123456789");
-    }
-    var dur2 = System.currentTimeMillis() - startTime;
-    log.info("Duration with parsing:   {}", dur2);
-
-    assertThat(dur1).isLessThan(dur2);
   }
 }

--- a/operator-framework-core/src/test/resources/io/javaoperatorsdk/operator/processing/dependent/kubernetes/statefulset-with-managed-fields-missing.yaml
+++ b/operator-framework-core/src/test/resources/io/javaoperatorsdk/operator/processing/dependent/kubernetes/statefulset-with-managed-fields-missing.yaml
@@ -1,3 +1,19 @@
+#
+# Copyright Java Operator SDK Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:


### PR DESCRIPTION
Since it is not used in the framework yet internally removing it. We will further discuss the implementation for 5.3