### PR TITLE
fix: add automatically generated testindex to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ target/
 
 .java-version
 .aider*
+
+docs/content/en/docs/testindex/


### PR DESCRIPTION
Replacing #3078