### PR TITLE
improve: run PRs for every branch

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,6 @@ on:
     paths-ignore:
       - 'docs/**'
       - 'adr/**'
-    branches: [ main, v1, v2, v3, next ]
   workflow_dispatch:
 jobs:
   check_format_and_unit_tests:


### PR DESCRIPTION
Not sure why it seemed to be a good idea ti limit this on certain branches,
with this PR we will run the workflow all the time, it helps especially with PRs
on which we work together, and other may target branches of a PR with new additions.

Signed-off-by: Attila Mészáros <a_meszaros@apple.com>
