### PR TITLE
improve: timeouts for integration test

### DIFF
--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/IntegrationTestConstants.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/IntegrationTestConstants.java
@@ -15,7 +15,11 @@
  */
 package io.javaoperatorsdk.operator;
 
+import java.time.Duration;
+
 public class IntegrationTestConstants {
 
   public static final int GARBAGE_COLLECTION_TIMEOUT_SECONDS = 60;
+
+  public static final Duration GARBAGE_COLLECTION_TIMEOUT = Duration.ofSeconds(60);
 }

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/expectation/onallevent/ExpectationIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/expectation/onallevent/ExpectationIT.java
@@ -24,6 +24,7 @@ import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.javaoperatorsdk.annotation.Sample;
 import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
 
+import static io.javaoperatorsdk.operator.IntegrationTestConstants.GARBAGE_COLLECTION_TIMEOUT;
 import static io.javaoperatorsdk.operator.baseapi.expectation.onallevent.ExpectationReconciler.DEPLOYMENT_READY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -52,6 +53,7 @@ class ExpectationIT {
     extension.create(res);
 
     await()
+        .timeout(GARBAGE_COLLECTION_TIMEOUT)
         .untilAsserted(
             () -> {
               var actual = extension.get(ExpectationCustomResource.class, TEST_1);
@@ -67,6 +69,7 @@ class ExpectationIT {
     extension.create(res);
 
     await()
+        .timeout(GARBAGE_COLLECTION_TIMEOUT)
         .untilAsserted(
             () -> {
               var actual = extension.get(ExpectationCustomResource.class, TEST_1);

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/expectation/periodicclean/PeriodicCleanerExpectationIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/expectation/periodicclean/PeriodicCleanerExpectationIT.java
@@ -24,6 +24,7 @@ import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.javaoperatorsdk.annotation.Sample;
 import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
 
+import static io.javaoperatorsdk.operator.IntegrationTestConstants.GARBAGE_COLLECTION_TIMEOUT;
 import static io.javaoperatorsdk.operator.baseapi.expectation.periodicclean.PeriodicCleanerExpectationReconciler.DEPLOYMENT_READY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -57,6 +58,7 @@ class PeriodicCleanerExpectationIT {
     extension.create(res);
 
     await()
+        .timeout(GARBAGE_COLLECTION_TIMEOUT)
         .untilAsserted(
             () -> {
               var actual = extension.get(PeriodicCleanerExpectationCustomResource.class, TEST_1);
@@ -80,6 +82,7 @@ class PeriodicCleanerExpectationIT {
     var created = extension.create(res);
 
     await()
+        .timeout(GARBAGE_COLLECTION_TIMEOUT)
         .untilAsserted(
             () -> {
               assertThat(reconciler.getExpectationManager().getExpectation(created)).isPresent();

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/standalonedependent/StandaloneDependentResourceIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/standalonedependent/StandaloneDependentResourceIT.java
@@ -93,7 +93,7 @@ public class StandaloneDependentResourceIT {
   void awaitForDeploymentReadyReplicas(int expectedReplicaCount) {
     await()
         .pollInterval(Duration.ofMillis(300))
-        .atMost(Duration.ofSeconds(50))
+        .atMost(Duration.ofSeconds(180))
         .until(
             () -> {
               var deployment =

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/workflow/complexdependent/ComplexWorkflowIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/workflow/complexdependent/ComplexWorkflowIT.java
@@ -55,7 +55,7 @@ class ComplexWorkflowIT {
     operator.create(testResource());
 
     await()
-        .atMost(Duration.ofSeconds(90))
+        .atMost(Duration.ofSeconds(120))
         .untilAsserted(
             () -> {
               var res = operator.get(ComplexWorkflowCustomResource.class, TEST_RESOURCE_NAME);

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/workflow/workflowallfeature/WorkflowAllFeatureIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/workflow/workflowallfeature/WorkflowAllFeatureIT.java
@@ -27,6 +27,7 @@ import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.javaoperatorsdk.annotation.Sample;
 import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
 
+import static io.javaoperatorsdk.operator.IntegrationTestConstants.GARBAGE_COLLECTION_TIMEOUT;
 import static io.javaoperatorsdk.operator.workflow.workflowallfeature.ConfigMapDependentResource.READY_TO_DELETE_ANNOTATION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -69,7 +70,7 @@ public class WorkflowAllFeatureIT {
             });
 
     await()
-        .atMost(ONE_MINUTE)
+        .timeout(ONE_MINUTE)
         .untilAsserted(
             () -> {
               assertThat(
@@ -107,6 +108,7 @@ public class WorkflowAllFeatureIT {
     operator.replace(resource);
 
     await()
+        .timeout(GARBAGE_COLLECTION_TIMEOUT)
         .untilAsserted(
             () -> {
               assertThat(operator.get(ConfigMap.class, RESOURCE_NAME)).isNotNull();
@@ -141,7 +143,7 @@ public class WorkflowAllFeatureIT {
     markConfigMapForDelete();
 
     await()
-        .atMost(ONE_MINUTE)
+        .timeout(GARBAGE_COLLECTION_TIMEOUT)
         .untilAsserted(
             () -> {
               assertThat(operator.get(ConfigMap.class, RESOURCE_NAME)).isNull();


### PR DESCRIPTION

sometimes some integration tests fail (as far I can tell always the same set), 
see: https://github.com/operator-framework/java-operator-sdk/actions/runs/20992766537/job/60342081482?pr=3119

My guess is it a slower runner machine? Not sure, but enhanced a bit the timouts on those tests.

```
Error:  Errors: 
Error:    KubernetesResourceStatusUpdateIT.testReconciliationOfNonCustomResourceAndStatusUpdate:63 » ConditionTimeout Assertion condition defined as a Lambda expression in io.javaoperatorsdk.operator.baseapi.deployment.KubernetesResourceStatusUpdateIT 
Expecting actual not to be null within 2 minutes.
Error:    ExpectationIT.expectationTimeouts:70 » ConditionTimeout Assertion condition defined as a Lambda expression in io.javaoperatorsdk.operator.baseapi.expectation.onallevent.ExpectationIT 
Expecting actual not to be null within 10 seconds.
Error:    ExpectationIT.testExpectation:55 » ConditionTimeout Assertion condition defined as a Lambda expression in io.javaoperatorsdk.operator.baseapi.expectation.onallevent.ExpectationIT 
Expecting actual not to be null within 10 seconds.
Error:    PeriodicCleanerExpectationIT.testPeriodicCleanerExpectationBasicFlow:60 » ConditionTimeout Assertion condition defined as a Lambda expression in io.javaoperatorsdk.operator.baseapi.expectation.periodicclean.PeriodicCleanerExpectationIT 
Expecting actual not to be null within 10 seconds.
Error:    StandaloneDependentResourceIT.dependentResourceManagesDeployment:66->awaitForDeploymentReadyReplicas:97 » ConditionTimeout Condition with Lambda expression in io.javaoperatorsdk.operator.dependent.standalonedependent.StandaloneDependentResourceIT was not fulfilled within 50 seconds.
Error:    StandaloneDependentResourceIT.executeUpdateForTestingCacheUpdateForGetResource:81->awaitForDeploymentReadyReplicas:97 » ConditionTimeout Condition with Lambda expression in io.javaoperatorsdk.operator.dependent.standalonedependent.StandaloneDependentResourceIT was not fulfilled within 50 seconds.
Error:    ComplexWorkflowIT.successfullyReconciles:59 » ConditionTimeout Assertion condition defined as a Lambda expression in io.javaoperatorsdk.operator.workflow.complexdependent.ComplexWorkflowIT 
expected: READY
 but was: NOT_READY within 1 minutes  30 seconds.
Error:    WorkflowAllFeatureIT.configMapNotDeletedUntilNotMarked:123 » ConditionTimeout Assertion condition defined as a Lambda expression in io.javaoperatorsdk.operator.workflow.workflowallfeature.WorkflowAllFeatureIT 
Expecting value to be true but was false within 1 minutes.
Error:    WorkflowAllFeatureIT.configMapNotReconciledIfReconcileConditionNotMet:100 » ConditionTimeout Assertion condition defined as a Lambda expression in io.javaoperatorsdk.operator.workflow.workflowallfeature.WorkflowAllFeatureIT 
Expecting value to be true but was false within 1 minutes.
Error:    WorkflowAllFeatureIT.configMapNotReconciledUntilDeploymentReady:73 » ConditionTimeout Assertion condition defined as a Lambda expression in io.javaoperatorsdk.operator.workflow.workflowallfeature.WorkflowAllFeatureIT 
Expecting actual not to be null within 1 minutes.
[INFO] 
Error:  Tests run: 144, Failures: 0, Errors: 10, Skipped: 0

```

Signed-off-by: Attila Mészáros <a_meszaros@apple.com>
