### PR TITLE
feat: support additional java CRDs in test extension

### DIFF
--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/CRDMappingInTestExtensionIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/CRDMappingInTestExtensionIT.java
@@ -16,14 +16,21 @@
 package io.javaoperatorsdk.operator;
 
 import java.time.Duration;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.Namespaced;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinitionBuilder;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinitionList;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaPropsBuilder;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Kind;
 import io.fabric8.kubernetes.model.annotation.Version;
@@ -44,7 +51,8 @@ import static org.awaitility.Awaitility.await;
         Demonstrates how to manually specify and apply Custom Resource Definitions (CRDs) in \
         integration tests using the LocallyRunOperatorExtension. This test verifies that CRDs \
         can be loaded from specified file paths and properly registered with the Kubernetes API \
-        server during test execution.
+        server during test execution. It also verifies that CustomResourceDefinition instances
+        with no corresponding file can be applied.
         """)
 public class CRDMappingInTestExtensionIT {
   private final KubernetesClient client = new KubernetesClientBuilder().build();
@@ -54,32 +62,73 @@ public class CRDMappingInTestExtensionIT {
       LocallyRunOperatorExtension.builder()
           .withReconciler(new TestReconciler())
           .withAdditionalCRD("src/test/resources/crd/test.crd", "src/test/crd/test.crd")
+          .withAdditionalCustomResourceDefinition(testCRD())
           .build();
+
+  public static CustomResourceDefinition testCRD() {
+    return new CustomResourceDefinitionBuilder()
+        .editOrNewSpec()
+        .withScope("Cluster")
+        .withGroup("operator.javaoperatorsdk.io")
+        .editOrNewNames()
+        .withPlural("tests")
+        .withSingular("test")
+        .withKind("Test")
+        .endNames()
+        .addNewVersion()
+        .withName("v1")
+        .withServed(true)
+        .withStorage(true)
+        .withNewSchema()
+        .withNewOpenAPIV3Schema()
+        .withType("object")
+        .withProperties(Map.of("bar", new JSONSchemaPropsBuilder().withType("string").build()))
+        .endOpenAPIV3Schema()
+        .endSchema()
+        .endVersion()
+        .and()
+        .editOrNewMetadata()
+        .withName("tests.operator.javaoperatorsdk.io")
+        .and()
+        .build();
+  }
 
   @Test
   void correctlyAppliesManuallySpecifiedCRD() {
     final var crdClient = client.apiextensions().v1().customResourceDefinitions();
     await()
         .pollDelay(Duration.ofMillis(150))
+        .untilAsserted(() -> assertCrdApplied(crdClient, "tests.crd.example", "foo"));
+    await()
+        .pollDelay(Duration.ofMillis(150))
         .untilAsserted(
-            () -> {
-              final var actual = crdClient.withName("tests.crd.example").get();
-              assertThat(actual).isNotNull();
-              assertThat(
-                      actual
-                          .getSpec()
-                          .getVersions()
-                          .get(0)
-                          .getSchema()
-                          .getOpenAPIV3Schema()
-                          .getProperties()
-                          .containsKey("foo"))
-                  .isTrue();
-            });
+            () -> assertCrdApplied(crdClient, "tests.operator.javaoperatorsdk.io", "bar"));
     await()
         .pollDelay(Duration.ofMillis(150))
         .untilAsserted(
             () -> assertThat(crdClient.withName("externals.crd.example").get()).isNotNull());
+  }
+
+  private static void assertCrdApplied(
+      NonNamespaceOperation<
+              CustomResourceDefinition,
+              CustomResourceDefinitionList,
+              Resource<CustomResourceDefinition>>
+          crdClient,
+      String s,
+      String propertyName) {
+    final var actual = crdClient.withName(s).get();
+    assertThat(actual).isNotNull();
+    assertThat(
+            actual
+                .getSpec()
+                .getVersions()
+                .get(0)
+                .getSchema()
+                .getOpenAPIV3Schema()
+                .getProperties()
+                .containsKey(propertyName))
+        .isTrue();
   }
 
   @Group("crd.example")


### PR DESCRIPTION
Adds `withAdditionalCustomResourceDefinition(CustomResourceDefinition definition)` to `LocallyRunOperatorExtension#Builder`. These definitions are applied at the same time as the existing `additionalCustomResourceDefinitions`. The definitions are deleted according to the existing lifecycle.

Resolves #3004

Why:
In some cases we may wish to apply a CustomResourceDefinition that has no corresponding CRD file. For example, some frameworks publish fabric8-based api modules which contain only the java classes for their CRDs, and no CRD files.